### PR TITLE
Bug was not there, but __repr__() now more robust in debug

### DIFF
--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -2699,7 +2699,14 @@ class MultiIDSLoader(object):
             u = np.array([oo[:,1,0]*np.cos(oo[:,1,2]),
                           oo[:,1,0]*np.sin(oo[:,1,2]), oo[:,1,1]])
             u = (u-D) / np.sqrt(np.sum((u-D)**2, axis=0))[None,:]
-            dgeom = (D,u)
+            dgeom = (D, u)
+            indnan = np.any(np.isnan(D), axis=0) | np.any(np.isnan(u), axis=0)
+            if np.any(indnan):
+                nunav, ntot = str(indnan.sum()), str(D.shape[1])
+                msg = "Some lines of sight geometry unavailable in ids:\n"
+                msg += "    - nb. of LOS unavailable: %s / %s\n"%(nunav, ntot)
+                msg += "    - indices: %s"%str(indnan.nonzero()[0])
+                warnings.warn(msg)
         else:
             dgeom = None
 
@@ -2934,6 +2941,7 @@ class MultiIDSLoader(object):
                                             Name=Name, Diag=ids, Exp=Exp,
                                             dchans=dchans)
                 cam.Id.set_dUSR( {'imas-nchMax': nchMax} )
+
 
         # -----------------------
         # data

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -2705,7 +2705,7 @@ class MultiIDSLoader(object):
                 nunav, ntot = str(indnan.sum()), str(D.shape[1])
                 msg = "Some lines of sight geometry unavailable in ids:\n"
                 msg += "    - unavailable LOS: {0} / {1}\n".format(nunav, ntot)
-                msg += "    - indices: {0}"%format(str(indnan.nonzero()[0]))
+                msg += "    - indices: {0}".format(str(indnan.nonzero()[0]))
                 warnings.warn(msg)
         else:
             dgeom = None

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -2704,8 +2704,8 @@ class MultiIDSLoader(object):
             if np.any(indnan):
                 nunav, ntot = str(indnan.sum()), str(D.shape[1])
                 msg = "Some lines of sight geometry unavailable in ids:\n"
-                msg += "    - nb. of LOS unavailable: %s / %s\n"%(nunav, ntot)
-                msg += "    - indices: %s"%str(indnan.nonzero()[0])
+                msg += "    - unavailable LOS: {0} / {1}\n".format(nunav, ntot)
+                msg += "    - indices: {0}"%format(str(indnan.nonzero()[0]))
                 warnings.warn(msg)
         else:
             dgeom = None

--- a/tofu/utils.py
+++ b/tofu/utils.py
@@ -1451,11 +1451,13 @@ class ToFuObjectBase(object):
         # pass
 
     def __repr__(self):
-        if hasattr(self, 'get_summary'):
-            return self.get_summary(return_='msg', verb=False)
-        else:
-            return object.__repr__(self)
-
+        try:
+            if hasattr(self, 'get_summary'):
+                return self.get_summary(return_='msg', verb=False)
+            else:
+                return object.__repr__(self)
+        except Exception:
+            return self.__class__.__name__
 
     #############################
     #  strip and to/from dict

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.1-189-g5ca9e73'
+__version__ = '1.4.1-190-gd25622d'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.1-177-g5b98902'
+__version__ = '1.4.1-188-g044d87f'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.1-188-g044d87f'
+__version__ = '1.4.1-189-g5ca9e73'


### PR DESCRIPTION
Erratum
---------
The bug in `Rays._complete_dX12()` (see Issue #241) was not a bug: it was the input that was inappropriate (the line of sight geometry was not available in IDS). 
=> No change to Rays class

More informative camera construction from IDS
-----------------------------------------------------
A warning has been added to camera construction from ids if some channels have nan in D or u

General Improvement
---------------
I noticed that the overloading of the parent class ToFuObjectBase.__repr__() method, though very useful when everything works fine, was a problem when in debug mode inside a class because the debugger wants to print the current variables, including **_self_**. But while debugging inside the class, **_self_** is not fully valid yet and the get_summary() medthod may not work, leading to the debugger bugging...

The parent method __repr__() is now more robust in debug mode: falls back to __class__.__name__ if the current instance is not valid.

Issues
-------

Fixes, in devel, Issue #241 
