### PR TITLE
[Issue335] description_2d propagated and set to 1 by default

### DIFF
--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -3963,7 +3963,7 @@ class MultiIDSLoader(object):
                     dextra=None, t0=None, datacls=None, geomcls=None,
                     bck=True, fallback_X=None, nan=True, pos=None,
                     plot=True, plot_compare=None, plot_plasma=None):
-        """ Compute synthetic data for a diagnostics and export as DataCam1D object
+        """ Compute synthetic data for a diagnostics and export as DataCam1D
 
         Some ids typically contain plasma 1d (radial) or 2d (mesh) profiles
         They include for example ids:

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -2905,7 +2905,7 @@ class MultiIDSLoader(object):
                 - object :  as a Plasma2D instance
                 - dict:     as a dict
         description_2d: None / int
-            description_2d indiex to be used if the Config is to be built from
+            description_2d index to be used if the Config is to be built from
             wall ids. See self.to_Config()
         plot:       None / bool
             Flag whether to plot the result
@@ -2925,7 +2925,7 @@ class MultiIDSLoader(object):
                 - ('R', 'Z'): first dimension is R, second Z
                 - ('Z', 'R'): the other way around
 
-        Args nan and pos are fed to self.get_data()i
+        Args nan and pos are fed to self.get_data()
 
         Return
         ------
@@ -3440,12 +3440,12 @@ class MultiIDSLoader(object):
             Configuration (i.e.: tokamak geometry) to be used for the instance
             If None, created from the wall ids with self.to_Config().
         description_2d: None / int
-            description_2d indiex to be used if the Config is to be built from
+            description_2d index to be used if the Config is to be built from
             wall ids. See self.to_Config()
         plot:       None / bool
             Flag whether to plot the result
 
-        Args nan and pos are fed to self.get_data()i
+        Args nan and pos are fed to self.get_data()
 
         Return
         ------
@@ -3648,7 +3648,7 @@ class MultiIDSLoader(object):
             Configuration (i.e.: tokamak geometry) to be used for the instance
             If None, created from the wall ids with self.to_Config().
         description_2d: None / int
-            description_2d indiex to be used if the Config is to be built from
+            description_2d index to be used if the Config is to be built from
             wall ids. See self.to_Config()
         dextra:     None / dict
             dict of extra signals (time traces) to be plotted, for context
@@ -3680,7 +3680,7 @@ class MultiIDSLoader(object):
             Flag indicating whether to plot the grey envelop of the signal as a
             background, if plot is True
 
-        Args nan and pos are fed to self.get_data()i
+        Args nan and pos are fed to self.get_data()
 
         Return
         ------

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -2252,8 +2252,6 @@ class MultiIDSLoader(object):
     def to_Config(self, Name=None, occ=None,
                   description_2d=None, mobile=None, plot=True):
         lidsok = ['wall']
-        if description_2d is None:
-            description_2d = 0
 
         # ---------------------------
         # Preliminary checks on data source consistency
@@ -2278,6 +2276,12 @@ class MultiIDSLoader(object):
         assert occ.size == 1, "Please choose one occ only !"
         occ = occ[0]
         indoc = np.nonzero(self._dids[ids]['occ'] == occ)[0][0]
+
+        if description_2d is None:
+            if len(self._dids[ids]['ids'][indoc].description_2d) >= 1:
+                description_2d = 1
+            else:
+                description_2d = 0
 
         wall = self._dids[ids]['ids'][indoc].description_2d[description_2d]
         kwargs = dict(Exp=Exp, Type='Tor')
@@ -2795,6 +2799,7 @@ class MultiIDSLoader(object):
 
     def to_Plasma2D(self, tlim=None, dsig=None, t0=None,
                     Name=None, occ=None, config=None, out=object,
+                    description_2d=None,
                     plot=None, plot_sig=None, plot_X=None,
                     bck=True, dextra=None, nan=True, pos=None, shapeRZ=None):
 
@@ -2852,7 +2857,8 @@ class MultiIDSLoader(object):
 
         # config
         if config is None:
-            config = self.to_Config(Name=Name, occ=occ, plot=False)
+            config = self.to_Config(Name=Name, occ=occ,
+                                    description_2d=description_2d, plot=False)
 
         # dextra
         d0d, dtime0 = self._get_dextra(dextra)
@@ -3259,7 +3265,9 @@ class MultiIDSLoader(object):
 
 
     def to_Cam(self, ids=None, indch=None, indch_auto=False,
-               Name=None, occ=None, config=None, plot=True, nan=True, pos=None):
+               description_2d=None,
+               Name=None, occ=None, config=None,
+               plot=True, nan=True, pos=None):
 
         # dsig
         geom = self._checkformat_Cam_geom(ids)
