### PR TITLE
[nosetests] twitching nosetest config file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,13 +2,11 @@
 #   https://docs.python.org/2/distutils/configfile.html
 #   https://packaging.python.org/distributing/#manifest-in
 
-
 [nosetests]
-verbosity=1
+verbosity=2
 detailed-errors=1
+with-id=T
 with-coverage=1
 cover-package=nose
-debug=nose.loader
-pdb=1
-pdb-failures=1
-tests=tofu/tests/
+where=tofu/tests
+nologcapture=T


### PR DESCRIPTION
* no longer printing matplotlib debug logs
* updated to latest version of nosetest to have the ids of the tests (retrocompatible)
* took out debugger (probably not compatible with travis)