### PR TITLE
[quick fix] took out wheel deployment and add skip if already in pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,9 @@ deploy:
     skip_cleanup: true
   - provider: pypi
     user: "Didou09"
-    distributions: "sdist bdist_wheel"
+    distributions: "sdist"
     skip_cleanup: true
+    skip_existing: true
     on:
       tags: true
       all_branches: true


### PR DESCRIPTION
Changes in travis.yml:
- took out wheel deployment since it's failing on travis
- skipping uploading deployment if the package was already uploaded (by another build)