### PR TITLE
Issue #359 tofu-custom allow customization of script parameters

### DIFF
--- a/tofu/scripts/_def.py
+++ b/tofu/scripts/_def.py
@@ -1,0 +1,29 @@
+
+
+# #############################################################################
+#                   tofuplot parameters
+# #############################################################################
+
+_TFPLOT_RUN = 0
+_TFPLOT_USER = 'imas_public'
+_TFPLOT_TOKAMAK = 'west'
+_TFPLOT_VERSION = '3'
+_TFPLOT_T0 = 'IGNITRON'
+_TFPLOT_SHAREX = False
+_TFPLOT_BCK = True
+_TFPLOT_EXTRA = True
+_TFPLOT_INDCH_AUTO = True
+
+
+# #############################################################################
+#                   tofucalc parameters
+# #############################################################################
+_TFCALC_RUN = 0
+_TFCALC_USER = 'imas_public'
+_TFCALC_TOKAMAK = 'west'
+_TFCALC_VERSION = '3'
+_TFCALC_T0 = 'IGNITRON'
+_TFCALC_SHAREX = False
+_TFCALC_BCK = True
+_TFCALC_EXTRA = None
+_TFCALC_INDCH_AUTO = True

--- a/tofu/scripts/tofucalc.py
+++ b/tofu/scripts/tofucalc.py
@@ -27,6 +27,20 @@ if istofugit:
 else:
     import tofu as tf
     from tofu.imas2tofu import MultiIDSLoader
+
+# default parameters
+pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_scripts_def.py')
+if os.path.isfile(pfe):
+    cwd = os.getcwd()
+    os.chdir(os.path.join(os.path.expanduser('~'), '.tofu'))
+    import _scripts_def as _defscripts
+    os.chdir(cwd)
+else:
+    try:
+        import tofu.scripts._def as _defscripts
+    except Exception as err:
+        from . import _def as _defscripts
+
 tforigin = tf.__file__
 tfversion = tf.__version__
 print(tforigin, tfversion)
@@ -44,17 +58,22 @@ if 'imas2tofu' not in dir(tf):
 #       default values
 ###################################################
 
-_RUN = 0
-_USER = 'imas_public'
-_TOKAMAK = 'west'
-_VERSION = '3'
+
+# User-customizable
+_RUN = _defscripts._TFCALC_RUN
+_USER = _defscripts._TFCALC_USER
+_TOKAMAK = _defscripts._TFCALC_TOKAMAK
+_VERSION = _defscripts._TFCALC_VERSION
+_T0 = _defscripts._TFCALC_T0
+_SHAREX = _defscripts._TFCALC_SHAREX
+_BCK = _defscripts._TFCALC_BCK
+_EXTRA = _defscripts._TFCALC_EXTRA
+_INDCH_AUTO = _defscripts._TFCALC_INDCH_AUTO
+
+# Non user-customizable
 _LIDS_DIAG = MultiIDSLoader._lidsdiag
 _LIDS = _LIDS_DIAG
-_T0 = 'IGNITRON'
-_SHAREX = False
-_BCK = True
-_EXTRA = None
-_INDCH_AUTO = True
+
 
 ###################################################
 ###################################################

--- a/tofu/scripts/tofucustom.py
+++ b/tofu/scripts/tofucustom.py
@@ -16,7 +16,7 @@ _SOURCE = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 _USER = getpass.getuser()
 _USER_HOME = os.path.expanduser('~')
 _TARGET = os.path.join(_USER_HOME, '.tofu')
-_LF = ['_imas2tofu_def.py']
+_LF = ['_imas2tofu_def.py', '_scripts_def.py']
 
 
 ###################################################

--- a/tofu/scripts/tofuplot.py
+++ b/tofu/scripts/tofuplot.py
@@ -27,6 +27,20 @@ if istofugit:
 else:
     import tofu as tf
     from tofu.imas2tofu import MultiIDSLoader
+
+# default parameters
+pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_scripts_def.py')
+if os.path.isfile(pfe):
+    cwd = os.getcwd()
+    os.chdir(os.path.join(os.path.expanduser('~'), '.tofu'))
+    import _scripts_def as _defscripts
+    os.chdir(cwd)
+else:
+    try:
+        import tofu.scripts._def as _defscripts
+    except Exception as err:
+        from . import _def as _defscripts
+
 tforigin = tf.__file__
 tfversion = tf.__version__
 print(tforigin, tfversion)
@@ -44,18 +58,23 @@ if 'imas2tofu' not in dir(tf):
 #       default values
 ###################################################
 
-_RUN = 0
-_USER = 'imas_public'
-_TOKAMAK = 'west'
-_VERSION = '3'
+
+# User-customizable
+_RUN = _defscripts._TFPLOT_RUN
+_USER = _defscripts._TFPLOT_USER
+_TOKAMAK = _defscripts._TFPLOT_TOKAMAK
+_VERSION = _defscripts._TFPLOT_VERSION
+_T0 = _defscripts._TFPLOT_T0
+_SHAREX = _defscripts._TFPLOT_SHAREX
+_BCK = _defscripts._TFPLOT_BCK
+_EXTRA = _defscripts._TFPLOT_EXTRA
+_INDCH_AUTO = _defscripts._TFPLOT_INDCH_AUTO
+
+# Not user-customizable
 _LIDS_DIAG = MultiIDSLoader._lidsdiag
 _LIDS_PLASMA = tf.imas2tofu.MultiIDSLoader._lidsplasma
 _LIDS = _LIDS_DIAG + _LIDS_PLASMA + ['magfieldlines']
-_T0 = 'IGNITRON'
-_SHAREX = False
-_BCK = True
-_EXTRA = True
-_INDCH_AUTO = True
+
 
 ###################################################
 ###################################################

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2b4-63-gf16dd82e'
+__version__ = '1.4.2b4-67-g4784c5ba'


### PR DESCRIPTION
Main changes:
-------------------

* User-customizable default parameters of tofuplot and tofucalc have been moved to a dedicated module tofu/scripts/_def.py
* tofu-custom now copies this module into the local .tofu/ directory so the user can edit these parameters

Issues:
---------
Fixes, in devel, issue #359  