### PR TITLE
Setup.py should not cythonize extensions except when building. #221

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -414,7 +414,7 @@ setup(
     #    ],
     # },
     ext_modules=extensions,
-    cmdclass={'build_ext': cth.Build.build_ext,
+    cmdclass={"build_ext": cth.Build.build_ext,
               "clean": CleanCommand},
     include_dirs=[np.get_include()],
 )

--- a/setup.py
+++ b/setup.py
@@ -297,8 +297,6 @@ extensions = [
     ),
 ]
 
-extensions = cythonize(extensions, annotate=True)
-
 
 setup(
     name="tofu",
@@ -416,6 +414,7 @@ setup(
     #    ],
     # },
     ext_modules=extensions,
-    cmdclass={"build_ext": build_ext, "clean": CleanCommand},
+    cmdclass={'build_ext': cth.Build.build_ext,
+              "clean": CleanCommand},
     include_dirs=[np.get_include()],
 )


### PR DESCRIPTION
Cython’s build_ext module runs cythonize as part of the build process:
https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#distributing-cython-modules