### PR TITLE
[Issue215] fixed

### DIFF
--- a/tofu/data/_comp.py
+++ b/tofu/data/_comp.py
@@ -621,34 +621,34 @@ def get_finterp_ani(plasma, idq2dR, idq2dPhi, idq2dZ,
                 for ii in range(0,ntall):
                     valR[ii,...]   = mplTriLinInterp(mpltri,
                                                      vq2dR[indtq[ii],:],
-                                                     trifinder=trifind)(r,z)
+                                                     trifinder=trifind)(r, z)
                     valPhi[ii,...] = mplTriLinInterp(mpltri,
                                                      vq2dPhi[indtq[ii],:],
-                                                     trifinder=trifind)(r,z)
+                                                     trifinder=trifind)(r, z)
                     valZ[ii,...]   = mplTriLinInterp(mpltri,
                                                      vq2dZ[indtq[ii],:],
-                                                     trifinder=trifind)(r,z)
+                                                     trifinder=trifind)(r, z)
                 t = tall
             else:
                 ntall, indt, indtu = plasma._get_indtu(t=t, tall=tall,
                                                        tbinall=tbinall)[1:4]
                 for ii in range(0,ntall):
                     ind = indt == indtu[ii]
-                    valR[ind, ...]   = mplTriLinInterp(mpltri,
-                                                       vq2dR[indtq[indtu[ii]], :],
-                                                       trifinder=trifind)(r,z)
+                    valR[ind, ...] = mplTriLinInterp(mpltri,
+                                                     vq2dR[indtq[indtu[ii]], :],
+                                                     trifinder=trifind)(r, z)
                     valPhi[ind, ...] = mplTriLinInterp(mpltri,
                                                        vq2dPhi[indtq[indtu[ii]], :],
-                                                       trifinder=trifind)(r,z)
-                    valZ[ind, ...]   = mplTriLinInterp(mpltri,
-                                                       vq2dZ[indtq[indtu[ii]], :],
-                                                       trifinder=trifind)(r,z)
+                                                       trifinder=trifind)(r, z)
+                    valZ[ind, ...] = mplTriLinInterp(mpltri,
+                                                     vq2dZ[indtq[indtu[ii]], :],
+                                                     trifinder=trifind)(r, z)
 
 
             if Type == 'sca':
-                val = valR*vR[None,:] + valPhi*vPhi[None,:] + valZ*vZ[None,:]
+                val = valR*vR[None, :] + valPhi*vPhi[None,:] + valZ*vZ[None, :]
             elif Type == 'abs(sca)':
-                val = np.abs(valR*vR[None,:] + valPhi*vPhi[None,:] + valZ*vZ[None,:])
+                val = np.abs(valR*vR[None, :] + valPhi*vPhi[None, :] + valZ*vZ[None, :])
 
             val[np.isnan(val)] = fill_value
             return val, t
