### PR TITLE
[bf #331] raising exceptions when poly ill defined

### DIFF
--- a/tofu/geom/_GG.pyx
+++ b/tofu/geom/_GG.pyx
@@ -207,7 +207,7 @@ def Poly_isClockwise(np.ndarray[double,ndim=2] Poly):
     cdef int idp1 = (idmin + 1) % npts
     cdef str err_msg = ""
     if idmin == 0 :
-        idm1 = npts - 1
+        idm1 = npts - 2
     res = mvx[idm1]  * (mvy[idmin] - mvy[idp1]) + \
           mvx[idmin] * (mvy[idp1]  - mvy[idm1]) + \
           mvx[idp1]  * (mvy[idm1]  - mvy[idmin])

--- a/tofu/geom/_GG.pyx
+++ b/tofu/geom/_GG.pyx
@@ -200,14 +200,27 @@ def Poly_isClockwise(np.ndarray[double,ndim=2] Poly):
     cdef double res
     cdef double[:,::1] mv_poly = np.ascontiguousarray(Poly)
     cdef int npts = mv_poly.shape[1]
-    cdef double[::1] mvx = mv_poly[0,:]
-    cdef double[::1] mvy = mv_poly[1,:]
-    cdef int idmin = _bgt.find_ind_lowerright_corner(mvx, mvy, npts)
-    cdef int idm1 = idmin - 1
-    cdef int idp1 = (idmin + 1) % npts
+    cdef int ndim = mv_poly.shape[0]
+    cdef double[::1] mvx
+    cdef double[::1] mvy
+    cdef int idmin
+    cdef int idm1
+    cdef int idp1
     cdef str err_msg = ""
+    # Checking that Poly wasn't given in the shape (npts, ndim)
+    if ndim > npts:
+        mv_poly = np.ascontiguousarray(Poly.T)
+        npts = mv_poly.shape[1]
+        ndim = mv_poly.shape[0]
+    mvx = mv_poly[0,:]
+    mvy = mv_poly[1,:]
+    # Getting index of lower right corner and its neighbors
+    idmin = _bgt.find_ind_lowerright_corner(mvx, mvy, npts)
+    idm1 = idmin - 1
+    idp1 = (idmin + 1) % npts
     if idmin == 0 :
         idm1 = npts - 2
+    # Computing area of lower right triangle
     res = mvx[idm1]  * (mvy[idmin] - mvy[idp1]) + \
           mvx[idmin] * (mvy[idp1]  - mvy[idm1]) + \
           mvx[idp1]  * (mvy[idm1]  - mvy[idmin])
@@ -219,7 +232,6 @@ def Poly_isClockwise(np.ndarray[double,ndim=2] Poly):
                     + ", " + str(mvy[idmin]) + ".\n"
                     + "   The two neighboring points are : "
                     + str(idm1) + " and " + str(idp1) + ".")
-        print(err_msg)
         raise Exception(err_msg) # not working
     return res < 0.
 

--- a/tofu/geom/_basic_geom_tools.pxd
+++ b/tofu/geom/_basic_geom_tools.pxd
@@ -1,6 +1,7 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True
+# cython: initializedcheck=False
 #
 ################################################################################
 # Utility functions for basic geometry :

--- a/tofu/geom/_basic_geom_tools.pyx
+++ b/tofu/geom/_basic_geom_tools.pyx
@@ -1,6 +1,8 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True
+# cython: initializedcheck=False
+#
 cimport cython
 
 from cython.parallel import prange

