### PR TITLE
[Issue230] Remove travis build for python 2.7 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-- '2.7'
+# - '2.7' # stopped since tofu > 1.4.1
 - '3.6'
 #- '3.7-dev'
 

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.1-145-ge5ffef4'
+__version__ = '1.4.1-147-g93ae5c5'


### PR DESCRIPTION
Fixes, in devel, Issue #230 

Travis will not build against python 2.7 anymore