### PR TITLE
Faster los calc signal sum calls for newcalc=False

### DIFF
--- a/tofu/data/_comp.py
+++ b/tofu/data/_comp.py
@@ -413,6 +413,7 @@ def get_finterp_isotropic(plasma, idquant, idref1d, idref2d,
                 shapeval = list(pts.shape)
                 shapeval[0] = ntall if t is None else t.size
                 val = np.full(tuple(shapeval), fill_value)
+
                 if t is None:
                     for ii in range(0,ntall):
                         val[ii,...] = mplTriLinInterp(mpltri,

--- a/tofu/data/_core.py
+++ b/tofu/data/_core.py
@@ -3677,11 +3677,15 @@ class Plasma2D(utils.ToFuObject):
         # Get indt (t with respect to tbinall)
         indt, indtu = None, None
         if t is not None:
-            indt = np.digitize(t, tbinall)
-            indtu = np.unique(indt)
+            if len(t) == len(tall) and np.allclose(t, tall):
+                indt = np.arange(0, tall.size)
+                indtu = indt
+            else:
+                indt = np.digitize(t, tbinall)
+                indtu = np.unique(indt)
+                # Update
+                tall = tall[indtu]
 
-            # Update
-            tall = tall[indtu]
             if idref1d is not None:
                 assert indtr1 is not None
                 indtr1 = indtr1[indtu]

--- a/tofu/geom/_core.py
+++ b/tofu/geom/_core.py
@@ -6180,7 +6180,8 @@ class Rays(utils.ToFuObject):
             #    and interferometer)
             val = func(pts, t=t, vect=vect)
             # Integrate
-            sig = np.add.reduceat(val, np.r_[0, indpts], axis=-1)*reseff[None, :]
+            sig = np.add.reduceat(val, np.r_[0, indpts],
+                                  axis=-1)*reseff[None, :]
 
         # Format output
         return self._calc_signal_postformat(
@@ -6381,7 +6382,8 @@ class Rays(utils.ToFuObject):
 
             # Integrate using ufunc reduceat for speed
             # (cf. https://stackoverflow.com/questions/59079141)
-            sig = np.add.reduceat(val, np.r_[0, indpts], axis=-1)*reseff[None, :]
+            sig = np.add.reduceat(val, np.r_[0, indpts],
+                                  axis=-1)*reseff[None, :]
 
         # Format output
         # this is the secod slowest step (~0.75 s)

--- a/tofu/tests/tests01_geom/tests03_core.py
+++ b/tofu/tests/tests01_geom/tests03_core.py
@@ -874,7 +874,7 @@ class Test03_Rays(object):
                                               resMode=rm,
                                               method=dm, minimize=mmz,
                                               ind=ind,
-                                              plot=False, out=np.ndarray,
+                                              plot=False, returnas=np.ndarray,
                                               fs=(12, 6), connect=connect)
                         sig, units = out
                         assert not np.all(np.isnan(sig)), str(ii)

--- a/tofu/tests/tests02_data/tests03_core.py
+++ b/tofu/tests/tests02_data/tests03_core.py
@@ -475,7 +475,7 @@ class Test02_DataCam12DSpectral(Test01_DataCam12D):
         lData = [None for ii in range(0,len(lc))]
         for ii in range(0,len(lc)):
             sig = lc[ii].calc_signal(emiss, t=t, res=0.01, method=lm[ii],
-                                     plot=False, out=np.ndarray)[0]
+                                     plot=False, returnas=np.ndarray)[0]
             sig = sig[:,:,None]*flamb[None,None,:]
             cla = eval('tfd.DataCam%sDSpectral'%('2' if lc[ii]._is2D() else '1'))
             data = cla(data=sig, Name='All', Diag='Test',


### PR DESCRIPTION
Motivations:
--------------
In the case where newcalc is False, we use a for loop over the LOS to compute the sum (integral).
I wanted to know whether there might be more efficient function available in numpy.
I asked the question on Stackoverflow.

It exists, and here it is:   np.add.reduceat()

Ref:
https://stackoverflow.com/questions/59079141/perform-numpy-sum-or-scipy-integrate-simps-on-large-splitted-array-efficient/59085492#59085492

This PR is interesting because the algorithm used when newcalc=False is very similar to the one used when (newcalc=True, method='sum', minimize='calls').
So acceleration in one case may be useful in the other.

Main changes:
----------------
* Replaced the for loop in Rays.calc_signal(newcalc=False) and Rays.calc_signal_from_Plasma2D(newcalc=False) by np.add.reduceat()
* While testing, a bug appeared in Plasma2D._get_indtu(), when t has only one time step. Fixed.

Benefits:
---------
A small benchmark on ITER (git + python setup.py build_ext) yielded (on a case with 250,000 LOS but only res=0.1):

```
In [1]: import tofu as tf
m/home/ITER/vezined/ToFu_All/tofu/tofu/__init__.py:95: UserWarning: 
The following subpackages are not available:
    - tofu.mag
  => see tofu.dsub[<subpackage>] for details.
  warnings.warn(msg)

In [2]: multi = tf.imas2tofu.MultiIDSLoader(user='hoeneno', tokamak='convert', shot=134000, run=29, ids=['edge_sources'])
Getting ids   [occ]  tokamak  user     version  shot    run  refshot  refrun
------------  -----  -------  -------  -------  ------  ---  -------  ------
edge_sources  [0]    convert  hoeneno  3        134000  29   -1       -1    

In [3]: _dshort = {'core_sources': {'1drhotn':'source[identifier.name=radiation].profiles_1d[time].grid.rho_tor_norm',
   ...:    ...:                             '1deEnergy':'source[identifier.name=radiation].profiles_1d[time].electrons.energy'
   ...:    ...:                             },
   ...:    ...:            'equilibrium': {'2dpsi': 'time_slice[time].profiles_2d[0].psi',
   ...:    ...:                            '2dmeshR': 'time_slice[time].profiles_2d[0].r',
   ...:    ...:                            '2dmeshZ': 'time_slice[time].profiles_2d[0].z'}}
   ...:                            

In [4]: multi.set_shortcuts(dshort=_dshort)

In [5]: plasma = multi.to_Plasma2D()

In [6]: cam = tf.load('/home/ITER/munechk/public/MyTofu/output/ITER_test_camera_config.npz')
sLoaded from:
    /home/ITER/munechk/public/MyTofu/output/ITER_test_camera_config.npz

In [7]: sig_oldbasic, units = cam.calc_signal_from_Plasma2D(plasma, quant='edge_sources.2dradiation', plot=False, res=0.1, newcalc=False, ufunc=False)

In [8]: sig_oldufunc, units = cam.calc_signal_from_Plasma2D(plasma, quant='edge_sources.2dradiation', plot=False, res=0.1, newcalc=False, ufunc=True, fill_value=0.)

In [9]: sig_newbasic, units = cam.calc_signal_from_Plasma2D(plasma, quant='edge_sources.2dradiation', plot=False, res=0.1, newcalc=True, method='sum', minimize='calls', ufunc=False)

In [10]: np.allclose(sig_oldbasic.data, sig_oldufunc.data)
Out[10]: True

In [11]: np.allclose(sig_newbasic.data, sig_oldufunc.data)
Out[11]: True

In [12]: %timeit sig_oldbasic, units = cam.calc_signal_from_Plasma2D(plasma, quant='edge_sources.2dradiation', plot=False, res=0.1, newcalc=False, ufunc=False)
11.8 s ± 90.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [13]: %timeit sig_oldufunc, units = cam.calc_signal_from_Plasma2D(plasma, quant='edge_sources.2dradiation', plot=False, res=0.1, newcalc=False, ufunc=True, fill_value=0.)
8.77 s ± 19.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [14]: %timeit sig_newbasic, units = cam.calc_signal_from_Plasma2D(plasma, quant='edge_sources.2dradiation', plot=False, res=0.1, newcalc=True, method='sum', minimize='calls', ufunc=False)
9.94 s ± 19.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Notice the 25% speed gain when newcalc=False.

The comparison with newcalc=True and a look at the code shows that in _GG.pyx, in the case (method='sum', minimize='calls'), the summing operation (l. 2991-2997) is done is a loop which is not parallelized, we could either:
* Parallelize this loop ?
* Quick hotfix : use the same function np.add.reduceat() to suppress the loop ?

What do you think @lasofivec ?

P.S.: keep in mind that currently, running tofu on the ITER clusters in ipython does not make use of the parallelization (cf. issue #307 ), which explains why in the above benchmark newcalc=True is not faster than newcalc=True, since it runs on only one CPU