### PR TITLE
Issue318 add synth diag ids

### DIFF
--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -614,7 +614,7 @@ class MultiIDSLoader(object):
                  'core_profiles':['t','Te','ne']}
                }
 
-
+    _IDS_BASE = ['wall', 'pulse_schedule']
 
 
     ###################################
@@ -625,7 +625,8 @@ class MultiIDSLoader(object):
 
     def __init__(self, preset=None, dids=None, ids=None, occ=None, idd=None,
                  shot=None, run=None, refshot=None, refrun=None,
-                 user=None, tokamak=None, version=None, get=None, ref=True):
+                 user=None, tokamak=None, version=None,
+                 ids_base=None, synthdiag=None, get=None, ref=True):
         super(MultiIDSLoader, self).__init__()
 
         # Initialize dicts
@@ -642,6 +643,14 @@ class MultiIDSLoader(object):
             self.add_ids(preset=preset, ids=ids, occ=occ, idd=idd, get=False)
             if get is None and (ids is not None or preset is not None):
                 get = True
+            if ids_base is None:
+                ids_base = True
+            if ids_base is True:
+                self.add_ids_base(get=False)
+            if synthdiag is None:
+                synthdiag = False
+            if synthdiag is True:
+                self.add_ids_synthdiag(get=False)
         else:
             self.set_dids(dids)
             if get is None:
@@ -1483,6 +1492,20 @@ class MultiIDSLoader(object):
             self._dids.update(dids)
             if get:
                 self.open_get_close()
