### PR TITLE
Issue108 calc los signal

### DIFF
--- a/tofu/geom/_GG02.pyx
+++ b/tofu/geom/_GG02.pyx
@@ -2067,9 +2067,9 @@ def LOS_Calc_PInOut_VesStruct(double[:, ::1] ray_orig,
 
     Params
     ======
-    ray_orig : (3, num_los) double array
+    ray_orig : (3, nlos) double array
        LOS origin points coordinates
-    ray_vdir : (3, num_los) double array
+    ray_vdir : (3, nlos) double array
        LOS normalized direction vector
     ves_poly : (2, num_vertex) double array
        Coordinates of the vertices of the Polygon defining the 2D poloidal
@@ -2106,13 +2106,13 @@ def LOS_Calc_PInOut_VesStruct(double[:, ::1] ray_orig,
        Typically this is the number of cores available on the machine.
     Returns
     ======
-    coeff_inter_in : (num_los) array
+    coeff_inter_in : (nlos) array
        scalars level of "in" intersection of the LOS (if k=0 at origin)
-    coeff_inter_out : (num_los) array
+    coeff_inter_out : (nlos) array
        scalars level of "out" intersection of the LOS (if k=0 at origin)
-    vperp_out : (3, num_los) array
+    vperp_out : (3, nlos) array
        Coordinates of the normal vector of impact of the LOS (NaN if none)
-    ind_inter_out : (3, num_los)
+    ind_inter_out : (3, nlos)
        Index of structure impacted by LOS: ind_inter_out[:,ind_los]=(i,j,k)
        where k is the index of edge impacted on the j-th sub structure of the
        structure number i. If the LOS impacted the vessel i=j=0
@@ -2120,14 +2120,14 @@ def LOS_Calc_PInOut_VesStruct(double[:, ::1] ray_orig,
     cdef str vt_lower = ves_type.lower()
     cdef str error_message
     cdef int sz_ves_lims
-    cdef int num_los = ray_orig.shape[1]
+    cdef int nlos = ray_orig.shape[1]
     cdef int npts_poly = ves_norm.shape[1]
     cdef bint bool1, bool2
     cdef double min_poly_r
-    cdef array vperp_out = clone(array('d'), num_los * 3, True)
-    cdef array coeff_inter_in  = clone(array('d'), num_los, True)
-    cdef array coeff_inter_out = clone(array('d'), num_los, True)
-    cdef array ind_inter_out = clone(array('i'), num_los * 3, True)
+    cdef array vperp_out = clone(array('d'), nlos * 3, True)
+    cdef array coeff_inter_in  = clone(array('d'), nlos, True)
+    cdef array coeff_inter_out = clone(array('d'), nlos, True)
+    cdef array ind_inter_out = clone(array('i'), nlos * 3, True)
     # == Testing inputs ========================================================
     if test:
         error_message = "ray_orig and ray_vdir must have the same shape: "\
@@ -2196,7 +2196,7 @@ def LOS_Calc_PInOut_VesStruct(double[:, ::1] ray_orig,
     # ==========================================================================
     sz_ves_lims = np.size(ves_lims)
     min_poly_r = _bgt.comp_min(ves_poly[0, ...], npts_poly-1)
-    _rt.compute_inout_tot(num_los, npts_poly,
+    _rt.compute_inout_tot(nlos, npts_poly,
                           ray_orig, ray_vdir,
                           ves_poly, ves_norm,
                           lstruct_nlim, ves_lims,
@@ -2211,9 +2211,9 @@ def LOS_Calc_PInOut_VesStruct(double[:, ::1] ray_orig,
                           coeff_inter_out, coeff_inter_in, vperp_out,
                           ind_inter_out)
     return np.asarray(coeff_inter_in), np.asarray(coeff_inter_out),\
-           np.transpose(np.asarray(vperp_out).reshape(num_los,3)),\
+           np.transpose(np.asarray(vperp_out).reshape(nlos,3)),\
            np.transpose(np.asarray(ind_inter_out,
-                                   dtype=int).reshape(num_los, 3))
+                                   dtype=int).reshape(nlos, 3))
 
 
 # =============================================================================
@@ -2242,9 +2242,9 @@ def LOS_Calc_kMinkMax_VesStruct(double[:, ::1] ray_orig,
 
     Params
     ======
-    ray_orig : (3, num_los) double array
+    ray_orig : (3, nlos) double array
        LOS origin points coordinates
-    ray_vdir : (3, num_los) double array
+    ray_vdir : (3, nlos) double array
        LOS normalized direction vector
     num_surf : int
        number of surfaxes, aka 'in' structures or 'vessels'
@@ -2272,17 +2272,17 @@ def LOS_Calc_kMinkMax_VesStruct(double[:, ::1] ray_orig,
        Typically this is the number of cores available on the machine.
     Return
     ======
-    coeff_inter_in : (num_surf, num_los) array
+    coeff_inter_in : (num_surf, nlos) array
        scalars level of "in" intersection of the LOS (if k=0 at origin) for
        each surface
        [kmin(surf0, los0), kmin(surf0, los1), ..., kmin(surf1, los0),....]
-    coeff_inter_out : (num_surf, num_los) array
+    coeff_inter_out : (num_surf, nlos) array
        scalars level of "out" intersection of the LOS (if k=0 at origin) for
        each surface
        [kmax(surf0, los0), kmax(surf0, los1), ..., kmax(surf1, los0),....]
     """
     cdef int npts_poly
-    cdef int num_los = ray_orig.shape[1]
+    cdef int nlos = ray_orig.shape[1]
     cdef int ind_struct = 0
     cdef int ind_surf
     cdef double crit2_base = eps_uz * eps_uz /400.
@@ -2292,8 +2292,8 @@ def LOS_Calc_kMinkMax_VesStruct(double[:, ::1] ray_orig,
     cdef str error_message
     cdef bint forbidbis, forbid0
     cdef bint bool1, bool2
-    cdef array coeff_inter_in  = clone(array('d'), num_los * num_surf, True)
-    cdef array coeff_inter_out = clone(array('d'), num_los * num_surf, True)
+    cdef array coeff_inter_in  = clone(array('d'), nlos * num_surf, True)
+    cdef array coeff_inter_out = clone(array('d'), nlos * num_surf, True)
     cdef int *llimits = NULL
     cdef long *lsz_lim = NULL
     cdef bint are_limited
@@ -2339,7 +2339,7 @@ def LOS_Calc_kMinkMax_VesStruct(double[:, ::1] ray_orig,
                 rmin = 0.95*min(np.min(ves_poly[ind_surf][0, ...]),
                                 _bgt.comp_min_hypot(ray_orig[0, ...],
                                                     ray_orig[1, ...],
-                                                    num_los))
+                                                    nlos))
             rmin2 = rmin*rmin
             # Variable to avoid looking "behind" blind spot of tore
             if forbid:
@@ -2351,9 +2351,9 @@ def LOS_Calc_kMinkMax_VesStruct(double[:, ::1] ray_orig,
             tmp_poly = ves_poly[ind_surf]
             tmp_norm = ves_norm[ind_surf]
             # -- Computing intersection between LOS and Vessel -----------------
-            _rt.raytracing_minmax_struct_tor(num_los, ray_vdir, ray_orig,
-                                             &ptr_coeff_out[ind_surf*num_los],
-                                             &ptr_coeff_in[ind_surf*num_los],
+            _rt.raytracing_minmax_struct_tor(nlos, ray_vdir, ray_orig,
+                                             &ptr_coeff_out[ind_surf*nlos],
+                                             &ptr_coeff_in[ind_surf*nlos],
                                              forbid0, forbidbis,
                                              rmin, rmin2, crit2_base,
                                              npts_poly, lbounds_ves,
@@ -2382,15 +2382,15 @@ def LOS_Calc_kMinkMax_VesStruct(double[:, ::1] ray_orig,
             npts_poly = lnvert[ind_surf]
             tmp_poly = ves_poly[ind_surf]
             tmp_norm = ves_norm[ind_surf]
-            _rt.raytracing_minmax_struct_lin(num_los, ray_orig, ray_vdir,
+            _rt.raytracing_minmax_struct_lin(nlos, ray_orig, ray_vdir,
                                              npts_poly,
                                              &tmp_poly[0][0],
                                              &tmp_poly[1][0],
                                              &tmp_norm[0][0],
                                              &tmp_norm[1][0],
                                              lbounds_ves[0], lbounds_ves[1],
-                                             &ptr_coeff_out[ind_surf*num_los],
-                                             &ptr_coeff_in[ind_surf*num_los],
+                                             &ptr_coeff_out[ind_surf*nlos],
+                                             &ptr_coeff_in[ind_surf*nlos],
                                              eps_plane)
 
     return np.asarray(coeff_inter_in), np.asarray(coeff_inter_out)
@@ -2564,9 +2564,9 @@ def vignetting(double[:, ::1] ray_orig,
                long[::1] lnvert,
                int num_threads=16):
     """
-    ray_orig : (3, num_los) double array
+    ray_orig : (3, nlos) double array
        LOS origin points coordinates
-    ray_vdir : (3, num_los) double array
+    ray_vdir : (3, nlos) double array
        LOS normalized direction vector
     vignett_poly : (num_vign, 3, num_vertex) double list of arrays
        Coordinates of the vertices of the Polygon defining the 3D vignett.
@@ -2575,7 +2575,7 @@ def vignetting(double[:, ::1] ray_orig,
        Number of vertices for each vignett (without counting the rebound)
     Returns
     ======
-    goes_through: (num_vign, num_los) bool array
+    goes_through: (num_vign, nlos) bool array
        Indicates for each vignett if each LOS wents through or not
     """
     cdef int ii
@@ -2624,7 +2624,7 @@ def vignetting(double[:, ::1] ray_orig,
 #                                  LOS SAMPLING
 #
 # ==============================================================================
-def LOS_get_sample(int num_los, dL, double[:,::1] DLs, str dmethod='abs',
+def LOS_get_sample(int nlos, dL, double[:,::1] DLs, str dmethod='abs',
                    str method='sum', bint Test=True, int num_threads=16):
     """
     Return the sampled line, with the specified method
@@ -2637,10 +2637,10 @@ def LOS_get_sample(int num_los, dL, double[:,::1] DLs, str dmethod='abs',
     ======
     dL: double or list of doubles
         If dL is a single double: discretization step for all LOS.
-        Else dL should be a list of size num_los with the discretization
-        step for each num_los.
-    DLs: (2, num_los) double array
-        For each num_los, it given the maximum and minimum limits of the ray
+        Else dL should be a list of size nlos with the discretization
+        step for each nlos.
+    DLs: (2, nlos) double array
+        For each nlos, it given the maximum and minimum limits of the ray
     dmethod: string
         type of discretization step: 'abs' for absolute or 'rel' for relative
     method: string
@@ -2671,18 +2671,18 @@ def LOS_get_sample(int num_los, dL, double[:,::1] DLs, str dmethod='abs',
     cdef long* tmp_arr
     cdef double* los_coeffs = NULL
     # .. ray_orig shape needed for testing and in algo .........................
-    dLr = np.zeros((num_los,), dtype=float)
-    los_ind = np.zeros((num_los,), dtype=int)
+    dLr = np.zeros((nlos,), dtype=float)
+    los_ind = np.zeros((nlos,), dtype=int)
     dl_is_list = hasattr(dL, '__iter__')
     # .. verifying arguments ...................................................
     if Test:
         sz1_dls = DLs.shape[0]
         sz2_dls = DLs.shape[1]
         assert sz1_dls == 2, "Dim 0 of arg DLs should be 2"
-        error_message = "Args DLs should have dim 1 = num_los"
-        assert num_los == sz2_dls, error_message
+        error_message = "Args DLs should have dim 1 = nlos"
+        assert nlos == sz2_dls, error_message
         bool1 = not dl_is_list and dL > 0.
-        bool2 = dl_is_list and len(dL)==num_los and np.all(dL>0.)
+        bool2 = dl_is_list and len(dL)==nlos and np.all(dL>0.)
         assert bool1 or bool2, "Arg dL must be a double or a List, and dL >0.!"
         error_message = "Argument dmethod (discretization method) should be in"\
                         +" ['abs','rel'], for absolute or relative."
@@ -2697,43 +2697,43 @@ def LOS_get_sample(int num_los, dL, double[:,::1] DLs, str dmethod='abs',
         if dmode=='rel':
             N = <int> Cceil(1./val_resol)
             if imode=='sum':
-                coeff_arr = np.empty((N*num_los,), dtype=float)
-                _st.middle_rule_rel(num_los, N, &DLs[0,0], &DLs[1, 0],
+                coeff_arr = np.empty((N*nlos,), dtype=float)
+                _st.middle_rule_rel(nlos, N, &DLs[0,0], &DLs[1, 0],
                                     &dLr[0], &coeff_arr[0], &los_ind[0],
                                     num_threads=num_threads)
             elif imode=='simps':
                 N = N if N%2==0 else N+1
-                coeff_arr = np.empty(((N+1)*num_los,), dtype=float)
-                _st.left_rule_rel(num_los, N,
+                coeff_arr = np.empty(((N+1)*nlos,), dtype=float)
+                _st.left_rule_rel(nlos, N,
                                   &DLs[0,0], &DLs[1, 0], &dLr[0],
                                   &coeff_arr[0], &los_ind[0],
                                   num_threads=num_threads)
             elif imode=='romb':
                 N = 2**(int(Cceil(Clog2(N))))
-                coeff_arr = np.empty(((N+1)*num_los,), dtype=float)
-                _st.left_rule_rel(num_los, N,
+                coeff_arr = np.empty(((N+1)*nlos,), dtype=float)
+                _st.left_rule_rel(nlos, N,
                                   &DLs[0,0], &DLs[1, 0],
                                   &dLr[0], &coeff_arr[0], &los_ind[0],
                                   num_threads=num_threads)
-            return coeff_arr, dLr, los_ind[:num_los-1]
+            return coeff_arr, dLr, los_ind[:nlos-1]
         else:
             if imode=='sum':
-                _st.middle_rule_abs_1(num_los, val_resol, &DLs[0,0], &DLs[1, 0],
+                _st.middle_rule_abs_1(nlos, val_resol, &DLs[0,0], &DLs[1, 0],
                                       &dLr[0], &los_ind[0],
                                       num_threads=num_threads)
                 ntmp = np.sum(los_ind)
                 coeff_arr = np.empty((ntmp,), dtype=float)
-                _st.middle_rule_abs_2(num_los, &DLs[0,0], &los_ind[0],
+                _st.middle_rule_abs_2(nlos, &DLs[0,0], &los_ind[0],
                                       &dLr[0], &coeff_arr[0],
                                       num_threads=num_threads)
-                return coeff_arr, dLr, los_ind[0:num_los-1]
+                return coeff_arr, dLr, los_ind[0:nlos-1]
             elif imode=='simps':
-                _st.simps_left_rule_abs(num_los, val_resol,
+                _st.simps_left_rule_abs(nlos, val_resol,
                                         &DLs[0,0], &DLs[1, 0],
                                         &dLr[0], &los_coeffs, &los_ind[0],
                                         num_threads=num_threads)
             else:
-                _st.romb_left_rule_abs(num_los, val_resol,
+                _st.romb_left_rule_abs(nlos, val_resol,
                                        &DLs[0,0], &DLs[1, 0],
                                        &dLr[0], &los_coeffs, &los_ind[0],
                                        num_threads=num_threads)
@@ -2742,38 +2742,38 @@ def LOS_get_sample(int num_los, dL, double[:,::1] DLs, str dmethod='abs',
         dl_view=dL
         if dmode=='abs':
             if imode=='sum':
-                _st.middle_rule_abs_var(num_los, &dl_view[0],
+                _st.middle_rule_abs_var(nlos, &dl_view[0],
                                         &DLs[0,0], &DLs[1, 0],
                                         &dLr[0], &los_coeffs, &los_ind[0],
                                         num_threads=num_threads)
             elif imode=='simps':
-                _st.simps_left_rule_abs_var(num_los, &dl_view[0],
+                _st.simps_left_rule_abs_var(nlos, &dl_view[0],
                                             &DLs[0,0], &DLs[1, 0],
                                             &dLr[0], &los_coeffs, &los_ind[0],
                                             num_threads=num_threads)
             else:
-                _st.romb_left_rule_abs_var(num_los, &dl_view[0],
+                _st.romb_left_rule_abs_var(nlos, &dl_view[0],
                                            &DLs[0,0], &DLs[1, 0],
                                            &dLr[0], &los_coeffs, &los_ind[0],
                                            num_threads=num_threads)
         else:
             if imode=='sum':
-                _st.middle_rule_rel_var(num_los, &dl_view[0],
+                _st.middle_rule_rel_var(nlos, &dl_view[0],
                                         &DLs[0,0], &DLs[1, 0],
                                         &dLr[0], &los_coeffs, &los_ind[0],
                                         num_threads=num_threads)
             elif imode=='simps':
-                _st.simps_left_rule_rel_var(num_los, &dl_view[0],
+                _st.simps_left_rule_rel_var(nlos, &dl_view[0],
                                             &DLs[0,0], &DLs[1, 0],
                                             &dLr[0], &los_coeffs, &los_ind[0],
                                             num_threads=num_threads)
             else:
-                _st.romb_left_rule_rel_var(num_los, &dl_view[0],
+                _st.romb_left_rule_rel_var(nlos, &dl_view[0],
                                            &DLs[0,0], &DLs[1, 0],
                                            &dLr[0], &los_coeffs, &los_ind[0],
                                            num_threads=num_threads)
-    return np.asarray(<double[:los_ind[num_los-1]]> los_coeffs),\
-        dLr, los_ind[0:num_los-1]
+    return np.asarray(<double[:los_ind[nlos-1]]> los_coeffs),\
+        dLr, los_ind[0:nlos-1]
 
 
 
@@ -2886,7 +2886,39 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     t=None, fkwdargs={}, str minimize='calls',
                     bint Test=True, int num_threads=16):
     """ Compute the synthetic signal, minimizing either function calls or memory
-    TODO: since we are working in cython... the least is to give "func" 's signature
+    Params
+    =====
+    func : python function st. func(pts, t=None, vect=None) => data
+           with pts : ndarray (3, npts) - points where function is evaluated
+                vect : ndarray(3, npts) - if anisotropic signal vector of emiss.
+                t: ndarray(m) - times where to compute the function
+           returns: data : ndarray(n) if t is None, else ndarray(m,n)
+                           values of func at pts, at given time
+           func is the function to be integrated along the LOS
+    Ds: ndarray (3, nlos) LOS origins
+    us: ndarray (3, nlos) LOS directional vector
+    dL: double or list of doubles
+        If dL is a single double: discretization step for all LOS.
+        Else dL should be a list of size nlos with the discretization
+        step for each nlos.
+    DLs: (2, nlos) double array
+        For each nlos, it given the maximum and minimum limits of the ray
+    dmethod: string
+        type of discretization step: 'abs' for absolute or 'rel' for relative
+    method: string
+        method of quadrature on the LOS
+    ani : bool
+        to indicate if emission is anisotropic or not
+    t : None or array-like
+        times where to integrate
+    minimize: string
+        "calls" : we use algorithm to minimize the calls to 'func' (default)
+        "memory": we use algorithm to minimize memory used
+        "hybrid": a mix of both methods
+    Test : bool
+        we test if the inputs are giving in a proper way.
+    num_threads: int
+        number of threads if we want to parallelize the code.
     """
     cdef str error_message
     cdef str dmode = dmethod.lower()
@@ -2900,7 +2932,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
     cdef bint dl_is_list
     cdef bint C0, C1
     cdef double** los_coeffs = NULL
-    cdef unsigned int num_los
+    cdef unsigned int nlos
     cdef unsigned int nt=0, axm, ii, jj
     cdef np.ndarray[double,ndim=2] usbis, dsbis, ksbis
     cdef np.ndarray[double,ndim=2] sig
@@ -2912,9 +2944,9 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
     # .. Ds shape needed for testing and in algo ...............................
     sz1_ds = Ds.shape[0]
     sz2_ds = Ds.shape[1]
-    num_los = sz2_ds
-    dLr = np.zeros((num_los,), dtype=float)
-    los_ind = np.zeros((num_los,), dtype=int)
+    nlos = sz2_ds
+    dLr = np.zeros((nlos,), dtype=float)
+    los_ind = np.zeros((nlos,), dtype=int)
     dl_is_list = hasattr(dL, '__iter__')
     # .. verifying arguments ...................................................
     if Test:
@@ -2952,15 +2984,15 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
     n_dmode = _st.get_nb_dmode(dmode)
     n_imode = _st.get_nb_imode(imode)
     # Initialization result
-    sig = np.empty((nt,num_los),dtype=float)
+    sig = np.empty((nt,nlos),dtype=float)
     # --------------------------------------------------------------------------
     # Minimize function calls: sample (vect), call (once) and integrate
     if minim == 'calls':
         # Discretize all LOS
-        k, reseff, ind = LOS_get_sample(num_los, dL, DLs,
+        k, reseff, ind = LOS_get_sample(nlos, dL, DLs,
                                         dmethod=dmode, method=imode,
                                         num_threads=num_threads, Test=Test)
-        nbrep = np.r_[ind[0], np.diff(ind), k.size - ind[num_los-2]]
+        nbrep = np.r_[ind[0], np.diff(ind), k.size - ind[nlos-2]]
         # get pts and values
         usbis = np.repeat(us, nbrep, axis=1)
         if ani:
@@ -2972,16 +3004,16 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
         indbis = np.concatenate(([0],ind,[k.size]))
         # Integrate
         if method=='sum':
-            for ii in range(num_los):
+            for ii in range(nlos):
                 sig[:,ii] = np.sum(val[:,indbis[ii]:indbis[ii+1]],
                                    axis=-1)*reseff[ii]
         elif method=='simps':
-            for ii in range(num_los):
+            for ii in range(nlos):
                 sig[:,ii] = scpintg.simps(val[:,indbis[ii]:indbis[ii+1]],
                                           x=None, dx=reseff[ii], axis=-1)
         else:
             axm = 1
-            for ii in range(num_los):
+            for ii in range(nlos):
                 sig[:,ii] = scpintg.romb(val[:,indbis[ii]:indbis[ii+1]],
                                          dx=reseff[ii], axis=axm, show=False)
     # --------------------------------------------------------------------------
@@ -2991,7 +3023,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
         # loop over LOS and parallelize
         if dl_is_list and ani:
             if n_imode == 0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3008,7 +3040,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                                    t=ltime[jj], vect=-usbis, **fkwdargs)
                         sig[jj, ii] = np.sum(val)*loc_eff_res[0]
             elif n_imode == 1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3026,7 +3058,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                         sig[jj, ii] = scpintg.simps(val, x=None,
                                                     dx=loc_eff_res[0])
             elif n_imode == 2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3045,7 +3077,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                                                    dx=loc_eff_res[0])
         elif dl_is_list and not ani:
             if n_imode == 0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3062,7 +3094,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                                    t=ltime[jj], **fkwdargs)
                         sig[jj, ii] = np.sum(val)*loc_eff_res[0]
             elif n_imode == 1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3080,7 +3112,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                         sig[jj, ii] = scpintg.simps(val, x=None,
                                                     dx=loc_eff_res[0])
             elif n_imode == 2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3100,7 +3132,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
         elif ani:
             # dl is not a list: constant resolution
             if n_imode==0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3116,7 +3148,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                                    t=ltime[jj], vect=-usbis,**fkwdargs)
                         sig[jj, ii] = np.sum(val)*loc_eff_res[0]
             elif n_imode==1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3133,7 +3165,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                         sig[jj, ii] = scpintg.simps(val, x=None,
                                                     dx=loc_eff_res[0])
             elif n_imode==2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3152,7 +3184,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
         elif not ani:
             # dl is not a list: constant resolution
             if n_imode==0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3168,7 +3200,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                                    t=ltime[jj], **fkwdargs)
                         sig[jj, ii] = np.sum(val)*loc_eff_res[0]
             elif n_imode==1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3185,7 +3217,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                         sig[jj, ii] = scpintg.simps(val, x=None,
                                                     dx=loc_eff_res[0])
             elif n_imode==2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3202,14 +3234,14 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                         sig[jj, ii] = scpintg.romb(val, show=False,
                                                    dx=loc_eff_res[0])
     # --------------------------------------------------------------------------
-    # Minimize memory and calls (compromise): loop everything, starting with LOS
-    # call func only once for each los (treat all times)
+    # HYBRID method: Minimize memory and calls (compromise): loop everything,
+    # starting with LOS, call func only once for each los (treat all times)
     # loop over time for integrals
     else:
         # loop over LOS and parallelize
         if dl_is_list and ani:
             if n_imode == 0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3222,11 +3254,9 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, vect=-usbis, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = np.sum(val, axis=-1)*loc_eff_res[0]
+                    sig[:, ii] = np.sum(val, axis=-1)*loc_eff_res[0]
             elif n_imode == 1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3239,12 +3269,11 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, vect=-usbis, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.simps(val, x=None, axis=-1,
-                                                    dx=loc_eff_res[0])
+                    # integration
+                    sig[:, ii] = scpintg.simps(val, x=None, axis=-1,
+                                               dx=loc_eff_res[0])
             elif n_imode == 2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3257,13 +3286,11 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, vect=-usbis, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.romb(val, show=False, axis=1,
-                                                   dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.romb(val, show=False, axis=1,
+                                               dx=loc_eff_res[0])
         elif dl_is_list and not ani:
             if n_imode == 0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3276,11 +3303,9 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                    t=ltime, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = np.sum(val,axis=-1)*loc_eff_res[0]
+                    sig[:, ii] = np.sum(val,axis=-1)*loc_eff_res[0]
             elif n_imode == 1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3293,12 +3318,10 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.simps(val, x=None, axis=-1,
-                                                    dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.simps(val, x=None, axis=-1,
+                                                dx=loc_eff_res[0])
             elif n_imode == 2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3311,14 +3334,12 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.romb(val, show=False, axis=1,
-                                                   dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.romb(val, show=False, axis=1,
+                                               dx=loc_eff_res[0])
         elif ani:
             # dl is not a list: constant resolution
             if n_imode==0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3330,11 +3351,9 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, vect=-usbis,**fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = np.sum(val,axis=-1)*loc_eff_res[0]
+                    sig[:, ii] = np.sum(val,axis=-1)*loc_eff_res[0]
             elif n_imode==1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3346,12 +3365,10 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, vect=-usbis,**fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.simps(val, x=None, axis=-1,
-                                                    dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.simps(val, x=None, axis=-1,
+                                               dx=loc_eff_res[0])
             elif n_imode==2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3364,13 +3381,12 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, vect=-usbis,**fkwdargs)
                     # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.romb(val, show=False, axis=1,
-                                                   dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.romb(val, show=False, axis=1,
+                                               dx=loc_eff_res[0])
         elif not ani:
             # dl is not a list: constant resolution
             if n_imode==0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3383,10 +3399,9 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, **fkwdargs)
                     # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = np.sum(val,axis=1)*loc_eff_res[0]
+                    sig[:, ii] = np.sum(val,axis=1)*loc_eff_res[0]
             elif n_imode==1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3398,12 +3413,10 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.simps(val, x=None, axis=-1,
-                                                    dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.simps(val, x=None, axis=-1,
+                                               dx=loc_eff_res[0])
             elif n_imode==2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3415,10 +3428,8 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.romb(val, show=False, axis=-1,
-                                                   dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.romb(val, show=False, axis=-1,
+                                              dx=loc_eff_res[0])
     if los_coeffs != NULL:
         if los_coeffs[0] != NULL:
             free(los_coeffs[0])
@@ -3572,7 +3583,7 @@ cdef inline void NEW_LOS_sino_Tor(double orig0, double orig1, double orig2,
     results[8] = phi
     return
 
-cdef inline void NEW_los_sino_tor_vec(int num_los,
+cdef inline void NEW_los_sino_tor_vec(int nlos,
                                       double[:,::1] origins,
                                       double[:,::1] directions,
                                       double circ_radius,
@@ -3603,7 +3614,7 @@ cdef inline void NEW_los_sino_tor_vec(int num_los,
         dirv = <double*>malloc(3*sizeof(double))
         orig = <double*>malloc(3*sizeof(double))
         res = <double*>malloc(2*sizeof(double))
-        for ind_los in prange(num_los):
+        for ind_los in prange(nlos):
             dirv[0] = directions[0, ind_los]
             dirv[1] = directions[1, ind_los]
             dirv[2] = directions[2, ind_los]
@@ -4024,16 +4035,16 @@ def comp_dist_los_vpoly(double[:, ::1] ray_orig,
                         int num_threads=16, bint debug=False,
                         int debug_nlos=-1):
     """
-    This function computes the distance (and the associated k) between num_los
+    This function computes the distance (and the associated k) between nlos
     Rays (or LOS) and an `IN` structure (a polygon extruded around the axis
     (0,0,1), eg. a flux surface).
     For more details on the algorithm please see PDF: <name_of_pdf>.pdf #TODO
 
     Params
     ======
-        ray_orig : (3, num_los) double array
+        ray_orig : (3, nlos) double array
            LOS origin points coordinates
-        ray_vdir : (3, num_los) double array
+        ray_vdir : (3, nlos) double array
            LOS normalized direction vector
         ves_poly : (2, num_vertex) double array
            Coordinates of the vertices of the Polygon defining the 2D poloidal
@@ -4042,26 +4053,26 @@ def comp_dist_los_vpoly(double[:, ::1] ray_orig,
            Small value, acceptance of error
     Returns
     =======
-        kmin_vpoly : (num_los) double array
+        kmin_vpoly : (nlos) double array
             Of the form [k_0, k_1, ..., k_n], where k_i is the coefficient
             such that the i-th ray (LOS) is closest to the extruded polygon
             at the point P_i = orig[i] + kmin[i] * vdir[i]
-        dist_vpoly : (num_los) double array
+        dist_vpoly : (nlos) double array
             `distance[i]` is the distance from P_i to the extruded polygon.
     ---
     This is the PYTHON function, use only if you need this computation from
     Python, if you need it from Cython, use `simple_dist_los_vpoly_core`
     """
     cdef int npts_poly = ves_poly.shape[1]
-    cdef int num_los = ray_orig.shape[1]
+    cdef int nlos = ray_orig.shape[1]
     cdef int ii, ind_vert, ind_los
     cdef double* res_loc = NULL
     cdef double* loc_org = NULL
     cdef double* loc_dir = NULL
     cdef double crit2, invuz,  dpar2, upar2, upscaDp
     cdef double crit2_base = eps_uz * eps_uz /400.
-    cdef np.ndarray[double,ndim=1] dist = np.empty((num_los,),dtype=float)
-    cdef np.ndarray[double,ndim=1] kmin = np.empty((num_los,),dtype=float)
+    cdef np.ndarray[double,ndim=1] dist = np.empty((nlos,),dtype=float)
+    cdef np.ndarray[double,ndim=1] kmin = np.empty((nlos,),dtype=float)
     cdef double* list_vpoly_x = NULL
     cdef double* list_vpoly_y = NULL
     cdef int new_npts_poly
@@ -4081,7 +4092,7 @@ def comp_dist_los_vpoly(double[:, ::1] ray_orig,
         loc_dir   = <double *> malloc(sizeof(double) * 3)
         res_loc = <double *> malloc(2*sizeof(double))
         # == The parallelization over the LOS ==================================
-        for ind_los in prange(num_los, schedule='dynamic'):
+        for ind_los in prange(nlos, schedule='dynamic'):
             loc_org[0] = ray_orig[0, ind_los]
             loc_org[1] = ray_orig[1, ind_los]
             loc_org[2] = ray_orig[2, ind_los]
@@ -4121,7 +4132,7 @@ def comp_dist_los_vpoly_vec(int nvpoly, int nlos,
                             double eps_plane=_VSMALL, str ves_type='Tor',
                             str algo_type='simple', int num_threads=16):
     """
-    This function computes the distance (and the associated k) between num_los
+    This function computes the distance (and the associated k) between nlos
     Rays (or LOS) and several `IN` structures (polygons extruded around the axis
     (0,0,1), eg. flux surfaces).
     For more details on the algorithm please see PDF: <name_of_pdf>.pdf #TODO
@@ -4132,9 +4143,9 @@ def comp_dist_los_vpoly_vec(int nvpoly, int nlos,
            Number of flux surfaces
         nlos : int
            Number of LOS
-        ray_orig : (3, num_los) double array
+        ray_orig : (3, nlos) double array
            LOS origin points coordinates
-        ray_vdir : (3, num_los) double array
+        ray_vdir : (3, nlos) double array
            LOS normalized direction vector
         ves_poly : (num_pol, 2, num_vertex) double array
            Coordinates of the vertices of the Polygon defining the 2D poloidal
@@ -4145,12 +4156,12 @@ def comp_dist_los_vpoly_vec(int nvpoly, int nlos,
            Small value, acceptance of error
     Returns
     =======
-        kmin_vpoly : (npoly, num_los) double array
+        kmin_vpoly : (npoly, nlos) double array
             Of the form [k_00, k_01, ..., k_0n, k_10, k_11, ..., k_1n, ...]
             where k_ij is the coefficient for the j-th flux surface
             such that the i-th ray (LOS) is closest to the extruded polygon
             at the point P_i = orig[i] + kmin[i] * vdir[i]
-        dist_vpoly : (npoly, num_los) double array
+        dist_vpoly : (npoly, nlos) double array
             `distance[i * num_poly + j]` is the distance from P_i to the i-th
             extruded poly.
     ---
@@ -4199,7 +4210,7 @@ def is_close_los_vpoly_vec(int nvpoly, int nlos,
                            double eps_plane=_VSMALL, str ves_type='Tor',
                            str algo_type='simple', int num_threads=16):
     """
-    This function tests if the distance between num_los Rays (or LOS) and
+    This function tests if the distance between nlos Rays (or LOS) and
     several `IN` structures (polygons extruded around the axis (0,0,1),
     eg. flux surfaces) is smaller than `epsilon`.
     For more details on the algorithm please see PDF: <name_of_pdf>.pdf #TODO
@@ -4210,9 +4221,9 @@ def is_close_los_vpoly_vec(int nvpoly, int nlos,
            Number of flux surfaces
         nlos : int
            Number of LOS
-        ray_orig : (3, num_los) double array
+        ray_orig : (3, nlos) double array
            LOS origin points coordinates
-        ray_vdir : (3, num_los) double array
+        ray_vdir : (3, nlos) double array
            LOS normalized direction vector
         ves_poly : (num_pol, 2, num_vertex) double array
            Coordinates of the vertices of the Polygon defining the 2D poloidal
@@ -4225,7 +4236,7 @@ def is_close_los_vpoly_vec(int nvpoly, int nlos,
            Small value, acceptance of error
     Returns
     =======
-        are_close : (npoly * num_los) bool array
+        are_close : (npoly * nlos) bool array
             `are_close[i * num_poly + j]` indicates if distance between i-th LOS
             and j-th poly are closer than epsilon. (True if distance<epsilon)
     ---
@@ -4277,9 +4288,9 @@ def which_los_closer_vpoly_vec(int nvpoly, int nlos,
            Number of flux surfaces
         nlos : int
            Number of LOS
-        ray_orig : (3, num_los) double array
+        ray_orig : (3, nlos) double array
            LOS origin points coordinates
-        ray_vdir : (3, num_los) double array
+        ray_vdir : (3, nlos) double array
            LOS direction vector
         ves_poly : (num_pol, 2, num_vertex) double array
            Coordinates of the vertices of the Polygon defining the 2D poloidal
@@ -4338,9 +4349,9 @@ def which_vpoly_closer_los_vec(int nvpoly, int nlos,
            Number of flux surfaces
         nlos : int
            Number of LOS
-        ray_orig : (3, num_los) double array
+        ray_orig : (3, nlos) double array
            LOS origin points coordinates
-        ray_vdir : (3, num_los) double array
+        ray_vdir : (3, nlos) double array
            LOS direction vector
         ves_poly : (num_pol, 2, num_vertex) double array
            Coordinates of the vertices of the Polygon defining the 2D poloidal

--- a/tofu/geom/_GG03.pyx
+++ b/tofu/geom/_GG03.pyx
@@ -2067,9 +2067,9 @@ def LOS_Calc_PInOut_VesStruct(double[:, ::1] ray_orig,
 
     Params
     ======
-    ray_orig : (3, num_los) double array
+    ray_orig : (3, nlos) double array
        LOS origin points coordinates
-    ray_vdir : (3, num_los) double array
+    ray_vdir : (3, nlos) double array
        LOS normalized direction vector
     ves_poly : (2, num_vertex) double array
        Coordinates of the vertices of the Polygon defining the 2D poloidal
@@ -2106,13 +2106,13 @@ def LOS_Calc_PInOut_VesStruct(double[:, ::1] ray_orig,
        Typically this is the number of cores available on the machine.
     Returns
     ======
-    coeff_inter_in : (num_los) array
+    coeff_inter_in : (nlos) array
        scalars level of "in" intersection of the LOS (if k=0 at origin)
-    coeff_inter_out : (num_los) array
+    coeff_inter_out : (nlos) array
        scalars level of "out" intersection of the LOS (if k=0 at origin)
-    vperp_out : (3, num_los) array
+    vperp_out : (3, nlos) array
        Coordinates of the normal vector of impact of the LOS (NaN if none)
-    ind_inter_out : (3, num_los)
+    ind_inter_out : (3, nlos)
        Index of structure impacted by LOS: ind_inter_out[:,ind_los]=(i,j,k)
        where k is the index of edge impacted on the j-th sub structure of the
        structure number i. If the LOS impacted the vessel i=j=0
@@ -2120,14 +2120,14 @@ def LOS_Calc_PInOut_VesStruct(double[:, ::1] ray_orig,
     cdef str vt_lower = ves_type.lower()
     cdef str error_message
     cdef int sz_ves_lims
-    cdef int num_los = ray_orig.shape[1]
+    cdef int nlos = ray_orig.shape[1]
     cdef int npts_poly = ves_norm.shape[1]
     cdef bint bool1, bool2
     cdef double min_poly_r
-    cdef array vperp_out = clone(array('d'), num_los * 3, True)
-    cdef array coeff_inter_in  = clone(array('d'), num_los, True)
-    cdef array coeff_inter_out = clone(array('d'), num_los, True)
-    cdef array ind_inter_out = clone(array('i'), num_los * 3, True)
+    cdef array vperp_out = clone(array('d'), nlos * 3, True)
+    cdef array coeff_inter_in  = clone(array('d'), nlos, True)
+    cdef array coeff_inter_out = clone(array('d'), nlos, True)
+    cdef array ind_inter_out = clone(array('i'), nlos * 3, True)
     # == Testing inputs ========================================================
     if test:
         error_message = "ray_orig and ray_vdir must have the same shape: "\
@@ -2196,7 +2196,7 @@ def LOS_Calc_PInOut_VesStruct(double[:, ::1] ray_orig,
     # ==========================================================================
     sz_ves_lims = np.size(ves_lims)
     min_poly_r = _bgt.comp_min(ves_poly[0, ...], npts_poly-1)
-    _rt.compute_inout_tot(num_los, npts_poly,
+    _rt.compute_inout_tot(nlos, npts_poly,
                           ray_orig, ray_vdir,
                           ves_poly, ves_norm,
                           lstruct_nlim, ves_lims,
@@ -2211,9 +2211,9 @@ def LOS_Calc_PInOut_VesStruct(double[:, ::1] ray_orig,
                           coeff_inter_out, coeff_inter_in, vperp_out,
                           ind_inter_out)
     return np.asarray(coeff_inter_in), np.asarray(coeff_inter_out),\
-           np.transpose(np.asarray(vperp_out).reshape(num_los,3)),\
+           np.transpose(np.asarray(vperp_out).reshape(nlos,3)),\
            np.transpose(np.asarray(ind_inter_out,
-                                   dtype=int).reshape(num_los, 3))
+                                   dtype=int).reshape(nlos, 3))
 
 
 # =============================================================================
@@ -2242,9 +2242,9 @@ def LOS_Calc_kMinkMax_VesStruct(double[:, ::1] ray_orig,
 
     Params
     ======
-    ray_orig : (3, num_los) double array
+    ray_orig : (3, nlos) double array
        LOS origin points coordinates
-    ray_vdir : (3, num_los) double array
+    ray_vdir : (3, nlos) double array
        LOS normalized direction vector
     num_surf : int
        number of surfaxes, aka 'in' structures or 'vessels'
@@ -2272,17 +2272,17 @@ def LOS_Calc_kMinkMax_VesStruct(double[:, ::1] ray_orig,
        Typically this is the number of cores available on the machine.
     Return
     ======
-    coeff_inter_in : (num_surf, num_los) array
+    coeff_inter_in : (num_surf, nlos) array
        scalars level of "in" intersection of the LOS (if k=0 at origin) for
        each surface
        [kmin(surf0, los0), kmin(surf0, los1), ..., kmin(surf1, los0),....]
-    coeff_inter_out : (num_surf, num_los) array
+    coeff_inter_out : (num_surf, nlos) array
        scalars level of "out" intersection of the LOS (if k=0 at origin) for
        each surface
        [kmax(surf0, los0), kmax(surf0, los1), ..., kmax(surf1, los0),....]
     """
     cdef int npts_poly
-    cdef int num_los = ray_orig.shape[1]
+    cdef int nlos = ray_orig.shape[1]
     cdef int ind_struct = 0
     cdef int ind_surf
     cdef double crit2_base = eps_uz * eps_uz /400.
@@ -2292,8 +2292,8 @@ def LOS_Calc_kMinkMax_VesStruct(double[:, ::1] ray_orig,
     cdef str error_message
     cdef bint forbidbis, forbid0
     cdef bint bool1, bool2
-    cdef array coeff_inter_in  = clone(array('d'), num_los * num_surf, True)
-    cdef array coeff_inter_out = clone(array('d'), num_los * num_surf, True)
+    cdef array coeff_inter_in  = clone(array('d'), nlos * num_surf, True)
+    cdef array coeff_inter_out = clone(array('d'), nlos * num_surf, True)
     cdef int *llimits = NULL
     cdef long *lsz_lim = NULL
     cdef bint are_limited
@@ -2339,7 +2339,7 @@ def LOS_Calc_kMinkMax_VesStruct(double[:, ::1] ray_orig,
                 rmin = 0.95*min(np.min(ves_poly[ind_surf][0, ...]),
                                 _bgt.comp_min_hypot(ray_orig[0, ...],
                                                     ray_orig[1, ...],
-                                                    num_los))
+                                                    nlos))
             rmin2 = rmin*rmin
             # Variable to avoid looking "behind" blind spot of tore
             if forbid:
@@ -2351,9 +2351,9 @@ def LOS_Calc_kMinkMax_VesStruct(double[:, ::1] ray_orig,
             tmp_poly = ves_poly[ind_surf]
             tmp_norm = ves_norm[ind_surf]
             # -- Computing intersection between LOS and Vessel -----------------
-            _rt.raytracing_minmax_struct_tor(num_los, ray_vdir, ray_orig,
-                                             &ptr_coeff_out[ind_surf*num_los],
-                                             &ptr_coeff_in[ind_surf*num_los],
+            _rt.raytracing_minmax_struct_tor(nlos, ray_vdir, ray_orig,
+                                             &ptr_coeff_out[ind_surf*nlos],
+                                             &ptr_coeff_in[ind_surf*nlos],
                                              forbid0, forbidbis,
                                              rmin, rmin2, crit2_base,
                                              npts_poly, lbounds_ves,
@@ -2382,15 +2382,15 @@ def LOS_Calc_kMinkMax_VesStruct(double[:, ::1] ray_orig,
             npts_poly = lnvert[ind_surf]
             tmp_poly = ves_poly[ind_surf]
             tmp_norm = ves_norm[ind_surf]
-            _rt.raytracing_minmax_struct_lin(num_los, ray_orig, ray_vdir,
+            _rt.raytracing_minmax_struct_lin(nlos, ray_orig, ray_vdir,
                                              npts_poly,
                                              &tmp_poly[0][0],
                                              &tmp_poly[1][0],
                                              &tmp_norm[0][0],
                                              &tmp_norm[1][0],
                                              lbounds_ves[0], lbounds_ves[1],
-                                             &ptr_coeff_out[ind_surf*num_los],
-                                             &ptr_coeff_in[ind_surf*num_los],
+                                             &ptr_coeff_out[ind_surf*nlos],
+                                             &ptr_coeff_in[ind_surf*nlos],
                                              eps_plane)
 
     return np.asarray(coeff_inter_in), np.asarray(coeff_inter_out)
@@ -2564,9 +2564,9 @@ def vignetting(double[:, ::1] ray_orig,
                long[::1] lnvert,
                int num_threads=16):
     """
-    ray_orig : (3, num_los) double array
+    ray_orig : (3, nlos) double array
        LOS origin points coordinates
-    ray_vdir : (3, num_los) double array
+    ray_vdir : (3, nlos) double array
        LOS normalized direction vector
     vignett_poly : (num_vign, 3, num_vertex) double list of arrays
        Coordinates of the vertices of the Polygon defining the 3D vignett.
@@ -2575,7 +2575,7 @@ def vignetting(double[:, ::1] ray_orig,
        Number of vertices for each vignett (without counting the rebound)
     Returns
     ======
-    goes_through: (num_vign, num_los) bool array
+    goes_through: (num_vign, nlos) bool array
        Indicates for each vignett if each LOS wents through or not
     """
     cdef int ii
@@ -2624,7 +2624,7 @@ def vignetting(double[:, ::1] ray_orig,
 #                                  LOS SAMPLING
 #
 # ==============================================================================
-def LOS_get_sample(int num_los, dL, double[:,::1] DLs, str dmethod='abs',
+def LOS_get_sample(int nlos, dL, double[:,::1] DLs, str dmethod='abs',
                    str method='sum', bint Test=True, int num_threads=16):
     """
     Return the sampled line, with the specified method
@@ -2637,10 +2637,10 @@ def LOS_get_sample(int num_los, dL, double[:,::1] DLs, str dmethod='abs',
     ======
     dL: double or list of doubles
         If dL is a single double: discretization step for all LOS.
-        Else dL should be a list of size num_los with the discretization
-        step for each num_los.
-    DLs: (2, num_los) double array
-        For each num_los, it given the maximum and minimum limits of the ray
+        Else dL should be a list of size nlos with the discretization
+        step for each nlos.
+    DLs: (2, nlos) double array
+        For each nlos, it given the maximum and minimum limits of the ray
     dmethod: string
         type of discretization step: 'abs' for absolute or 'rel' for relative
     method: string
@@ -2671,18 +2671,18 @@ def LOS_get_sample(int num_los, dL, double[:,::1] DLs, str dmethod='abs',
     cdef long* tmp_arr
     cdef double* los_coeffs = NULL
     # .. ray_orig shape needed for testing and in algo .........................
-    dLr = np.zeros((num_los,), dtype=float)
-    los_ind = np.zeros((num_los,), dtype=int)
+    dLr = np.zeros((nlos,), dtype=float)
+    los_ind = np.zeros((nlos,), dtype=int)
     dl_is_list = hasattr(dL, '__iter__')
     # .. verifying arguments ...................................................
     if Test:
         sz1_dls = DLs.shape[0]
         sz2_dls = DLs.shape[1]
         assert sz1_dls == 2, "Dim 0 of arg DLs should be 2"
-        error_message = "Args DLs should have dim 1 = num_los"
-        assert num_los == sz2_dls, error_message
+        error_message = "Args DLs should have dim 1 = nlos"
+        assert nlos == sz2_dls, error_message
         bool1 = not dl_is_list and dL > 0.
-        bool2 = dl_is_list and len(dL)==num_los and np.all(dL>0.)
+        bool2 = dl_is_list and len(dL)==nlos and np.all(dL>0.)
         assert bool1 or bool2, "Arg dL must be a double or a List, and dL >0.!"
         error_message = "Argument dmethod (discretization method) should be in"\
                         +" ['abs','rel'], for absolute or relative."
@@ -2697,43 +2697,43 @@ def LOS_get_sample(int num_los, dL, double[:,::1] DLs, str dmethod='abs',
         if dmode=='rel':
             N = <int> Cceil(1./val_resol)
             if imode=='sum':
-                coeff_arr = np.empty((N*num_los,), dtype=float)
-                _st.middle_rule_rel(num_los, N, &DLs[0,0], &DLs[1, 0],
+                coeff_arr = np.empty((N*nlos,), dtype=float)
+                _st.middle_rule_rel(nlos, N, &DLs[0,0], &DLs[1, 0],
                                     &dLr[0], &coeff_arr[0], &los_ind[0],
                                     num_threads=num_threads)
             elif imode=='simps':
                 N = N if N%2==0 else N+1
-                coeff_arr = np.empty(((N+1)*num_los,), dtype=float)
-                _st.left_rule_rel(num_los, N,
+                coeff_arr = np.empty(((N+1)*nlos,), dtype=float)
+                _st.left_rule_rel(nlos, N,
                                   &DLs[0,0], &DLs[1, 0], &dLr[0],
                                   &coeff_arr[0], &los_ind[0],
                                   num_threads=num_threads)
             elif imode=='romb':
                 N = 2**(int(Cceil(Clog2(N))))
-                coeff_arr = np.empty(((N+1)*num_los,), dtype=float)
-                _st.left_rule_rel(num_los, N,
+                coeff_arr = np.empty(((N+1)*nlos,), dtype=float)
+                _st.left_rule_rel(nlos, N,
                                   &DLs[0,0], &DLs[1, 0],
                                   &dLr[0], &coeff_arr[0], &los_ind[0],
                                   num_threads=num_threads)
-            return coeff_arr, dLr, los_ind[:num_los-1]
+            return coeff_arr, dLr, los_ind[:nlos-1]
         else:
             if imode=='sum':
-                _st.middle_rule_abs_1(num_los, val_resol, &DLs[0,0], &DLs[1, 0],
+                _st.middle_rule_abs_1(nlos, val_resol, &DLs[0,0], &DLs[1, 0],
                                       &dLr[0], &los_ind[0],
                                       num_threads=num_threads)
                 ntmp = np.sum(los_ind)
                 coeff_arr = np.empty((ntmp,), dtype=float)
-                _st.middle_rule_abs_2(num_los, &DLs[0,0], &los_ind[0],
+                _st.middle_rule_abs_2(nlos, &DLs[0,0], &los_ind[0],
                                       &dLr[0], &coeff_arr[0],
                                       num_threads=num_threads)
-                return coeff_arr, dLr, los_ind[0:num_los-1]
+                return coeff_arr, dLr, los_ind[0:nlos-1]
             elif imode=='simps':
-                _st.simps_left_rule_abs(num_los, val_resol,
+                _st.simps_left_rule_abs(nlos, val_resol,
                                         &DLs[0,0], &DLs[1, 0],
                                         &dLr[0], &los_coeffs, &los_ind[0],
                                         num_threads=num_threads)
             else:
-                _st.romb_left_rule_abs(num_los, val_resol,
+                _st.romb_left_rule_abs(nlos, val_resol,
                                        &DLs[0,0], &DLs[1, 0],
                                        &dLr[0], &los_coeffs, &los_ind[0],
                                        num_threads=num_threads)
@@ -2742,38 +2742,38 @@ def LOS_get_sample(int num_los, dL, double[:,::1] DLs, str dmethod='abs',
         dl_view=dL
         if dmode=='abs':
             if imode=='sum':
-                _st.middle_rule_abs_var(num_los, &dl_view[0],
+                _st.middle_rule_abs_var(nlos, &dl_view[0],
                                         &DLs[0,0], &DLs[1, 0],
                                         &dLr[0], &los_coeffs, &los_ind[0],
                                         num_threads=num_threads)
             elif imode=='simps':
-                _st.simps_left_rule_abs_var(num_los, &dl_view[0],
+                _st.simps_left_rule_abs_var(nlos, &dl_view[0],
                                             &DLs[0,0], &DLs[1, 0],
                                             &dLr[0], &los_coeffs, &los_ind[0],
                                             num_threads=num_threads)
             else:
-                _st.romb_left_rule_abs_var(num_los, &dl_view[0],
+                _st.romb_left_rule_abs_var(nlos, &dl_view[0],
                                            &DLs[0,0], &DLs[1, 0],
                                            &dLr[0], &los_coeffs, &los_ind[0],
                                            num_threads=num_threads)
         else:
             if imode=='sum':
-                _st.middle_rule_rel_var(num_los, &dl_view[0],
+                _st.middle_rule_rel_var(nlos, &dl_view[0],
                                         &DLs[0,0], &DLs[1, 0],
                                         &dLr[0], &los_coeffs, &los_ind[0],
                                         num_threads=num_threads)
             elif imode=='simps':
-                _st.simps_left_rule_rel_var(num_los, &dl_view[0],
+                _st.simps_left_rule_rel_var(nlos, &dl_view[0],
                                             &DLs[0,0], &DLs[1, 0],
                                             &dLr[0], &los_coeffs, &los_ind[0],
                                             num_threads=num_threads)
             else:
-                _st.romb_left_rule_rel_var(num_los, &dl_view[0],
+                _st.romb_left_rule_rel_var(nlos, &dl_view[0],
                                            &DLs[0,0], &DLs[1, 0],
                                            &dLr[0], &los_coeffs, &los_ind[0],
                                            num_threads=num_threads)
-    return np.asarray(<double[:los_ind[num_los-1]]> los_coeffs),\
-        dLr, los_ind[0:num_los-1]
+    return np.asarray(<double[:los_ind[nlos-1]]> los_coeffs),\
+        dLr, los_ind[0:nlos-1]
 
 
 
@@ -2886,7 +2886,39 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     t=None, fkwdargs={}, str minimize='calls',
                     bint Test=True, int num_threads=16):
     """ Compute the synthetic signal, minimizing either function calls or memory
-    TODO: since we are working in cython... the least is to give "func" 's signature
+    Params
+    =====
+    func : python function st. func(pts, t=None, vect=None) => data
+           with pts : ndarray (3, npts) - points where function is evaluated
+                vect : ndarray(3, npts) - if anisotropic signal vector of emiss.
+                t: ndarray(m) - times where to compute the function
+           returns: data : ndarray(n) if t is None, else ndarray(m,n)
+                           values of func at pts, at given time
+           func is the function to be integrated along the LOS
+    Ds: ndarray (3, nlos) LOS origins
+    us: ndarray (3, nlos) LOS directional vector
+    dL: double or list of doubles
+        If dL is a single double: discretization step for all LOS.
+        Else dL should be a list of size nlos with the discretization
+        step for each nlos.
+    DLs: (2, nlos) double array
+        For each nlos, it given the maximum and minimum limits of the ray
+    dmethod: string
+        type of discretization step: 'abs' for absolute or 'rel' for relative
+    method: string
+        method of quadrature on the LOS
+    ani : bool
+        to indicate if emission is anisotropic or not
+    t : None or array-like
+        times where to integrate
+    minimize: string
+        "calls" : we use algorithm to minimize the calls to 'func' (default)
+        "memory": we use algorithm to minimize memory used
+        "hybrid": a mix of both methods
+    Test : bool
+        we test if the inputs are giving in a proper way.
+    num_threads: int
+        number of threads if we want to parallelize the code.
     """
     cdef str error_message
     cdef str dmode = dmethod.lower()
@@ -2900,7 +2932,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
     cdef bint dl_is_list
     cdef bint C0, C1
     cdef double** los_coeffs = NULL
-    cdef unsigned int num_los
+    cdef unsigned int nlos
     cdef unsigned int nt=0, axm, ii, jj
     cdef np.ndarray[double,ndim=2] usbis, dsbis, ksbis
     cdef np.ndarray[double,ndim=2] sig
@@ -2912,9 +2944,9 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
     # .. Ds shape needed for testing and in algo ...............................
     sz1_ds = Ds.shape[0]
     sz2_ds = Ds.shape[1]
-    num_los = sz2_ds
-    dLr = np.zeros((num_los,), dtype=float)
-    los_ind = np.zeros((num_los,), dtype=int)
+    nlos = sz2_ds
+    dLr = np.zeros((nlos,), dtype=float)
+    los_ind = np.zeros((nlos,), dtype=int)
     dl_is_list = hasattr(dL, '__iter__')
     # .. verifying arguments ...................................................
     if Test:
@@ -2952,15 +2984,15 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
     n_dmode = _st.get_nb_dmode(dmode)
     n_imode = _st.get_nb_imode(imode)
     # Initialization result
-    sig = np.empty((nt,num_los),dtype=float)
+    sig = np.empty((nt,nlos),dtype=float)
     # --------------------------------------------------------------------------
     # Minimize function calls: sample (vect), call (once) and integrate
     if minim == 'calls':
         # Discretize all LOS
-        k, reseff, ind = LOS_get_sample(num_los, dL, DLs,
+        k, reseff, ind = LOS_get_sample(nlos, dL, DLs,
                                         dmethod=dmode, method=imode,
                                         num_threads=num_threads, Test=Test)
-        nbrep = np.r_[ind[0], np.diff(ind), k.size - ind[num_los-2]]
+        nbrep = np.r_[ind[0], np.diff(ind), k.size - ind[nlos-2]]
         # get pts and values
         usbis = np.repeat(us, nbrep, axis=1)
         if ani:
@@ -2972,16 +3004,16 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
         indbis = np.concatenate(([0],ind,[k.size]))
         # Integrate
         if method=='sum':
-            for ii in range(num_los):
+            for ii in range(nlos):
                 sig[:,ii] = np.sum(val[:,indbis[ii]:indbis[ii+1]],
                                    axis=-1)*reseff[ii]
         elif method=='simps':
-            for ii in range(num_los):
+            for ii in range(nlos):
                 sig[:,ii] = scpintg.simps(val[:,indbis[ii]:indbis[ii+1]],
                                           x=None, dx=reseff[ii], axis=-1)
         else:
             axm = 1
-            for ii in range(num_los):
+            for ii in range(nlos):
                 sig[:,ii] = scpintg.romb(val[:,indbis[ii]:indbis[ii+1]],
                                          dx=reseff[ii], axis=axm, show=False)
     # --------------------------------------------------------------------------
@@ -2991,7 +3023,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
         # loop over LOS and parallelize
         if dl_is_list and ani:
             if n_imode == 0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3008,7 +3040,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                                    t=ltime[jj], vect=-usbis, **fkwdargs)
                         sig[jj, ii] = np.sum(val)*loc_eff_res[0]
             elif n_imode == 1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3026,7 +3058,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                         sig[jj, ii] = scpintg.simps(val, x=None,
                                                     dx=loc_eff_res[0])
             elif n_imode == 2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3045,7 +3077,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                                                    dx=loc_eff_res[0])
         elif dl_is_list and not ani:
             if n_imode == 0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3062,7 +3094,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                                    t=ltime[jj], **fkwdargs)
                         sig[jj, ii] = np.sum(val)*loc_eff_res[0]
             elif n_imode == 1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3080,7 +3112,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                         sig[jj, ii] = scpintg.simps(val, x=None,
                                                     dx=loc_eff_res[0])
             elif n_imode == 2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3100,7 +3132,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
         elif ani:
             # dl is not a list: constant resolution
             if n_imode==0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3116,7 +3148,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                                    t=ltime[jj], vect=-usbis,**fkwdargs)
                         sig[jj, ii] = np.sum(val)*loc_eff_res[0]
             elif n_imode==1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3133,7 +3165,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                         sig[jj, ii] = scpintg.simps(val, x=None,
                                                     dx=loc_eff_res[0])
             elif n_imode==2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3152,7 +3184,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
         elif not ani:
             # dl is not a list: constant resolution
             if n_imode==0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3168,7 +3200,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                                    t=ltime[jj], **fkwdargs)
                         sig[jj, ii] = np.sum(val)*loc_eff_res[0]
             elif n_imode==1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3185,7 +3217,7 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                         sig[jj, ii] = scpintg.simps(val, x=None,
                                                     dx=loc_eff_res[0])
             elif n_imode==2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3202,14 +3234,14 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                         sig[jj, ii] = scpintg.romb(val, show=False,
                                                    dx=loc_eff_res[0])
     # --------------------------------------------------------------------------
-    # Minimize memory and calls (compromise): loop everything, starting with LOS
-    # call func only once for each los (treat all times)
+    # HYBRID method: Minimize memory and calls (compromise): loop everything,
+    # starting with LOS, call func only once for each los (treat all times)
     # loop over time for integrals
     else:
         # loop over LOS and parallelize
         if dl_is_list and ani:
             if n_imode == 0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3222,11 +3254,9 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, vect=-usbis, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = np.sum(val, axis=-1)*loc_eff_res[0]
+                    sig[:, ii] = np.sum(val, axis=-1)*loc_eff_res[0]
             elif n_imode == 1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3239,12 +3269,11 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, vect=-usbis, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.simps(val, x=None, axis=-1,
-                                                    dx=loc_eff_res[0])
+                    # integration
+                    sig[:, ii] = scpintg.simps(val, x=None, axis=-1,
+                                               dx=loc_eff_res[0])
             elif n_imode == 2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3257,13 +3286,11 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, vect=-usbis, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.romb(val, show=False, axis=1,
-                                                   dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.romb(val, show=False, axis=1,
+                                               dx=loc_eff_res[0])
         elif dl_is_list and not ani:
             if n_imode == 0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3276,11 +3303,9 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                    t=ltime, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = np.sum(val,axis=-1)*loc_eff_res[0]
+                    sig[:, ii] = np.sum(val,axis=-1)*loc_eff_res[0]
             elif n_imode == 1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3293,12 +3318,10 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.simps(val, x=None, axis=-1,
-                                                    dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.simps(val, x=None, axis=-1,
+                                                dx=loc_eff_res[0])
             elif n_imode == 2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3311,14 +3334,12 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.romb(val, show=False, axis=1,
-                                                   dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.romb(val, show=False, axis=1,
+                                               dx=loc_eff_res[0])
         elif ani:
             # dl is not a list: constant resolution
             if n_imode==0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3330,11 +3351,9 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, vect=-usbis,**fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = np.sum(val,axis=-1)*loc_eff_res[0]
+                    sig[:, ii] = np.sum(val,axis=-1)*loc_eff_res[0]
             elif n_imode==1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3346,12 +3365,10 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, vect=-usbis,**fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.simps(val, x=None, axis=-1,
-                                                    dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.simps(val, x=None, axis=-1,
+                                               dx=loc_eff_res[0])
             elif n_imode==2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3364,13 +3381,12 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, vect=-usbis,**fkwdargs)
                     # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.romb(val, show=False, axis=1,
-                                                   dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.romb(val, show=False, axis=1,
+                                               dx=loc_eff_res[0])
         elif not ani:
             # dl is not a list: constant resolution
             if n_imode==0:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3383,10 +3399,9 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, **fkwdargs)
                     # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = np.sum(val,axis=1)*loc_eff_res[0]
+                    sig[:, ii] = np.sum(val,axis=1)*loc_eff_res[0]
             elif n_imode==1:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3398,12 +3413,10 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.simps(val, x=None, axis=-1,
-                                                    dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.simps(val, x=None, axis=-1,
+                                               dx=loc_eff_res[0])
             elif n_imode==2:
-                for ii in range(num_los):
+                for ii in range(nlos):
                     los_coeffs = <double**>malloc(sizeof(double*))
                     los_coeffs[0] = NULL
                     sz_coeff = _st.LOS_get_sample_single(DLs[0,0], DLs[1,0],
@@ -3415,10 +3428,8 @@ def LOS_calc_signal(func, double[:,::1] Ds, double[:,::1] us, dL,
                     ksbis = np.asarray(<double[:sz_coeff]>los_coeffs[0])
                     val = func(dsbis + ksbis * usbis,
                                t=ltime, **fkwdargs)
-                    # loop over time for integrating
-                    for jj in range(nt):
-                        sig[jj, ii] = scpintg.romb(val, show=False, axis=-1,
-                                                   dx=loc_eff_res[0])
+                    sig[:, ii] = scpintg.romb(val, show=False, axis=-1,
+                                              dx=loc_eff_res[0])
     if los_coeffs != NULL:
         if los_coeffs[0] != NULL:
             free(los_coeffs[0])
@@ -3572,7 +3583,7 @@ cdef inline void NEW_LOS_sino_Tor(double orig0, double orig1, double orig2,
     results[8] = phi
     return
 
-cdef inline void NEW_los_sino_tor_vec(int num_los,
+cdef inline void NEW_los_sino_tor_vec(int nlos,
                                       double[:,::1] origins,
                                       double[:,::1] directions,
                                       double circ_radius,
@@ -3603,7 +3614,7 @@ cdef inline void NEW_los_sino_tor_vec(int num_los,
         dirv = <double*>malloc(3*sizeof(double))
         orig = <double*>malloc(3*sizeof(double))
         res = <double*>malloc(2*sizeof(double))
-        for ind_los in prange(num_los):
+        for ind_los in prange(nlos):
             dirv[0] = directions[0, ind_los]
             dirv[1] = directions[1, ind_los]
             dirv[2] = directions[2, ind_los]
@@ -4024,16 +4035,16 @@ def comp_dist_los_vpoly(double[:, ::1] ray_orig,
                         int num_threads=16, bint debug=False,
                         int debug_nlos=-1):
     """
-    This function computes the distance (and the associated k) between num_los
+    This function computes the distance (and the associated k) between nlos
     Rays (or LOS) and an `IN` structure (a polygon extruded around the axis
     (0,0,1), eg. a flux surface).
     For more details on the algorithm please see PDF: <name_of_pdf>.pdf #TODO
 
     Params
     ======
-        ray_orig : (3, num_los) double array
+        ray_orig : (3, nlos) double array
            LOS origin points coordinates
-        ray_vdir : (3, num_los) double array
+        ray_vdir : (3, nlos) double array
            LOS normalized direction vector
         ves_poly : (2, num_vertex) double array
            Coordinates of the vertices of the Polygon defining the 2D poloidal
@@ -4042,26 +4053,26 @@ def comp_dist_los_vpoly(double[:, ::1] ray_orig,
            Small value, acceptance of error
     Returns
     =======
-        kmin_vpoly : (num_los) double array
+        kmin_vpoly : (nlos) double array
             Of the form [k_0, k_1, ..., k_n], where k_i is the coefficient
             such that the i-th ray (LOS) is closest to the extruded polygon
             at the point P_i = orig[i] + kmin[i] * vdir[i]
-        dist_vpoly : (num_los) double array
+        dist_vpoly : (nlos) double array
             `distance[i]` is the distance from P_i to the extruded polygon.
     ---
     This is the PYTHON function, use only if you need this computation from
     Python, if you need it from Cython, use `simple_dist_los_vpoly_core`
     """
     cdef int npts_poly = ves_poly.shape[1]
-    cdef int num_los = ray_orig.shape[1]
+    cdef int nlos = ray_orig.shape[1]
     cdef int ii, ind_vert, ind_los
     cdef double* res_loc = NULL
     cdef double* loc_org = NULL
     cdef double* loc_dir = NULL
     cdef double crit2, invuz,  dpar2, upar2, upscaDp
     cdef double crit2_base = eps_uz * eps_uz /400.
-    cdef np.ndarray[double,ndim=1] dist = np.empty((num_los,),dtype=float)
-    cdef np.ndarray[double,ndim=1] kmin = np.empty((num_los,),dtype=float)
+    cdef np.ndarray[double,ndim=1] dist = np.empty((nlos,),dtype=float)
+    cdef np.ndarray[double,ndim=1] kmin = np.empty((nlos,),dtype=float)
     cdef double* list_vpoly_x = NULL
     cdef double* list_vpoly_y = NULL
     cdef int new_npts_poly
@@ -4081,7 +4092,7 @@ def comp_dist_los_vpoly(double[:, ::1] ray_orig,
         loc_dir   = <double *> malloc(sizeof(double) * 3)
         res_loc = <double *> malloc(2*sizeof(double))
         # == The parallelization over the LOS ==================================
-        for ind_los in prange(num_los, schedule='dynamic'):
+        for ind_los in prange(nlos, schedule='dynamic'):
             loc_org[0] = ray_orig[0, ind_los]
             loc_org[1] = ray_orig[1, ind_los]
             loc_org[2] = ray_orig[2, ind_los]
@@ -4121,7 +4132,7 @@ def comp_dist_los_vpoly_vec(int nvpoly, int nlos,
                             double eps_plane=_VSMALL, str ves_type='Tor',
                             str algo_type='simple', int num_threads=16):
     """
-    This function computes the distance (and the associated k) between num_los
+    This function computes the distance (and the associated k) between nlos
     Rays (or LOS) and several `IN` structures (polygons extruded around the axis
     (0,0,1), eg. flux surfaces).
     For more details on the algorithm please see PDF: <name_of_pdf>.pdf #TODO
@@ -4132,9 +4143,9 @@ def comp_dist_los_vpoly_vec(int nvpoly, int nlos,
            Number of flux surfaces
         nlos : int
            Number of LOS
-        ray_orig : (3, num_los) double array
+        ray_orig : (3, nlos) double array
            LOS origin points coordinates
-        ray_vdir : (3, num_los) double array
+        ray_vdir : (3, nlos) double array
            LOS normalized direction vector
         ves_poly : (num_pol, 2, num_vertex) double array
            Coordinates of the vertices of the Polygon defining the 2D poloidal
@@ -4145,12 +4156,12 @@ def comp_dist_los_vpoly_vec(int nvpoly, int nlos,
            Small value, acceptance of error
     Returns
     =======
-        kmin_vpoly : (npoly, num_los) double array
+        kmin_vpoly : (npoly, nlos) double array
             Of the form [k_00, k_01, ..., k_0n, k_10, k_11, ..., k_1n, ...]
             where k_ij is the coefficient for the j-th flux surface
             such that the i-th ray (LOS) is closest to the extruded polygon
             at the point P_i = orig[i] + kmin[i] * vdir[i]
-        dist_vpoly : (npoly, num_los) double array
+        dist_vpoly : (npoly, nlos) double array
             `distance[i * num_poly + j]` is the distance from P_i to the i-th
             extruded poly.
     ---
@@ -4199,7 +4210,7 @@ def is_close_los_vpoly_vec(int nvpoly, int nlos,
                            double eps_plane=_VSMALL, str ves_type='Tor',
                            str algo_type='simple', int num_threads=16):
     """
-    This function tests if the distance between num_los Rays (or LOS) and
+    This function tests if the distance between nlos Rays (or LOS) and
     several `IN` structures (polygons extruded around the axis (0,0,1),
     eg. flux surfaces) is smaller than `epsilon`.
     For more details on the algorithm please see PDF: <name_of_pdf>.pdf #TODO
@@ -4210,9 +4221,9 @@ def is_close_los_vpoly_vec(int nvpoly, int nlos,
            Number of flux surfaces
         nlos : int
            Number of LOS
-        ray_orig : (3, num_los) double array
+        ray_orig : (3, nlos) double array
            LOS origin points coordinates
-        ray_vdir : (3, num_los) double array
+        ray_vdir : (3, nlos) double array
            LOS normalized direction vector
         ves_poly : (num_pol, 2, num_vertex) double array
            Coordinates of the vertices of the Polygon defining the 2D poloidal
@@ -4225,7 +4236,7 @@ def is_close_los_vpoly_vec(int nvpoly, int nlos,
            Small value, acceptance of error
     Returns
     =======
-        are_close : (npoly * num_los) bool array
+        are_close : (npoly * nlos) bool array
             `are_close[i * num_poly + j]` indicates if distance between i-th LOS
             and j-th poly are closer than epsilon. (True if distance<epsilon)
     ---
@@ -4277,9 +4288,9 @@ def which_los_closer_vpoly_vec(int nvpoly, int nlos,
            Number of flux surfaces
         nlos : int
            Number of LOS
-        ray_orig : (3, num_los) double array
+        ray_orig : (3, nlos) double array
            LOS origin points coordinates
-        ray_vdir : (3, num_los) double array
+        ray_vdir : (3, nlos) double array
            LOS direction vector
         ves_poly : (num_pol, 2, num_vertex) double array
            Coordinates of the vertices of the Polygon defining the 2D poloidal
@@ -4338,9 +4349,9 @@ def which_vpoly_closer_los_vec(int nvpoly, int nlos,
            Number of flux surfaces
         nlos : int
            Number of LOS
-        ray_orig : (3, num_los) double array
+        ray_orig : (3, nlos) double array
            LOS origin points coordinates
-        ray_vdir : (3, num_los) double array
+        ray_vdir : (3, nlos) double array
            LOS direction vector
         ves_poly : (num_pol, 2, num_vertex) double array
            Coordinates of the vertices of the Polygon defining the 2D poloidal

--- a/tofu/geom/_core.py
+++ b/tofu/geom/_core.py
@@ -4547,7 +4547,7 @@ class Rays(utils.ToFuObject):
                                invert=invert, draw=draw, connect=connect)
 
         if out in [object, 'object']:
-            return osig
+            return osig, units
         else:
             return sig, units
 
@@ -4616,9 +4616,6 @@ class Rays(utils.ToFuObject):
             sig = np.full((1,self.nRays), np.nan)
 
         if t is None or len(t)==1:
-            print(sig.shape)
-            print(indok.shape)
-            sig = sig.reshape((1,s.shape[1]))
             sig[0,indok] = s
         else:
             sig[:,indok] = s
@@ -4626,7 +4623,7 @@ class Rays(utils.ToFuObject):
         # Format output
         return self._calc_signal_postformat(sig, Brightness=Brightness,
                                             dataname=dataname, t=t, E=E,
-                                            units=units, plot=plot,
+                                            units=units, plot=plot, out=out,
                                             fs=fs, dmargin=dmargin, wintit=wintit,
                                             invert=invert, draw=draw,
                                             connect=connect)

--- a/tofu/geom/_core.py
+++ b/tofu/geom/_core.py
@@ -4616,8 +4616,10 @@ class Rays(utils.ToFuObject):
             sig = np.full((1,self.nRays), np.nan)
 
         if t is None or len(t)==1:
-            sig[indok] = s
-            sig = sig.reshape((1,len(sig)))
+            print(sig.shape)
+            print(indok.shape)
+            sig = sig.reshape((1,s.shape[1]))
+            sig[0,indok] = s
         else:
             sig[:,indok] = s
 


### PR DESCRIPTION
Took out useless loop when using hybrid  algorithm in the `calc_signal` function 
In `geom/_core.py` fixed in-/output treatment of the signal.
None of the fails of unit tests are regarding the `calc_signal` function.

## Extra
Rename all variables `num_los` to `nlos` to be more homogeneous throughout the code. 