@@ -679,28 +679,29 @@ def get_finterp_ani(plasma, idq2dR, idq2dPhi, idq2dZ,
             valZ = np.full(tuple(shapeval), fill_value)
 
             # Interpolate
-            indpts = trifind(r,z)
+            indpts = trifind(r, z)
             if t is None:
                 for ii in range(0,ntall):
-                    valR[ii,...]   = vq2dR[indtq[ii],indpts]
-                    valPhi[ii,...] = vq2dPhi[indtq[ii],indpts]
-                    valZ[ii,...]   = vq2dZ[indtq[ii],indpts]
+                    valR[ii, ...] = vq2dR[indtq[ii], indpts]
+                    valPhi[ii, ...] = vq2dPhi[indtq[ii], indpts]
+                    valZ[ii, ...] = vq2dZ[indtq[ii], indpts]
                 t = tall
             else:
                 ntall, indt, indtu = plasma._get_indtu(t=t, tall=tall,
                                                        tbinall=tbinall,
                                                        idref1d=idref1d,
                                                        idref2d=idref2d)[1:]
-                for ii in range(0,ntall):
+                for ii in range(0, ntall):
                     ind = indt == indtu[ii]
-                    valR[ind, ...]   = vq2dR[indtq[indtu[ii]], indpts]
+                    valR[ind, ...] = vq2dR[indtq[indtu[ii]], indpts]
                     valPhi[ind, ...] = vq2dPhi[indtq[indtu[ii]], indpts]
-                    valZ[ind, ...]   = vq2dZ[indtq[indtu[ii]], indpts]
+                    valZ[ind, ...] = vq2dZ[indtq[indtu[ii]], indpts]
 
             if Type == 'sca':
-                val = valR*vR[None,:] + valPhi*vPhi[None,:] + valZ*vZ[None,:]
+                val = valR*vR[None, :] + valPhi*vPhi[None, :] + valZ*vZ[None, :]
             elif Type == 'abs(sca)':
-                val = np.abs(valR*vR[None,:] + valPhi*vPhi[None,:] + valZ*vZ[None,:])
+                val = np.abs(valR*vR[None, :] + valPhi*vPhi[None, :]
+                             + valZ*vZ[None, :])
             val[np.isnan(val)] = fill_value
             return val, t
     return func

--- a/tofu/data/_comp.py
+++ b/tofu/data/_comp.py
@@ -634,15 +634,21 @@ def get_finterp_ani(plasma, idq2dR, idq2dPhi, idq2dZ,
                                                        tbinall=tbinall)[1:4]
                 for ii in range(0,ntall):
                     ind = indt == indtu[ii]
-                    valR[ind, ...] = mplTriLinInterp(mpltri,
-                                                     vq2dR[indtq[indtu[ii]], :],
-                                                     trifinder=trifind)(r, z)
-                    valPhi[ind, ...] = mplTriLinInterp(mpltri,
-                                                       vq2dPhi[indtq[indtu[ii]], :],
-                                                       trifinder=trifind)(r, z)
-                    valZ[ind, ...] = mplTriLinInterp(mpltri,
-                                                     vq2dZ[indtq[indtu[ii]], :],
-                                                     trifinder=trifind)(r, z)
+                    valR[ind, ...] = mplTriLinInterp(
+                        mpltri,
+                        vq2dR[indtq[indtu[ii]], :],
+                        trifinder=trifind
+                    )(r, z)
+                    valPhi[ind, ...] = mplTriLinInterp(
+                        mpltri,
+                        vq2dPhi[indtq[indtu[ii]], :],
+                        trifinder=trifind
+                    )(r, z)
+                    valZ[ind, ...] = mplTriLinInterp(
+                        mpltri,
+                        vq2dZ[indtq[indtu[ii]], :],
+                        trifinder=trifind
+                    )(r, z)
 
 
             if Type == 'sca':
@@ -698,7 +704,8 @@ def get_finterp_ani(plasma, idq2dR, idq2dPhi, idq2dZ,
                     valZ[ind, ...] = vq2dZ[indtq[indtu[ii]], indpts]
 
             if Type == 'sca':
-                val = valR*vR[None, :] + valPhi*vPhi[None, :] + valZ*vZ[None, :]
+                val = (valR*vR[None, :] + valPhi*vPhi[None, :]
+                       + valZ*vZ[None, :])
             elif Type == 'abs(sca)':
                 val = np.abs(valR*vR[None, :] + valPhi*vPhi[None, :]
                              + valZ*vZ[None, :])

--- a/tofu/data/_comp.py
+++ b/tofu/data/_comp.py
@@ -652,7 +652,8 @@ def get_finterp_ani(plasma, idq2dR, idq2dPhi, idq2dZ,
 
 
             if Type == 'sca':
-                val = valR*vR[None, :] + valPhi*vPhi[None, :] + valZ*vZ[None, :]
+                val = (valR*vR[None, :] + valPhi*vPhi[None, :]
+                       + valZ*vZ[None, :])
             elif Type == 'abs(sca)':
                 val = np.abs(valR*vR[None, :] + valPhi*vPhi[None, :]
                              + valZ*vZ[None, :])

--- a/tofu/data/_comp.py
+++ b/tofu/data/_comp.py
@@ -652,9 +652,10 @@ def get_finterp_ani(plasma, idq2dR, idq2dPhi, idq2dZ,
 
 
             if Type == 'sca':
-                val = valR*vR[None, :] + valPhi*vPhi[None,:] + valZ*vZ[None, :]
+                val = valR*vR[None, :] + valPhi*vPhi[None, :] + valZ*vZ[None, :]
             elif Type == 'abs(sca)':
-                val = np.abs(valR*vR[None, :] + valPhi*vPhi[None, :] + valZ*vZ[None, :])
+                val = np.abs(valR*vR[None, :] + valPhi*vPhi[None, :]
+                             + valZ*vZ[None, :])
 
             val[np.isnan(val)] = fill_value
             return val, t

--- a/tofu/data/_comp.py
+++ b/tofu/data/_comp.py
@@ -426,9 +426,11 @@ def get_finterp_isotropic(plasma, idquant, idref1d, idref2d,
                                                            idref2d=idref2d)[1:-2]
                     for ii in range(0, ntall):
                         ind = indt == indtu[ii]
-                        val[ind, ...] = mplTriLinInterp(mpltri,
-                                                        vquant[indtq[indtu[ii]], :],
-                                                        trifinder=trifind)(r,z).filled(fill_value)
+                        val[ind, ...] = mplTriLinInterp(
+                            mpltri,
+                            vquant[indtq[indtu[ii]], :],
+                            trifinder=trifind
+                        )(r, z).filled(fill_value)
                 return val, t
 
         # --------------------
@@ -458,7 +460,8 @@ def get_finterp_isotropic(plasma, idquant, idref1d, idref2d,
                                                            idref2d=idref2d)[1:-2]
                     for ii in range(0, ntall):
                         ind = indt == indtu[ii]
-                        val[ind, indok] = vquant[indtq[indtu[ii]], indpts[indok]]
+                        val[ind, indok] = vquant[indtq[indtu[ii]],
+                                                 indpts[indok]]
                 return val, t
 
 
@@ -492,11 +495,13 @@ def get_finterp_isotropic(plasma, idquant, idref1d, idref2d,
 
                         # interpolate 1d
                         # This is reasonable (~0.15 s)
-                        val[ii,...] = scpinterp.interp1d(vr1[indtr1[ii],:],
-                                                         vquant[indtq[ii],:],
-                                                         kind='linear',
-                                                         bounds_error=False,
-                                                         fill_value=fill_value)(np.asarray(vii))
+                        val[ii, ...] = scpinterp.interp1d(
+                            vr1[indtr1[ii], :],
+                            vquant[indtq[ii], :],
+                            kind='linear',
+                            bounds_error=False,
+                            fill_value=fill_value
+                        )(np.asarray(vii))
                     t = tall
                 else:
                     out = plasma._get_indtu(t=t, tall=tall, tbinall=tbinall,
@@ -511,11 +516,13 @@ def get_finterp_isotropic(plasma, idquant, idref1d, idref2d,
 
                         # interpolate 1d
                         ind = indt == indtu[ii]
-                        val[ind, ...] = scpinterp.interp1d(vr1[indtr1[indtu[ii]], :],
-                                                           vquant[indtq[indtu[ii]], :],
-                                                           kind='linear',
-                                                           bounds_error=False,
-                                                           fill_value=fill_value)(np.asarray(vii))
+                        val[ind, ...] = scpinterp.interp1d(
+                            vr1[indtr1[indtu[ii]], :],
+                            vquant[indtq[indtu[ii]], :],
+                            kind='linear',
+                            bounds_error=False,
+                            fill_value=fill_value
+                        )(np.asarray(vii))
                 val[np.isnan(val)] = fill_value
 
                 return val, t
@@ -535,15 +542,16 @@ def get_finterp_isotropic(plasma, idquant, idref1d, idref2d,
                 val = np.full(tuple(shapeval), fill_value)
                 indpts = trifind(r,z)
                 indok = indpts > -1
-                finterp = scpinterp.interp1d
                 if t is None:
                     for ii in range(0,ntall):
                         # interpolate 1d
-                        val[ii,indok] = finterp(vr1[indtr1[ii],:],
-                                                vquant[indtq[ii],:],
-                                                kind='linear',
-                                                bounds_error=False,
-                                                fill_value=fill_value)(vr2[indtr2[ii], indpts[indok]])
+                        val[ii, indok] = scpinterp.interp1d(
+                            vr1[indtr1[ii], :],
+                            vquant[indtq[ii], :],
+                            kind='linear',
+                            bounds_error=False,
+                            fill_value=fill_value
+                        )(vr2[indtr2[ii], indpts[indok]])
                     t = tall
                 else:
                     out = plasma._get_indtu(t=t, tall=tall, tbinall=tbinall,
@@ -553,11 +561,13 @@ def get_finterp_isotropic(plasma, idquant, idref1d, idref2d,
                     for ii in range(0,ntall):
                         # interpolate 1d
                         ind = indt == indtu[ii]
-                        val[ind, indok] = finterp(vr1[indtr1[indtu[ii]], :],
-                                                  vquant[indtq[indtu[ii]], :],
-                                                  kind='linear',
-                                                  bounds_error=False,
-                                                  fill_value=fill_value)(vr2[indtr2[ii], indpts[indok]])
+                        val[ind, indok] = scpinterp.interp1d(
+                            vr1[indtr1[indtu[ii]], :],
+                            vquant[indtq[indtu[ii]], :],
+                            kind='linear',
+                            bounds_error=False,
+                            fill_value=fill_value
+                        )(vr2[indtr2[ii], indpts[indok]])
                 return val, t
     return func
 

--- a/tofu/data/_comp.py
+++ b/tofu/data/_comp.py
@@ -424,11 +424,11 @@ def get_finterp_isotropic(plasma, idquant, idref1d, idref2d,
                                                            tbinall=tbinall,
                                                            idref1d=idref1d,
                                                            idref2d=idref2d)[1:-2]
-                    for ii in range(0,ntall):
+                    for ii in range(0, ntall):
                         ind = indt == indtu[ii]
-                        val[ind,...] = mplTriLinInterp(mpltri,
-                                                       vquant[indtq[ii],:],
-                                                       trifinder=trifind)(r,z).filled(fill_value)
+                        val[ind, ...] = mplTriLinInterp(mpltri,
+                                                        vquant[indtq[indtu[ii]], :],
+                                                        trifinder=trifind)(r,z).filled(fill_value)
                 return val, t
 
         # --------------------
@@ -456,9 +456,9 @@ def get_finterp_isotropic(plasma, idquant, idref1d, idref2d,
                                                            tbinall=tbinall,
                                                            idref1d=idref1d,
                                                            idref2d=idref2d)[1:-2]
-                    for ii in range(0,ntall):
+                    for ii in range(0, ntall):
                         ind = indt == indtu[ii]
-                        val[ind,indok] = vquant[indtq[ii],indpts[indok]]
+                        val[ind, indok] = vquant[indtq[indtu[ii]], indpts[indok]]
                 return val, t
 
 
@@ -503,19 +503,19 @@ def get_finterp_isotropic(plasma, idquant, idref1d, idref2d,
                                             idref1d=idref1d, idref2d=idref2d,
                                             indtr1=indtr1, indtr2=indtr2)[1:]
                     ntall, indt, indtu, indtr1, indtr2 = out
-                    for ii in range(0,ntall):
+                    for ii in range(0, ntall):
                         # get ref values for mapping
                         vii = mplTriLinInterp(mpltri,
-                                              vr2[indtr2[ii],:],
-                                              trifinder=trifind)(r,z)
+                                              vr2[indtr2[ii], :],
+                                              trifinder=trifind)(r, z)
 
                         # interpolate 1d
                         ind = indt == indtu[ii]
-                        val[ind,...] = scpinterp.interp1d(vr1[indtr1[ii],:],
-                                                          vquant[indtq[ii],:],
-                                                          kind='linear',
-                                                          bounds_error=False,
-                                                          fill_value=fill_value)(np.asarray(vii))
+                        val[ind, ...] = scpinterp.interp1d(vr1[indtr1[indtu[ii]], :],
+                                                           vquant[indtq[indtu[ii]], :],
+                                                           kind='linear',
+                                                           bounds_error=False,
+                                                           fill_value=fill_value)(np.asarray(vii))
                 val[np.isnan(val)] = fill_value
 
                 return val, t
@@ -535,14 +535,15 @@ def get_finterp_isotropic(plasma, idquant, idref1d, idref2d,
                 val = np.full(tuple(shapeval), fill_value)
                 indpts = trifind(r,z)
                 indok = indpts > -1
+                finterp = scpinterp.interp1d
                 if t is None:
                     for ii in range(0,ntall):
                         # interpolate 1d
-                        val[ii,indok] = scpinterp.interp1d(vr1[indtr1[ii],:],
-                                                           vquant[indtq[ii],:],
-                                                           kind='linear',
-                                                           bounds_error=False,
-                                                           fill_value=fill_value)(vr2[indtr2[ii],indpts[indok]])
+                        val[ii,indok] = finterp(vr1[indtr1[ii],:],
+                                                vquant[indtq[ii],:],
+                                                kind='linear',
+                                                bounds_error=False,
+                                                fill_value=fill_value)(vr2[indtr2[ii], indpts[indok]])
                     t = tall
                 else:
                     out = plasma._get_indtu(t=t, tall=tall, tbinall=tbinall,
@@ -552,11 +553,11 @@ def get_finterp_isotropic(plasma, idquant, idref1d, idref2d,
                     for ii in range(0,ntall):
                         # interpolate 1d
                         ind = indt == indtu[ii]
-                        val[ind,indok] = scpinterp.interp1d(vr1[indtr1[ii],:],
-                                                            vquant[indtq[ii],:],
-                                                            kind='linear',
-                                                            bounds_error=False,
-                                                            fill_value=fill_value)(vr2[indtr2[ii],indpts[indok]])
+                        val[ind, indok] = finterp(vr1[indtr1[indtu[ii]], :],
+                                                  vquant[indtq[indtu[ii]], :],
+                                                  kind='linear',
+                                                  bounds_error=False,
+                                                  fill_value=fill_value)(vr2[indtr2[ii], indpts[indok]])
                 return val, t
     return func
 
@@ -623,15 +624,15 @@ def get_finterp_ani(plasma, idq2dR, idq2dPhi, idq2dZ,
                                                        tbinall=tbinall)[1:4]
                 for ii in range(0,ntall):
                     ind = indt == indtu[ii]
-                    valR[ind,...]   = mplTriLinInterp(mpltri,
-                                                      vq2dR[indtq[ii],:],
-                                                      trifinder=trifind)(r,z)
-                    valPhi[ind,...] = mplTriLinInterp(mpltri,
-                                                      vq2dPhi[indtq[ii],:],
-                                                      trifinder=trifind)(r,z)
-                    valZ[ind,...]   = mplTriLinInterp(mpltri,
-                                                      vq2dZ[indtq[ii],:],
-                                                      trifinder=trifind)(r,z)
+                    valR[ind, ...]   = mplTriLinInterp(mpltri,
+                                                       vq2dR[indtq[indtu[ii]], :],
+                                                       trifinder=trifind)(r,z)
+                    valPhi[ind, ...] = mplTriLinInterp(mpltri,
+                                                       vq2dPhi[indtq[indtu[ii]], :],
+                                                       trifinder=trifind)(r,z)
+                    valZ[ind, ...]   = mplTriLinInterp(mpltri,
+                                                       vq2dZ[indtq[indtu[ii]], :],
+                                                       trifinder=trifind)(r,z)
 
 
             if Type == 'sca':
@@ -682,9 +683,9 @@ def get_finterp_ani(plasma, idq2dR, idq2dPhi, idq2dZ,
                                                        idref2d=idref2d)[1:]
                 for ii in range(0,ntall):
                     ind = indt == indtu[ii]
-                    valR[ind,...]   = vq2dR[indtq[ii],indpts]
-                    valPhi[ind,...] = vq2dPhi[indtq[ii],indpts]
-                    valZ[ind,...]   = vq2dZ[indtq[ii],indpts]
+                    valR[ind, ...]   = vq2dR[indtq[indtu[ii]], indpts]
+                    valPhi[ind, ...] = vq2dPhi[indtq[indtu[ii]], indpts]
+                    valZ[ind, ...]   = vq2dZ[indtq[indtu[ii]], indpts]
 
             if Type == 'sca':
                 val = valR*vR[None,:] + valPhi*vPhi[None,:] + valZ*vZ[None,:]

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2-alpha2-13-g7db6643'
+__version__ = '1.4.2-alpha2-19-gccaeae2'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2-alpha2-19-gccaeae2'
+__version__ = '1.4.2-alpha2-20-gb97c0f0'


### PR DESCRIPTION
Main changes:
----------------
Fixed interpolation bug, original quantity was called with wrong time index, fixed in all versions of interpolating function

Minimal working example (requires imas2tofu):
----------------------------------------------------
In [1]: import tofu as tf
   ...: shot = 54719
   ...: multi = tf.imas2tofu.MultiIDSLoader(shot=shot, \
   ...:           ids=['wall', 'pulse_schedule', 'soft_x_rays', 'equilibrium'])
   ...: sxr_data = multi.to_Data('soft_x_rays', plot=False)
   ...: sxr_cam = sxr_data.lCam[0]
   ...: sxr_cam.set_dsino([2.4, 0])
   ...: sxr_pts = sxr_cam.dsino['pts']
   ...: sxr_plasma = multi.to_Plasma2D()
   ...: rhopn_all = sxr_plasma.interp_pts2profile(sxr_pts, quant='equilibrium.2drhopn')
   ...: rhopn = sxr_plasma.interp_pts2profile(sxr_pts, quant='equilibrium.2drhopn', t=np.r_[rhopn_all[1][10]])
In [2]: np.allclose(rhopn[0], rhopn_all[0])
Out[2]: True

Issues fixed:
-------------
Fixes, in devel, issue #215 