+
+    def add_ids_base(self, occ=None, idd=None,
+                     shot=None, run=None, refshot=None, refrun=None,
+                     user=None, tokamak=None, version=None,
+                     ref=None, isget=None, get=None):
+        """ Add th list of ids stored in self._IDS_BASE
+
+        Typically used to add a list of common ids without having to re-type
+        them every time
+        """
+        self.add_ids(ids=self._IDS_BASE, occ=occ, idd=idd,
+                     shot=shot, run=run, refshot=refshot, refrun=refrun,
+                     user=user, tokamak=tokamak, version=version,
+                     ref=ref, isget=isget, get=get)
 
     def add_ids_for_synthdiag(self, ids=None, occ=None, idd=None,
                               shot=None, run=None, refshot=None, refrun=None,

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -1268,6 +1268,52 @@ class MultiIDSLoader(object):
         assert idd in self._didd.keys()
         return self._didd[idd]['idd']
 
+    def get_inputs_for_synthsignal(self, ids=None, verb=True, returnas=False):
+        """ Return and / or print a dict of the default inputs for desired ids
+
+        Synthetic signal for a given diagnostic ids is computed from
+        signal that comes from other ids (e.g. core_profiles, equilibrium...)
+        For some diagnostics, the inputs required are already tabulated in
+        self._didsdiag[<ids>]['synth']
+
+        This method simply shows this already tabulated information
+        Advanced users may edit this hidden dictionnary to their needs
+
+        """
+
+        if ids is None:
+            if len(self._dids) == 1:
+                ids = list(self._dids.keys())[0]
+            else:
+                msg = "Please provide a valid ids!"
+                raise Exception(msg)
+
+        # Eliminate trivial case
+        if (ids not in self._didsdiag.keys() or 'synth' not in
+            self._didsdiag[ids].keys()):
+            msg = ("Necessary inputs for synthetic signal not tabulated for:\n"
+                   + "\t- {}".format(str(ids)))
+            if verb:
+                print(msg)
+            if returnas is True:
+                return msg
+
+        # Deal with real case
+        out = self._didsdiag[ids]['synth']
+        lids = sorted(out.get('dsig', {}).keys())
+        if verb:
+            dmsg = ("\n\t-" +
+                    "\n\t-".join([kk+':\n\t\t'+'\n\t\t'.join(vv)
+                                  for kk, vv in out.get('dsig', {}).items()]))
+            extra = {kk: vv for kk, vv in out.items()
+                     if kk not in ['dsynth', 'dsig']}
+            msg = ("For computing synthetic signal for ids {}".format(ids)
+                   + dmsg + '\n'
+                   + "\t- Extra parametersi (if any):\n"
+                   + "\t\t{}\n".format(extra))
+            print(msg)
+        if returnas is True:
+            return out
 
     def _checkformat_ids(self, ids, occ=None, idd=None, isget=None):
 
@@ -1323,7 +1369,6 @@ class MultiIDSLoader(object):
             if dids[lids[ii]]['ids'] is not None:
                 dids[lids[ii]]['ids'] = [dids[lids[ii]]['ids']]*nocc
 
-
         # Format isget / get
         for ii in range(0,nids):
             nocc = dids[lids[ii]]['nocc']
@@ -1346,8 +1391,6 @@ class MultiIDSLoader(object):
             dids[lids[ii]]['isget'] = isgeti
 
         return dids
-
-
 
     def add_ids(self, ids=None, occ=None, idd=None, preset=None,
                 shot=None, run=None, refshot=None, refrun=None,
@@ -1395,13 +1438,34 @@ class MultiIDSLoader(object):
             assert idd in self._didd.keys()
 
         # Add ids
-
         if ids is not None:
             dids = self._checkformat_ids(ids, occ=occ, idd=idd, isget=isget)
 
             self._dids.update(dids)
             if get:
                 self.open_get_close(ids=ids)
+
+    def add_ids_for_synthdiag(self, ids=None, occ=None, idd=None, preset=None,
+                              shot=None, run=None, refshot=None, refrun=None,
+                              user=None, tokamak=None, version=None,
+                              ref=None, isget=None, get=None):
+        """ Add pre-tabulated input ids necessary for calculating synth. signal
+
+        The necessary input ids are given by self.get_inputs_for_synthsignal()
+
+        """
+        lc = [ids is None, isinstance(ids, str), isinstance(ids, list)]
+        assert any(lc)
+        lidssynth = [kk for kk, vv in self._didsdiag.items()
+                     if 'synth' in vv.keys()]
+
+        if lc[0]:
+            ids = list(set(self._dids.keys()).)
+        elif lc[1]:
+            ids = [ids]
+        lids = []
+        for idsi in ids:
+            pass
 
 
     def remove_ids(self, ids=None, occ=None):

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -1330,8 +1330,9 @@ class MultiIDSLoader(object):
             lids = sorted(out.get('dsig', {}).keys())
             if verb:
                 dmsg = ("\n\t-" +
-                        "\n\t-".join([kk+':\n\t\t'+'\n\t\t'.join(vv)
-                                      for kk, vv in out.get('dsig', {}).items()]))
+                        "\n\t-".join([
+                            kk+':\n\t\t'+'\n\t\t'.join(vv)
+                            for kk, vv in out.get('dsig', {}).items()]))
                 extra = {kk: vv for kk, vv in out.items()
                          if kk not in ['dsynth', 'dsig']}
                 msg = ("For computing synthetic signal for ids {}".format(ids)
@@ -1340,7 +1341,7 @@ class MultiIDSLoader(object):
                        + "\t\t{}\n".format(extra))
                 print(msg)
             if returnas is True:
-                returnas  = dict
+                returnas = dict
         else:
             out = None
             lids = sorted(set(itt.chain.from_iterable([
@@ -1653,8 +1654,8 @@ class MultiIDSLoader(object):
         msg = ("Arg ids must be either:\n"
                + "\t- None: if self.dids only has one key\n"
                + "\t- str: a valid key of self.dids\n\n"
-               + "  Provided : %s\n"%ids
-               + "  Available: %s\n"%str(list(self._dids.keys()))
+               + "  Provided : {}\n".format(ids)
+               + "  Available: {}\n".format(str(list(self._dids.keys())))
                + "  => Consider using self.add_ids({})".format(str(ids)))
 
         lc = [ids is None, type(ids) is str]
@@ -2094,7 +2095,6 @@ class MultiIDSLoader(object):
             warnings.warn(msg)
         return dout
 
-
     def get_events(self, occ=None, verb=True, returnas=False):
         """ Return chronoligical events stored in pulse_schedule
 
@@ -2113,7 +2113,8 @@ class MultiIDSLoader(object):
         assert isinstance(verb, bool)
         assert returnas in [False, list, tuple]
 
-        events = self.get_data('pulse_schedule', sig='events', occ=occ)['events']
+        events = self.get_data('pulse_schedule',
+                               sig='events', occ=occ)['events']
         name, time = zip(*events)
         ind = np.argsort(time)
         if verb:

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2-a5-14-gde4bc67'
+__version__ = '1.4.2-a5-15-g231dacd'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2-a5-11-g2af533b'
+__version__ = '1.4.2-a5-12-g1874b91'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2-a5'
+__version__ = '1.4.2-a5-10-ge0d44f3'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2-a5-13-gbbc8b8e'
+__version__ = '1.4.2-a5-14-gde4bc67'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2-a5-12-g1874b91'
+__version__ = '1.4.2-a5-13-gbbc8b8e'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2-a5-10-ge0d44f3'
+__version__ = '1.4.2-a5-11-g2af533b'


### PR DESCRIPTION
Motivations:
--------------
* For non-experienced users, the imas interface class MultiIDSLoader shall provide an easy way to:
     - load diagnostics geometries
     - load experimental diagnostic data
     - load all ids necessary to compute synthetic signal for a given diagnostic
* The current status allowed to do that in ~5-6 lines, provided the user knows where to get the info
* This need being a typical use-case, it should be easier / faster

Main changes:
----------------
* All diagnostocs for which a synthetic diagnostic exists are tabulated inside the class hidden attributes, along with their corresponding ids (core_profiles...)
* A method allows to instantaneously get the ids necessary for synthetic data (get_input_for_synthdiag())
* A method, add_ids_synthdiag(), calls the previous to automatically add and load then necessary ids, if necessary with a custom idd defined just-in-time.
* Two keywords added at instanciation (ids_base and synthdiag) for users who want to load everythong at once from a single idd)
* (extra) a get_events() method is implemented to easily print the chronologial events in a shot from ids 'pulse_schedule' 

Issues:
-------
* Fixes, in devel, issue #318 

Example (with a custom idd):
--------------------------------

**Before (5 lines, a bit complicated)**
```
> import tofu as tf

# load experimental data and wall for geometry, and pulse_schedule for tIGNITRON
> multi = tf.imas2tofu.MultiIDSLoader(shot=53259, ids=['pulse_schedule', 'wall', 'interferometer'], get=False)

# Find which ids are necessary for synthetic signal calculation
> print(multi._didsdiag['interferometer']['synth']['dsig'])
{'core_profiles': ['t', '1dne', '1drhotn'],
 'equilibrium': ['t', '2drhotn', '2dmeshNodes', '2dmeshFaces']}

# add these ids to multi
> multi.add_ids(ids=['core_profiles', 'equilibrium'], shot=53259, user='CB165101', run=1, get=False)

# Load everything that was added
> multi.open_get_close()

# Calculate signal
> sig = multi.calc_signal('interferometer')
```

**Now (3 lines, simpler)**
```
> import tofu as tf

# load experimental data (wall and pulse_schedule are automatically included)
> multi = tf.imas2tofu.MultiIDSLoader(shot=53259, ids='interferometer', get=False)

# Add ids necessary for calculation (automatically identified: tabulated in class attribute)
> multi.add_ids_synth_diag(shot=53259,  user='CB165101', run=1)

# Calculate signal
> sig = multi.calc_signal('interferometer')
```

Also, events can now be obtained using (will only work if 'pulse_schedule' was properly populated):
`> multi.get_events()`
