### PR TITLE
Faster LOS calc signal with new_calc = True

### DIFF
--- a/tofu/geom/_GG.pyx
+++ b/tofu/geom/_GG.pyx
@@ -2988,18 +2988,10 @@ def LOS_calc_signal(func, double[:,::1] ray_orig, double[:,::1] ray_vdir, res,
         # Integrate
         if n_imode == 0:  # "sum" integration mode
             # .. integrating function ..........................................
-            #reseff  = np.copy(np.asarray(<double[:nlos]>reseff_arr[0]))
-            reseff_mv = reseff
-            indices = np.copy(np.asarray(<long[:nlos]>ind_arr).astype(int))
+            reseffs = np.copy(np.asarray(<double[:nlos]>reseff_arr))
+            indices = np.copy(np.asarray(<long[:nlos-1]>ind_arr).astype(int))
             sig = np.add.reduceat(val_2d, np.r_[0, indices],
-                                  axis=-1)*reseff_mv[None, :]
-            # for ii in range(nlos):
-            #     if ii > 0:
-            #         sig[:,ii] = np.sum(val_2d[:, ind_arr[ii-1]:ind_arr[ii]],
-            #                     axis=-1) * reseff_arr[ii]
-            #     else:
-            #         sig[:,0] = np.sum(val_2d[:, 0:ind_arr[0]],
-            #                     axis=-1) * reseff_arr[0]
+                                  axis=-1)*reseffs[None, :]
             # Cleaning up...
             free(coeff_ptr[0])
             free(coeff_ptr)

--- a/tofu/geom/_GG.pyx
+++ b/tofu/geom/_GG.pyx
@@ -2982,16 +2982,19 @@ def LOS_calc_signal(func, double[:,::1] ray_orig, double[:,::1] ray_vdir, res,
                                    num_threads)
             # ..................................................................
         if ani:
-            val_2d = func(pts, t=t, vect=-usbis, **fkwdargs)
+            val_arr = func(pts, t=t, vect=-usbis, **fkwdargs)
         else:
-            val_2d = func(pts, t=t, **fkwdargs)
+            val_arr = func(pts, t=t, **fkwdargs)
+        val_2d = val_arr
         # Integrate
         if n_imode == 0:  # "sum" integration mode
             # .. integrating function ..........................................
             reseffs = np.copy(np.asarray(<double[:nlos]>reseff_arr))
             indices = np.copy(np.asarray(<long[:nlos-1]>ind_arr).astype(int))
-            sig = np.add.reduceat(val_2d, np.r_[0, indices],
-                                  axis=-1)*reseffs[None, :]
+            sig = np.asfortranarray(np.add.reduceat(val_arr,
+                                                    np.r_[0, indices],
+                                                    axis=-1)
+                                    * reseffs[None, :])
             # Cleaning up...
             free(coeff_ptr[0])
             free(coeff_ptr)

