### PR TITLE
Issue310 more robust warning for out of vessel los

### DIFF
--- a/tofu/geom/_core.py
+++ b/tofu/geom/_core.py
@@ -4461,19 +4461,24 @@ class Rays(utils.ToFuObject):
             msg += repr(ind.nonzero()[0])
             warnings.warn(msg)
             if plotdebug:
-                PIn = self.D[:, ind] + kIn[None, ind] * self.u[:, ind]
-                POut = self.D[:, ind] + kOut[None, ind] * self.u[:, ind]
-                # To be updated
-                _plot._LOS_calc_InOutPolProj_Debug(
-                    self.config,
-                    self.D[:, ind],
-                    self.u[:, ind],
-                    PIn,
-                    POut,
-                    nptstot=kOut.size,
-                    Lim=[np.pi / 4.0, 2.0 * np.pi / 4],
-                    Nstep=50,
-                )
+                try:
+                    PIn = self.D[:, ind] + kIn[None, ind] * self.u[:, ind]
+                    POut = self.D[:, ind] + kOut[None, ind] * self.u[:, ind]
+                    # To be updated
+                    _plot._LOS_calc_InOutPolProj_Debug(
+                        self.config,
+                        self.D[:, ind],
+                        self.u[:, ind],
+                        PIn,
+                        POut,
+                        nptstot=kOut.size,
+                        Lim=[np.pi / 4.0, 2.0 * np.pi / 4],
+                        Nstep=50,
+                    )
+                except Exception as err:
+                    msg = ("The 3D debugging plot could not be displayed\n"
+                           + str(err))
+                    warnings.warn(msg)
 
         # Handle particular cases with kIn > kOut
         ind = np.zeros(kIn.shape, dtype=bool)

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2-a5'
+__version__ = '1.4.2-a5-6-g2d9b183'


### PR DESCRIPTION
Main changes:
----------------
* Try / except introduced in tf.geom.Rays._compute_dgeom() in case where some LOS have no visibility inside vessel to make sure an error during the plotting process does not stop computation
* Exception is still caught and displayed as warning

Issues:
-------
* Fixes, in devel, issue #310 