@@ -3275,7 +3283,8 @@ class MultiIDSLoader(object):
 
         # config
         if config is None:
-            config = self.to_Config(Name=Name, occ=occ, plot=False)
+            config = self.to_Config(Name=Name, occ=occ,
+                                    description_2d=description_2d, plot=False)
 
         # dchans
         dchans = {}
@@ -3389,7 +3398,8 @@ class MultiIDSLoader(object):
 
 
     def to_Data(self, ids=None, dsig=None, data=None, X=None, tlim=None,
-                indch=None, indch_auto=False, Name=None, occ=None, config=None,
+                indch=None, indch_auto=False, Name=None, occ=None,
+                config=None, description_2d=None,
                 dextra=None, t0=None, datacls=None, geomcls=None,
                 plot=True, bck=True, fallback_X=None, nan=True, pos=None,
                 return_indch=False):
@@ -3411,7 +3421,8 @@ class MultiIDSLoader(object):
 
         # config
         if config is None:
-            config = self.to_Config(Name=Name, occ=occ, plot=False)
+            config = self.to_Config(Name=Name, occ=occ,
+                                    description_2d=description_2d, plot=False)
 
         # dchans
         if indch is not None:
@@ -3660,7 +3671,8 @@ class MultiIDSLoader(object):
                     q2dR=None, q2dPhi=None, q2dZ=None,
                     Brightness=None, interp_t=None, newcalc=True,
                     indch=None, indch_auto=False, Name=None,
-                    occ_cam=None, occ_plasma=None, config=None,
+                    occ_cam=None, occ_plasma=None,
+                    config=None, description_2d=None,
                     dextra=None, t0=None, datacls=None, geomcls=None,
                     bck=True, fallback_X=None, nan=True, pos=None,
                     plot=True, plot_compare=None, plot_plasma=None):
@@ -3680,11 +3692,14 @@ class MultiIDSLoader(object):
         if plot and plot_compare:
             data, indch = self.to_Data(ids, indch=indch,
                                        indch_auto=indch_auto, t0=t0,
+                                       config=config,
+                                       description_2d=description_2d,
                                        return_indch=True, plot=False)
 
         # Get camera
         cam = self.to_Cam(ids=ids, indch=indch,
-                          Name=None, occ=occ_cam, config=config,
+                          Name=None, occ=occ_cam,
+                          config=config, description_2d=description_2d,
                           plot=False, nan=True, pos=None)
 
         # Get relevant parameters
@@ -3693,7 +3708,8 @@ class MultiIDSLoader(object):
 
         # Get relevant plasma
         plasma = self.to_Plasma2D(tlim=tlim, dsig=dsig, t0=t0,
-                                  Name=None, occ=occ_plasma, config=cam.config, out=object,
+                                  Name=None, occ=occ_plasma,
+                                  config=cam.config, out=object,
                                   plot=False, dextra=dextra, nan=True, pos=None)
 
         # Intermediate computation if necessary
