### PR TITLE
Issue #357 Made allow_pickle available to user

### DIFF
--- a/tofu/utils.py
+++ b/tofu/utils.py
@@ -454,7 +454,7 @@ def _filefind(name, path=None, lmodes=['.npz','.mat']):
 
 
 
-def load(name, path=None, strip=None, verb=True):
+def load(name, path=None, strip=None, verb=True, allow_pickle=None):
     """     Load a tofu object file
 
     Can load from .npz or .txt files
@@ -483,7 +483,7 @@ def load(name, path=None, strip=None, verb=True):
         obj = _load_from_txt(name, pfe)
     else:
         if mode == 'npz':
-            dd = _load_npz(pfe)
+            dd = _load_npz(pfe, allow_pîckle=allow_pickle)
         elif mode == 'mat':
             dd = _load_mat(pfe)
 
@@ -581,12 +581,15 @@ def _get_load_npzmat_dict(out, pfe, mode='npz', exclude_keys=[]):
 
 
 
-def _load_npz(pfe):
+def _load_npz(pfe, allow_pickle=None):
+    if allow_pickle is None:
+        allow_pickle = True
 
     try:
-        out = np.load(pfe, mmap_mode=None)
+        out = np.load(pfe, mmap_mode=None, allow_pickle=allow_pickle)
     except UnicodeError:
-        out = np.load(pfe, mmap_mode=None, encoding='latin1')
+        out = np.load(pfe, mmap_mode=None, allow_pickle=allow_pickle,
+                      encoding='latin1')
     except Exception as err:
         raise err
 

--- a/tofu/utils.py
+++ b/tofu/utils.py
@@ -453,7 +453,6 @@ def _filefind(name, path=None, lmodes=['.npz','.mat']):
     return name, mode, pfe
 
 
-
 def load(name, path=None, strip=None, verb=True, allow_pickle=None):
     """     Load a tofu object file
 
@@ -578,7 +577,6 @@ def _get_load_npzmat_dict(out, pfe, mode='npz', exclude_keys=[]):
         raise Exception(msg)
 
     return dout
-
 
 
 def _load_npz(pfe, allow_pickle=None):

--- a/tofu/utils.py
+++ b/tofu/utils.py
@@ -483,7 +483,7 @@ def load(name, path=None, strip=None, verb=True, allow_pickle=None):
         obj = _load_from_txt(name, pfe)
     else:
         if mode == 'npz':
-            dd = _load_npz(pfe, allow_pîckle=allow_pickle)
+            dd = _load_npz(pfe, allow_pickle=allow_pickle)
         elif mode == 'mat':
             dd = _load_mat(pfe)
 

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2b4-56-g4622b310'
+__version__ = '1.4.2b4-61-g1a5ca76a'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2b4-61-g1a5ca76a'
+__version__ = '1.4.2b4-62-ge4d82cd9'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2b4-62-ge4d82cd9'
+__version__ = '1.4.2b4-63-gf16dd82e'


### PR DESCRIPTION
Motivation:
-------------
Safety and backward compatibility for old saved files, see:
https://stackoverflow.com/questions/41696360/numpy-consequences-of-using-np-save-with-allow-pickle-false

Main Changes:
----------------
* parameter allow_pickle, fed to np.load(), is now available to the user using tf.load()

Issues:
-------
Fixes, in devel, issue #357 