### PR TITLE
Quick fix: wrong path in update version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,7 @@ def get_version_tofu(path=_HERE):
                 .decode()
             )
             if git_branch in ["master"]:
-                version_tofu = updateversion(os.path.join(path, "tofu"))
+                version_tofu = updateversion()
             else:
                 isgit = False
         except Exception:


### PR DESCRIPTION
the path to the file version had twice the directory "tofu" appended:

Once here (**in** the function)
https://github.com/ToFuProject/tofu/blob/c25c76c95682f4cf57c71cf72ff987c9b37cc224/setup.py#L154

A second time here (at **call** time):
https://github.com/ToFuProject/tofu/blob/0bfdf2b272210945353004dadf3b6ee0b69ad6eb/setup.py#L189

so it was working for the ``version.py`` file in `$TOFU_DIR/tofu/tofu/`