--- a/tofu/geom/_GG.pyx
+++ b/tofu/geom/_GG.pyx
@@ -2988,13 +2988,18 @@ def LOS_calc_signal(func, double[:,::1] ray_orig, double[:,::1] ray_vdir, res,
         # Integrate
         if n_imode == 0:  # "sum" integration mode
             # .. integrating function ..........................................
-            for ii in range(nlos):
-                if ii > 0:
-                    sig[:,ii] = np.sum(val_2d[:, ind_arr[ii-1]:ind_arr[ii]],
-                                axis=-1) * reseff_arr[ii]
-                else:
-                    sig[:,0] = np.sum(val_2d[:, 0:ind_arr[0]],
-                                axis=-1) * reseff_arr[0]
+            #reseff  = np.copy(np.asarray(<double[:nlos]>reseff_arr[0]))
+            reseff_mv = reseff
+            indices = np.copy(np.asarray(<long[:nlos]>ind_arr).astype(int))
+            sig = np.add.reduceat(val_2d, np.r_[0, indices],
+                                  axis=-1)*reseff_mv[None, :]
+            # for ii in range(nlos):
+            #     if ii > 0:
+            #         sig[:,ii] = np.sum(val_2d[:, ind_arr[ii-1]:ind_arr[ii]],
+            #                     axis=-1) * reseff_arr[ii]
+            #     else:
+            #         sig[:,0] = np.sum(val_2d[:, 0:ind_arr[0]],
+            #                     axis=-1) * reseff_arr[0]
             # Cleaning up...
             free(coeff_ptr[0])
             free(coeff_ptr)

--- a/tofu/geom/_GG.pyx
+++ b/tofu/geom/_GG.pyx
@@ -2982,16 +2982,16 @@ def LOS_calc_signal(func, double[:,::1] ray_orig, double[:,::1] ray_vdir, res,
                                    num_threads)
             # ..................................................................
         if ani:
-            val_arr = func(pts, t=t, vect=-usbis, **fkwdargs)
+            val_2d = func(pts, t=t, vect=-usbis, **fkwdargs)
         else:
-            val_arr = func(pts, t=t, **fkwdargs)
-        val_2d = val_arr
+            val_2d = func(pts, t=t, **fkwdargs)
+
         # Integrate
         if n_imode == 0:  # "sum" integration mode
             # .. integrating function ..........................................
             reseffs = np.copy(np.asarray(<double[:nlos]>reseff_arr))
             indices = np.copy(np.asarray(<long[:nlos-1]>ind_arr).astype(int))
-            sig = np.asfortranarray(np.add.reduceat(val_arr,
+            sig = np.asfortranarray(np.add.reduceat(val_2d,
                                                     np.r_[0, indices],
                                                     axis=-1)
                                     * reseffs[None, :])


### PR DESCRIPTION
Same as #308 but for the new algorithm implemented (activated whent `LOS_calc_signal(..., new_calc=True, ...)`).

Here are the results with the same benchmark

```
In [1]: import tofu as tf
/home/ITER/mendozl/repositories/tofu/usr/lib/python3.6/site-packages/tofu-1.4.2a5-py3.6-linux-x86_64.egg/tofu/imas2tofu/__init__.py:83: UserWarning:
You do not seem to be using the latest IMAS version:
'module list' vs 'module av IMAS' suggests:
	- Current version: 3.24.0-4.1.5
	- Latest version : 3.25.0-4.4.0
  warnings.warn(msg)
/home/ITER/mendozl/repositories/tofu/usr/lib/python3.6/site-packages/tofu-1.4.2a5-py3.6-linux-x86_64.egg/tofu/__init__.py:95: UserWarning:
The following subpackages are not available:
    - tofu.mag
  => see tofu.dsub[<subpackage>] for details.
  warnings.warn(msg)

In [2]: multi = tf.imas2tofu.MultiIDSLoader(user='hoeneno', tokamak='convert', shot=134000, run=29, ids=['edge_sources'])
Getting ids   [occ]  tokamak  user     version  shot    run  refshot  refrun
------------  -----  -------  -------  -------  ------  ---  -------  ------
edge_sources  [0]    convert  hoeneno  3        134000  29   -1       -1
_d^[[A
In [3]: _dshort = {'core_sources': {'1drhotn':'source[identifier.name=radiation].profiles_1d[time].grid.rho_tor_norm',
   ...:                             '1deEnergy':'source[identifier.name=radiation].profiles_1d[time].electrons.energy'
   ...:                                  },
   ...:            'equilibrium': {'2dpsi': 'time_slice[time].profiles_2d[0].psi',
   ...:                            '2dmeshR': 'time_slice[time].profiles_2d[0].r',
   ...:                            '2dmeshZ': 'time_slice[time].profiles_2d[0].z'}}
   ...:

In [4]: multi.set_shortcuts(dshort=_dshort)

In [5]: plasma = multi.to_Plasma2D()

In [6]: cam = tf.load('/home/ITER/munechk/public/MyTofu/output/ITER_test_camera_config.npz')
Loaded from:
    /home/ITER/munechk/public/MyTofu/output/ITER_test_camera_config.npz

In [7]: %timeit sig_newbasic, units = cam.calc_signal_from_Plasma2D(plasma, quant='edge_sources.2dradiation', plot=False, res=0.1, newcalc=True, method='sum', minimize='calls')
6.79 s ± 116 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [8]: %timeit sig_newbasic, units = cam.calc_signal_from_Plasma2D(plasma, quant='edge_sources.2dradiation', plot=False, res=0.1, newcalc=False)
7.36 s ± 50.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [9]: %timeit  sig_oldufunc, units = cam.calc_signal_from_Plasma2D(plasma, quant='edge_sources.2dradiation', plot=False, res=0.1, newcalc=False, fill_value=0.)
7.25 s ± 40.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [10]: sig_newbasic, units = cam.calc_signal_from_Plasma2D(plasma, quant='edge_sources.2dradiation', plot=False, res=0.1, newcalc=True, method='sum', minimize='calls')

In [11]:  sig_oldufunc, units = cam.calc_signal_from_Plasma2D(plasma, quant='edge_sources.2dradiation', plot=False, res=0.1, newcalc=False, fill_value=0.)

In [12]: np.allclose(sig_newbasic.data, sig_oldufunc.data)
Out[12]: True
```

The difference is less obvious than in the OPR, but `new_calc=True` seems to always yield the best results.
(I tried the benchmark in the `hpc-login02` cluster)