@@ -3832,7 +3848,7 @@ class MultiIDSLoader(object):
 
 
 def load_Config(shot=None, run=None, user=None, tokamak=None, version=None,
-                Name=None, occ=0, description_2d=0, plot=True):
+                Name=None, occ=0, description_2d=None, plot=True):
 
     didd = MultiIDSLoader()
     didd.add_idd(shot=shot, run=run,
@@ -3845,7 +3861,8 @@ def load_Config(shot=None, run=None, user=None, tokamak=None, version=None,
 
 # occ ?
 def load_Plasma2D(shot=None, run=None, user=None, tokamak=None, version=None,
-                  tlim=None, occ=None, dsig=None, ids=None, config=None,
+                  tlim=None, occ=None, dsig=None, ids=None,
+                  config=None, description_2d=None,
                   Name=None, t0=None, out=object, dextra=None,
                   plot=None, plot_sig=None, plot_X=None, bck=True):
 
@@ -3871,13 +3888,15 @@ def load_Plasma2D(shot=None, run=None, user=None, tokamak=None, version=None,
     didd.add_ids(ids=lids, get=True)
 
     return didd.to_Plasma2D(Name=Name, tlim=tlim, dsig=dsig, t0=t0,
-                            occ=occ, config=config, out=out,
+                            occ=occ, config=config,
+                            description_2d=description_2d, out=out,
                             plot=plot, plot_sig=plot_sig, plot_X=plot_X,
                             bck=bcki, dextra=dextra)
 
 
 def load_Cam(shot=None, run=None, user=None, tokamak=None, version=None,
-             ids=None, indch=None, config=None, occ=None, Name=None, plot=True):
+             ids=None, indch=None, config=None, description_2d=None,
+             occ=None, Name=None, plot=True):
 
     didd = MultiIDSLoader()
     didd.add_idd(shot=shot, run=run,
@@ -3892,13 +3911,15 @@ def load_Cam(shot=None, run=None, user=None, tokamak=None, version=None,
     didd.add_ids(ids=lids, get=True)
 
     return didd.to_Cam(ids=ids, Name=Name, indch=indch,
-                       config=config, occ=occ, plot=plot)
+                       config=config, description_2d=description_2d,
+                       occ=occ, plot=plot)
 
 
 def load_Data(shot=None, run=None, user=None, tokamak=None, version=None,
               ids=None, datacls=None, geomcls=None, indch_auto=True,
               tlim=None, dsig=None, data=None, X=None, indch=None,
-              config=None, occ=None, Name=None, dextra=None,
+              config=None, description_2d=None,
+              occ=None, Name=None, dextra=None,
               t0=None, plot=True, bck=True):
 
     didd = MultiIDSLoader()
@@ -3921,7 +3942,8 @@ def load_Data(shot=None, run=None, user=None, tokamak=None, version=None,
     return didd.to_Data(ids=ids, Name=Name, tlim=tlim, t0=t0,
                         datacls=datacls, geomcls=geomcls,
                         dsig=dsig, data=data, X=X, indch=indch,
-                        config=config, occ=occ, dextra=dextra,
+                        config=config, description_2d=description_2d,
+                        occ=occ, dextra=dextra,
                         plot=plot, bck=bck, indch_auto=indch_auto)
 
 

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2b13-70-gf5b8d06e'
+__version__ = '1.4.2b13-77-g822c9daa'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2b13-79-g375c9f34'
+__version__ = '1.4.2b13-80-g038ef357'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2b13-78-ge4c7c243'
+__version__ = '1.4.2b13-79-g375c9f34'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2b13-77-g822c9daa'
+__version__ = '1.4.2b13-78-ge4c7c243'


### PR DESCRIPTION
Main changes:
----------------
* The input keyword argument 'description_2d', used to choosed the wall geometry from an imas wall IDS, is now available from all methods of MultiIDSLoader that call to_Config() in the background. These include in particular to_Plasma2D(), to_Cam(), to_Data() and calc_signal()
* When not set (description_2d=None), the variable is now automatocally set to 1 if possible (to 0 otherwise)

Example (on IRFM Intra only):
---------------------------------
```
In [1]: import tofu as tf
/Home/DV226270/ToFu_All/tofu_git/tofu/tofu/imas2tofu/__init__.py:83: UserWarning: 
You do not seem to be using the latest IMAS version:
'module list' vs 'module av IMAS' suggests:
	- Current version: 3.23.1-4.0.3
	- Latest version : 3.25.0-4.4.0
  warnings.warn(msg)
/Home/DV226270/ToFu_All/tofu_git/tofu/tofu/__init__.py:95: UserWarning: 
The following subpackages are not available:
    - tofu.mag
  => see print(tofu.dsub[<subpackage>]) for details.
  warnings.warn(msg)

In [2]: multi = tf.imas2tofu.MultiIDSLoader(ids=['bolometer'], shot=55983, ids_base=True)
Getting ids     [occ]  tokamak  user         version  shot   run  refshot  refrun
--------------  -----  -------  -----------  -------  -----  ---  -------  ------
bolometer       [0]    west     imas_public  3        55983  0    -1       -1    
pulse_schedule  [0]    "        "            "        "      "    "        "     
wall            [0]    "        "            "        "      "    "        "     

In [3]: bolo = multi.to_Data('bolometer')

In [4]: bolo = multi.to_Data('bolometer', description_2d=0)
/Home/DV226270/ToFu_All/tofu_git/tofu/tofu/imas2tofu/_core.py:2350: UserWarning: 
ids wall has same number of limiter / mobile units
	- len(wall.description_2[0].limiter.unit) = 1
	- len(wall.description_2[0].mobile.unit) = 1
  => Choosing limiter by default
  warnings.warn(msg)
```

![issues335](https://user-images.githubusercontent.com/5929562/73183316-e418b100-411a-11ea-87be-854234ee264d.png)

Issues:
-------
Fixes, in devel, Issue #335 