--- a/tofu/geom/_comp.py
+++ b/tofu/geom/_comp.py
@@ -35,9 +35,8 @@ def _Struct_set_Poly(
 
     # Make Poly closed, counter-clockwise, with '(cc,N)' layout and arrayorder
     try:
-        Poly = _GG.Poly_Order(
-            Poly, order="C", Clock=False, close=True, layout="(cc,N)", Test=True
-            )
+        Poly = _GG.Poly_Order(Poly, order="C", Clock=False, close=True,
+                              layout="(cc,N)", Test=True)
     except Exception as excp:
         print(excp)
     assert Poly.shape[0] == 2, "Arg Poly must be a 2D polygon !"

--- a/tofu/geom/_comp.py
+++ b/tofu/geom/_comp.py
@@ -34,9 +34,12 @@ def _Struct_set_Poly(
     """ Compute geometrical attributes of a Struct object """
 
     # Make Poly closed, counter-clockwise, with '(cc,N)' layout and arrayorder
-    Poly = _GG.Poly_Order(
-        Poly, order="C", Clock=False, close=True, layout="(cc,N)", Test=True
-    )
+    try:
+        Poly = _GG.Poly_Order(
+            Poly, order="C", Clock=False, close=True, layout="(cc,N)", Test=True
+            )
+    except Exception as excp:
+        print(excp)
     assert Poly.shape[0] == 2, "Arg Poly must be a 2D polygon !"
     fPfmt = np.ascontiguousarray if arrayorder == "C" else np.asfortranarray
 

--- a/tofu/geom/_comp.py
+++ b/tofu/geom/_comp.py
@@ -64,8 +64,11 @@ def _Struct_set_Poly(
     else:
         Vol, BaryV = _GG.Poly_VolAngTor(Poly)
         if Vol <= 0.0:
-            msg = "Pb. with volume computation for Ves object of type 'Tor' !"
-            msg = "\n Here Volume = " + str(Vol)
+            msg = ("Pb. with volume computation for Struct of type 'Tor' !\n"
+                   + "\t- Vol = {}\n".format(Vol)
+                   + "\t- Poly = {}\n\n".format(str(Poly))
+                   + "  => Probably corrupted polygon\n"
+                   + "  => Please check polygon is not self-intersecting")
             raise Exception(msg)
 
     # Compute the non-normalized vector of each side of the Poly

--- a/tofu/geom/_core.py
+++ b/tofu/geom/_core.py
@@ -2203,8 +2203,8 @@ class Config(utils.ToFuObject):
 
     def _checkformat_inputs_Struct(self, struct, err=True):
         assert issubclass(struct.__class__, Struct)
-        C0 = struct.Id.Exp==self.Id.Exp
-        C1 = struct.Id.Type==self.Id.Type
+        C0 = struct.Id.Exp == self.Id.Exp
+        C1 = struct.Id.Type == self.Id.Type
         C2 = struct.Id.Name.isidentifier()
         C2 = C2 and '_' not in struct.Id.Name
         msgi = None
@@ -3134,7 +3134,6 @@ class Config(utils.ToFuObject):
                                               tit=tit, wintit=wintit,
                                               invertx=invertx, draw=draw)
 
-
     def isInside(self, pts, In="(X,Y,Z)", log="any"):
 
         """ Return a 2D array of bool
@@ -3728,7 +3727,7 @@ class Rays(utils.ToFuObject):
               if (isinstance(dgeom, self._dcases[k]['type'])
                   and all([kk in dgeom.keys()  # noqa
                            for kk in self._dcases[k]['lk']]))]
-        if not len(lC)==1:
+        if not len(lC) == 1:
             lstr = [v['lk'] for v in self._dcases.values()]
             msg = "Arg dgeom must be either:\n"
             msg += "  - dict with keys:\n"
@@ -4141,7 +4140,8 @@ class Rays(utils.ToFuObject):
                     k = np.sum(DDb*(u - np.sqrt(sca2)*dgeom['u'][:, 1:]),
                                axis=0)
                     k = k / (1.0-sca2)
-                    if k[0] > 0 and np.allclose(k, k[0], atol=1.e-3, rtol=1.e-6):
+                    if k[0] > 0 and np.allclose(k, k[0], atol=1.e-3,
+                                                rtol=1.e-6):
                         pinhole = dgeom['D'][:, 0] + k[0]*u[:, 0]
                         dgeom['pinhole'] = pinhole
 
@@ -5033,8 +5033,8 @@ class Rays(utils.ToFuObject):
 
     @property
     def u(self):
-        if (self._dgeom['u'] is not None
-            and self._dgeom['u'].shape[1] == self._dgeom['nRays']):
+        if self._dgeom['u'] is not None \
+          and self._dgeom['u'].shape[1] == self._dgeom['nRays']:
             u = self._dgeom['u']
         elif self.isPinhole:
             u = self._dgeom['pinhole'][:, None] - self._dgeom['D']
@@ -5127,7 +5127,7 @@ class Rays(utils.ToFuObject):
     def _check_indch(self, ind, out=int):
         if ind is not None:
             ind = np.asarray(ind)
-            assert ind.ndim==1
+            assert ind.ndim == 1
             assert ind.dtype in [np.int64, np.bool_, np.long]
             if ind.dtype == np.bool_:
                 assert ind.size == self.nRays
@@ -5574,17 +5574,17 @@ class Rays(utils.ToFuObject):
         if type(lPoly) is list:
             for ii in range(nPoly):
                 # Check closed and anti-clockwise
-                if _GG.Poly_isClockwise(lPoly[ii]):
-                    lPoly[ii] = lPoly[ii][:, ::-1]
                 if not np.allclose(lPoly[ii][:, 0], lPoly[ii][:, -1]):
                     lPoly[ii] = np.concatenate(
                         (lPoly[ii], lPoly[ii][:, 0:1]), axis=-1
                     )
+                try:
+                    if _GG.Poly_isClockwise(lPoly[ii]):
+                        lPoly[ii] = lPoly[ii][:, ::-1]
+                except Exception as excp:
+                    print("For structure ", ii, " : ", excp)
         else:
-            for ii in range(nPoly):
-                # Check closed and anti-clockwise
-                if _GG.Poly_isClockwise(lPoly[ii]):
-                    lPoly[ii] = lPoly[ii][:, ::-1]
+            # Check closed and anti-clockwise
             d = np.sum((lPoly[:, :, 0]-lPoly[:, :, -1])**2, axis=1)
             if np.allclose(d, 0.):
                 pass
@@ -5593,6 +5593,12 @@ class Rays(utils.ToFuObject):
             else:
                 msg = "All poly in lPoly should be closed or all non-closed!"
                 raise Exception(msg)
+            for ii in range(nPoly):
+                try:
+                    if _GG.Poly_isClockwise(lPoly[ii]):
+                        lPoly[ii] = lPoly[ii][:, ::-1]
+                except Exception as excp:
+                    print("For structure ", ii, " : ", excp)
 
         # Check lVIn
         if lVIn is None:
@@ -5663,14 +5669,14 @@ class Rays(utils.ToFuObject):
 
         # Compute intersections
         assert(self._method in ['ref', 'optimized'])
-        if self._method=='ref':
+        if self._method == 'ref':
             for ii in range(0, nPoly):
                 largs, dkwd = self._kInOut_Isoflux_inputs([lPoly[ii]],
                                                           lVIn=[lVIn[ii]])
                 out = _GG.SLOW_LOS_Calc_PInOut_VesStruct(*largs, **dkwd)
                 # PIn, POut, kin, kout, VperpIn, vperp, IIn, indout = out[]
                 kIn[ii, :], kOut[ii, :] = out[2], out[3]
-        elif self._method=="optimized":
+        elif self._method == "optimized":
             for ii in range(0, nPoly):
                 largs, dkwd = self._kInOut_Isoflux_inputs([lPoly[ii]],
                                                           lVIn=[lVIn[ii]])
@@ -6900,7 +6906,7 @@ class CamLOS2D(Rays):
         # Prepare
         kout = self._dgeom["kOut"]
         indout = self._dgeom["indout"]
-        lS = self._dconfig["Config"].lStruct
+        # lS = self._dconfig["Config"].lStruct
         angles = np.arccos(-np.sum(self.u*self.dgeom['vperp'], axis=0))
 
         # ar0

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2-a5-113-gcbcc34c7'
+__version__ = '1.4.2b13-65-ga0f432bb'


### PR DESCRIPTION
As discussed in #331 : 
The polygon needs to be properly defined in order for the algorithm `isClockwise` works correctly.
If it finds an issue (null volume) it will raise an exception.

The exception is caught and raised whenever function used
**Warning**: I didn't manage to properly catch and raise the error.  Can you see what I am doing wrong ? I left a `print` for the moment

I also realized in _core, `isClockwise` is defined sometimes **before** checking if the polygon is closed, however the algorithm needs for the polygon to be closed.

Lastly: some flake8 changes 