### PR TITLE
[Issue #337] replaced Poly_Order by format_poly

### DIFF
--- a/tofu/geom/_GG.pyx
+++ b/tofu/geom/_GG.pyx
@@ -236,18 +236,17 @@ def Poly_isClockwise(np.ndarray[double,ndim=2] Poly):
     return res < 0.
 
 
-def Poly_Order(np.ndarray[double,ndim=2] Poly, str order='C', Clock=False,
-               close=True, str layout='(cc,N)',
-               str layout_in=None, Test=True):
+def format_poly(np.ndarray[double,ndim=2] poly, str order='C', Clock=False,
+               close=True, Test=True):
     """
-    Return a polygon Poly as a np.ndarray formatted according to parameters
+    Return a polygon poly as a np.ndarray formatted according to parameters
 
     Parameters
     ----------
-        Poly    np.ndarray or list    Input polygon under from of (cc,N) or
-                or tuple              (N,cc) np.ndarray (where cc = 2 or 3, the
-                                      number of coordinates and N points), or
-                                      list or tuple of vertices
+        poly    np.ndarray or list    Input np.ndarray of shape (cc,N)
+                or tuple              (where cc = 2 or 3, the number of
+                                      coordinates and N points), or
+                                      list or tuple of vertices of a polygon
         order   str                   Flag indicating whether the output
                                       np.ndarray shall be C-contiguous ('C') or
                                       Fortran-contiguous ('F')
@@ -260,9 +259,6 @@ def Poly_Order(np.ndarray[double,ndim=2] Poly, str order='C', Clock=False,
                                       cating whether the output array shall be
                                       closed (True, ie: last point==first point)
                                       or not closed (False)
-        layout  str                   Flag indicating whether the output
-                                      np.ndarray shall be of shape '(cc,N)'
-                                      or '(N,cc)'
         Test    bool                  Flag indicating whether the inputs should
                                       be tested for conformity, default: True
 
@@ -271,27 +267,15 @@ def Poly_Order(np.ndarray[double,ndim=2] Poly, str order='C', Clock=False,
         poly    np.ndarray            Output formatted polygon
     """
     if Test:
-        assert (2 in np.shape(Poly) or 3 in np.shape(Poly)), \
-          "Arg Poly must contain the 2D or 3D coordinates of at least 3 points!"
-        assert max(np.shape(Poly))>=3, ("Arg Poly must contain the 2D or 3D",
-                                        " coordinates of at least 3 points!")
+        assert (poly.shape[0] == 2 or poly.shape[0] == 3), \
+            ("Arg poly must contain the 2D or 3D coordinates of N points."
+             " And be shaped in the form (dim, N).")
+        assert poly.shape[1]>=3, ("Arg poly must contain the 2D or 3D",
+                                  " coordinates of at least 3 points!")
         assert order.lower() in ['c','f'], "Arg order must be in ['c','f']!"
         assert type(Clock) is bool, "Arg Clock must be a bool!"
         assert type(close) is bool, "Arg close must be a bool!"
-        assert layout.lower() in ['(cc,n)','(n,cc)'], \
-          "Arg layout must be in ['(cc,n)','(n,cc)']!"
-        assert layout_in is None or layout_in.lower() in ['(cc,n)','(n,cc)'],\
-          "Arg layout_in must be None or in ['(cc,n)','(n,cc)']!"
 
-    if np.shape(Poly)==(3,3):
-        assert not layout_in is None, \
-          ("Could not resolve the input layout of Poly because shape==(3,3)",
-           " Please specify if input is in '(cc,n)' or '(n,cc)' format!")
-        poly = np.array(Poly).T if layout_in.lower()=='(n,cc)' \
-           else np.array(Poly)
-    else:
-        poly = np.array(Poly).T if min(np.shape(Poly))==Poly.shape[1]\
-           else np.array(Poly)
     if not np.allclose(poly[:,0],poly[:,-1], atol=_VSMALL):
         poly = np.concatenate((poly,poly[:,0:1]),axis=1)
     if poly.shape[0]==2 and not Clock is None:
@@ -302,8 +286,6 @@ def Poly_Order(np.ndarray[double,ndim=2] Poly, str order='C', Clock=False,
             raise excp
     if not close:
         poly = poly[:,:-1]
-    if layout.lower()=='(n,cc)':
-        poly = poly.T
     poly = np.ascontiguousarray(poly) if order.lower()=='c' \
            else np.asfortranarray(poly)
     return poly

--- a/tofu/geom/_comp.py
+++ b/tofu/geom/_comp.py
@@ -36,7 +36,7 @@ def _Struct_set_Poly(
     # Make Poly closed, counter-clockwise, with '(cc,N)' layout and arrayorder
     try:
         Poly = _GG.format_poly(Poly, order="C", Clock=False, close=True,
-                              Test=True)
+                               Test=True)
     except Exception as excp:
         print(excp)
     assert Poly.shape[0] == 2, "Arg Poly must be a 2D polygon !"

--- a/tofu/geom/_comp.py
+++ b/tofu/geom/_comp.py
@@ -35,8 +35,8 @@ def _Struct_set_Poly(
 
     # Make Poly closed, counter-clockwise, with '(cc,N)' layout and arrayorder
     try:
-        Poly = _GG.Poly_Order(Poly, order="C", Clock=False, close=True,
-                              layout="(cc,N)", Test=True)
+        Poly = _GG.format_poly(Poly, order="C", Clock=False, close=True,
+                              Test=True)
     except Exception as excp:
         print(excp)
     assert Poly.shape[0] == 2, "Arg Poly must be a 2D polygon !"
@@ -81,12 +81,11 @@ def _Struct_set_Poly(
     Vin = Vin / np.hypot(Vin[0, :], Vin[1, :])[np.newaxis, :]
     Vin = fPfmt(Vin)
 
-    poly = _GG.Poly_Order(
+    poly = _GG.format_poly(
         Poly,
         order=arrayorder,
         Clock=Clock,
         close=False,
-        layout="(cc,N)",
         Test=True,
     )
 

--- a/tofu/tests/tests01_geom/tests01_GG.py
+++ b/tofu/tests/tests01_geom/tests01_GG.py
@@ -114,25 +114,27 @@ def test02_Poly_CLockOrder():
     # Test arbitrary 2D polygon
     Poly = np.array([[0.,1.,1.,0.],[0.,0.,1.,1.]])
     P = GG.format_poly(Poly, order='C', Clock=False, close=True,
-                      Test=True)
-    assert all([np.allclose(P[:,0],P[:,-1]), P.shape==(2,5),
+                       Test=True)
+    assert all([np.allclose(P[:,0], P[:,-1]), P.shape==(2, 5),
                 not GG.Poly_isClockwise(P), P.flags['C_CONTIGUOUS'],
                 not P.flags['F_CONTIGUOUS']])
     P = GG.format_poly(Poly, order='F', Clock=True, close=False,
-                      Test=True)
-    assert all([not np.allclose(P[:,0],P[:,-1]), P.shape==(2,4),
-                GG.Poly_isClockwise(np.concatenate((P,P[:,0:1]),axis=1)),
+                       Test=True)
+    assert all([not np.allclose(P[:, 0], P[:, -1]), P.shape==(2, 4),
+                GG.Poly_isClockwise(np.concatenate((P, P[:,0:1]), axis=1)),
                 not P.flags['C_CONTIGUOUS'], P.flags['F_CONTIGUOUS']])
 
     # Test arbitrary 3D polygon
-    Poly = np.array([[0.,1.,1.,0.],[0.,0.,1.,1.],[0.,0.,0.,0.]])
+    Poly = np.array([[0., 1., 1., 0.],
+                     [0., 0., 1., 1.],
+                     [0., 0., 0., 0.]])
     P = GG.format_poly(Poly, order='C', Clock=False, close=False,
-                      Test=True)
-    assert all([not np.allclose(P[:,0],P[:,-1]), P.shape==(3,4),
+                       Test=True)
+    assert all([not np.allclose(P[:, 0], P[:, -1]), P.shape==(3, 4),
                 P.flags['C_CONTIGUOUS'], not P.flags['F_CONTIGUOUS']])
     P = GG.format_poly(Poly, order='F', Clock=True, close=True,
-                      Test=True)
-    assert all([np.allclose(P[:,0],P[:,-1]), P.shape==(3,5),
+                       Test=True)
+    assert all([np.allclose(P[:, 0], P[:, -1]), P.shape==(3, 5),
                 not P.flags['C_CONTIGUOUS'], P.flags['F_CONTIGUOUS']])
 
 

--- a/tofu/tests/tests01_geom/tests01_GG.py
+++ b/tofu/tests/tests01_geom/tests01_GG.py
@@ -113,33 +113,33 @@ def test02_Poly_CLockOrder():
 
     # Test arbitrary 2D polygon
     Poly = np.array([[0.,1.,1.,0.],[0.,0.,1.,1.]])
-    P = GG.Poly_Order(Poly, order='C', Clock=False, close=True,
-                      layout='(N,cc)', layout_in=None, Test=True)
-    assert all([np.allclose(P[0,:],P[-1,:]), P.shape==(5,2),
+    P = GG.format_poly(Poly, order='C', Clock=False, close=True,
+                      Test=True)
+    assert all([np.allclose(P[:,0],P[:,-1]), P.shape==(2,5),
                 not GG.Poly_isClockwise(P), P.flags['C_CONTIGUOUS'],
                 not P.flags['F_CONTIGUOUS']])
-    P = GG.Poly_Order(Poly, order='F', Clock=True, close=False,
-                      layout='(cc,N)', layout_in=None, Test=True)
+    P = GG.format_poly(Poly, order='F', Clock=True, close=False,
+                      Test=True)
     assert all([not np.allclose(P[:,0],P[:,-1]), P.shape==(2,4),
                 GG.Poly_isClockwise(np.concatenate((P,P[:,0:1]),axis=1)),
                 not P.flags['C_CONTIGUOUS'], P.flags['F_CONTIGUOUS']])
 
     # Test arbitrary 3D polygon
     Poly = np.array([[0.,1.,1.,0.],[0.,0.,1.,1.],[0.,0.,0.,0.]])
-    P = GG.Poly_Order(Poly, order='C', Clock=False, close=False,
-                      layout='(N,cc)', layout_in=None, Test=True)
-    assert all([not np.allclose(P[0,:],P[-1,:]), P.shape==(4,3),
+    P = GG.format_poly(Poly, order='C', Clock=False, close=False,
+                      Test=True)
+    assert all([not np.allclose(P[:,0],P[:,-1]), P.shape==(3,4),
                 P.flags['C_CONTIGUOUS'], not P.flags['F_CONTIGUOUS']])
-    P = GG.Poly_Order(Poly, order='F', Clock=True, close=True,
-                      layout='(cc,N)', layout_in=None, Test=True)
+    P = GG.format_poly(Poly, order='F', Clock=True, close=True,
+                      Test=True)
     assert all([np.allclose(P[:,0],P[:,-1]), P.shape==(3,5),
                 not P.flags['C_CONTIGUOUS'], P.flags['F_CONTIGUOUS']])
 
 
 def test03_Poly_VolAngTor():
     Poly = np.array([[1.,1.5,2.,2.,2.,1.5,1.],[0.,0.,0.,0.5,1.,1.,1.]])
-    Poly = GG.Poly_Order(Poly, order='C', Clock=False, close=True,
-                         layout='(cc,N)', Test=True)
+    Poly = GG.format_poly(Poly, order='C', Clock=False, close=True,
+                         Test=True)
     V, B = GG.Poly_VolAngTor(Poly)
     assert V==1.5
     assert np.allclose(B,[7./(3.*1.5),0.5])

--- a/tofu/tests/tests01_geom/tests01_GG.py
+++ b/tofu/tests/tests01_geom/tests01_GG.py
@@ -115,13 +115,13 @@ def test02_Poly_CLockOrder():
     Poly = np.array([[0.,1.,1.,0.],[0.,0.,1.,1.]])
     P = GG.format_poly(Poly, order='C', Clock=False, close=True,
                        Test=True)
-    assert all([np.allclose(P[:,0], P[:,-1]), P.shape==(2, 5),
+    assert all([np.allclose(P[:, 0], P[:, -1]), P.shape == (2, 5),
                 not GG.Poly_isClockwise(P), P.flags['C_CONTIGUOUS'],
                 not P.flags['F_CONTIGUOUS']])
     P = GG.format_poly(Poly, order='F', Clock=True, close=False,
                        Test=True)
-    assert all([not np.allclose(P[:, 0], P[:, -1]), P.shape==(2, 4),
-                GG.Poly_isClockwise(np.concatenate((P, P[:,0:1]), axis=1)),
+    assert all([not np.allclose(P[:, 0], P[:, -1]), P.shape == (2, 4),
+                GG.Poly_isClockwise(np.concatenate((P, P[:, 0:1]), axis=1)),
                 not P.flags['C_CONTIGUOUS'], P.flags['F_CONTIGUOUS']])
 
     # Test arbitrary 3D polygon
@@ -130,18 +130,18 @@ def test02_Poly_CLockOrder():
                      [0., 0., 0., 0.]])
     P = GG.format_poly(Poly, order='C', Clock=False, close=False,
                        Test=True)
-    assert all([not np.allclose(P[:, 0], P[:, -1]), P.shape==(3, 4),
+    assert all([not np.allclose(P[:, 0], P[:, -1]), P.shape == (3, 4),
                 P.flags['C_CONTIGUOUS'], not P.flags['F_CONTIGUOUS']])
     P = GG.format_poly(Poly, order='F', Clock=True, close=True,
                        Test=True)
-    assert all([np.allclose(P[:, 0], P[:, -1]), P.shape==(3, 5),
+    assert all([np.allclose(P[:, 0], P[:, -1]), P.shape == (3, 5),
                 not P.flags['C_CONTIGUOUS'], P.flags['F_CONTIGUOUS']])
 
 
 def test03_Poly_VolAngTor():
     Poly = np.array([[1.,1.5,2.,2.,2.,1.5,1.],[0.,0.,0.,0.5,1.,1.,1.]])
     Poly = GG.format_poly(Poly, order='C', Clock=False, close=True,
-                         Test=True)
+                          Test=True)
     V, B = GG.Poly_VolAngTor(Poly)
     assert V==1.5
     assert np.allclose(B,[7./(3.*1.5),0.5])


### PR DESCRIPTION
Replaced `Poly_Order` by `format_poly`:

- the function now doesn't change the layout of the polygon: a polygon should always be in the format `(cc,N) = (number_of_coordinates, number_of_points)`
- the tests were adapted
- calls were updated

Solves #337 