### PR TITLE
[doc] added warning for mac and gcc compiler

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -50,6 +50,10 @@ Mac OS X
 
 See :ref:`installing-as-a-developer`.
 
+Additional *caveat*: if you are using a version of `gcc < 8` be sure to
+turn off all parallelizations since there is a `known bug with cython
+<https://github.com/ToFuProject/tofu/issues/183>`__.
+
 .. _installing-tofu-on-windows:
 
 Windows


### PR DESCRIPTION
In the documentation, in the installation section:
- added a warning: a ggc version of at least 8 should be used when compiling tofu for OpenMP reductions. See #183 