### PR TITLE
[Issue180] took out useless params of Ves_get_sampleS

### DIFF
--- a/tofu/geom/_comp.py
+++ b/tofu/geom/_comp.py
@@ -266,7 +266,7 @@ def _Ves_get_sampleV(VPoly, Min1, Max1, Min2, Max2, dV,
     return Pts, dV, ind, dVr
 
 
-def _Ves_get_sampleS(VPoly, Min1, Max1, Min2, Max2, dS,
+def _Ves_get_sampleS(VPoly, dS,
                      DS=None, dSMode='abs', ind=None, DIn=0., VIn=None,
                      VType='Tor', VLim=None, nVLim=None, Out='(X,Y,Z)',
                      margin=1.e-9, Multi=False, Ind=None):
@@ -284,8 +284,6 @@ def _Ves_get_sampleS(VPoly, Min1, Max1, Min2, Max2, dS,
     assert type(Multi) is bool, "Arg Multi must be a bool !"
 
     VLim = None if (VLim is None or nVLim==0) else np.array(VLim)
-    MinMax1 = np.array([Min1,Max1])
-    MinMax2 = np.array([Min2,Max2])
 
     # Check if Multi
     if nVLim>1:

--- a/tofu/geom/_core.py
+++ b/tofu/geom/_core.py
@@ -933,8 +933,7 @@ class Struct(utils.ToFuObject):
                        VLim=np.ascontiguousarray(self.Lim), nVLim=self.noccur,
                        Out=Out, margin=1.e-9,
                        Multi=self.dgeom['Multi'], Ind=Ind)
-        args = [self.Poly, self.dgeom['P1Min'][0], self.dgeom['P1Max'][0],
-                self.dgeom['P2Min'][1], self.dgeom['P2Max'][1], res]
+        args = [self.Poly, res]
         pts, dS, ind, reseff = _comp._Ves_get_sampleS(*args, **kwdargs)
         return pts, dS, ind, reseff
 


### PR DESCRIPTION
Fixes #180 

While solving PEP8 rules realized there were some useless variables called in `Ves_get_sampleS`.
Took them out both in function and call of function