### PR TITLE
Issue #359 Minor bug fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ install:
 script:
 - cd $HOME
 - nosetests tofu.tests --nocapture -v --with-id --with-timer --with-coverage --cover-package=tofu
+- tofu-custom
 after_success:
 - codecov
 - chmod +x $START/anaconda_upload.sh

--- a/release_notes/release_notes_143.rst
+++ b/release_notes/release_notes_143.rst
@@ -1,0 +1,133 @@
+====================
+What's new in 1.4.3
+====================
+
+Main changes:
+=============
+
+- Python 2 not supported anymore
+- Several changes to try and make installation cleaner / easier
+- More robust IMAS interface #280, #317, #319, #336, #343, #350
+- Better documentation, more ressources
+- More informative error messages
+- Better PEP8 compliance
+
+New features:
+~~~~~~~~~~~~~
+- New bash commands tofuplot, tofucalc and tofu-custom #345, #352, #353, #360
+- New **AUG configuration** available! #333
+- More complete CrystalBragg class #320
+
+
+Detailed changes:
+=================
+
+Installation / portability:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- travis test matrix #328
+- Skipped deployment if package already detected, deploy bdist for Mac #293
+- Bug corrected Cython vs cython #274
+- pip install working, cleaned up setup.py, requirements.txt included #283 #299 #302
+- More general path delimiters, corrected path in update_version #296 #315
+- Bug fixed on Mac (due to wrong modulo operation) #323
+- Debugged deployment and updating of version number #348
+
+
+scripts:
+~~~~~~~~
+- Introduction of bash command line tools: tofuplot (for plotting IMAS data)
+  tofucalc (for calculating synthetic signal) and tofu-custom for user-specific
+  customization of tofu default parameters #345
+- tofucalc also handles input_file and output_file in .mat format #352
+- tofu-custom allows for cutomization of IMAS shortcuts #353
+- tofu-custom allows for cutomization of script parameters #360
+
+
+Exception / warnings:
+~~~~~~~~~~~~~~~~~~~~~
+- More details exception msg when loading wrong Config #327
+- Better warning when a sub-package is not available #269 #270
+- Warning added when gcc compiler < 8 used on Mac #268
+- Better (more concise) warnings when unable to load data from IMAS #280
+- Now warns if IMAS version loaded is not the latest available on the system #289
+- Exception raised when poly ill-defined #332
+
+
+Default configurations:
+~~~~~~~~~~~~~~~~~~~~~~~
+- Asdex Upgrade added (AUG) #333
+
+
+Geom classes (Struct, Config, CamLOS1D, CamLOS2D...):
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- Reformatted _GG.Poly_Order by _GG.format_poly #338
+- get_summary() routine implemented for Struct and CamLOS2D #305
+- Faster synthetic signal cmputation (calc_signal()) using method='sum' #308 #322
+
+
+Plasma2D:
+~~~~~~~~~
+- Bug fixed in interpolation routine #279
+- Now handles rectangular meshes #280
+- Can now save/load Config to/from IMAS and indch_auto propagated #325
+
+
+2D XRay spectrometer:
+~~~~~~~~~~~~~~~~~~~~~
+- CrystalBragg ow has several geometry and data plotting methods useful for geometrical adjustments and spectrum visualization #320
+
+
+IMAS interfacing:
+~~~~~~~~~~~~~~~~~
+- More robust MultiIDSLoader vs one-time-step signal #280
+- Now loads rectangular meshes #280
+- add_ids() now also works with idd handle #317
+- It is now possible to add the ids corresponding to the synthetic diagnostics of an ids, and optionally to add them from a diffrent idd #319
+- description_2d input argument propagated #336
+- Automated selection of valiud channels (indch_auto=True) now more robust #343
+- Updated signal for relectometer_profile #350
+
+
+Documentation:
+~~~~~~~~~~~~~~
+- New tutorials and link to release notes #273 #297 #300 #330
+- Better badges on Github #278
+- Better release notes #284
+- Documentation page on bash command lines
+
+
+Miscellaneous:
+~~~~~~~~~~~~~~
+- Better PEP8 compliance #285
+- Removed useless files #290 #324
+- Minutes from meeting on 27.11.2019 added #291
+- allow_pickle available to users #358
+
+
+Contributors:
+=============
+Many thanks to all developpers:
+- Didier Vezinet (@Didou09)
+- Laura Mendoza (@lasofivec)
+- Florian Le Bourdais (@flothesof)
+- Jack Hare (@harej)
+
+
+What's next (indicative):
+=========================
+- Migrating from nosetests (ongoing for @lasofivec : issues #95 and #232 )
+- Easier binary and source installs from pip and conda for all platforms, including unit tests on alla platforms (ongoing for @lasofivec and @flothesof : issue #92 and #259 )
+- Solid angles for Volume-Of-Sight and radiative heat loads computation (ongoing for @lasofivec : Issues #71, #72, #73, #74, #75, #76, #77, #78 )
+- Tools and classes to handle 2D Bragg X-Ray crystal spectrometer (ongoing for @Didou09 : Issues #202 and #263)
+- Generic data class to incorporate plateau-finding, data analysis and 1d Bayesian fitting routines and classes (ongoing for @Didou09 and @jmoralesFusion and @MohammadKozeiha: issues #208, #260 and #262)
+- More general magnetic field line tracing workflow
+- Better unit tests coverage
+- More complete documentation
+
+
+List of PR merged into this release:
+====================================
+- PR: #268, #269, #270, #273, #274, #278, #279, #280, #282, #283, #284, #285,
+  #289, #290, #291, #293, #296, #297, #299, #300, #302, #305, #308, #309, #315,
+  #317, #319, #320, #322, #323, #324, #325, #327, #328, #330, #332, #333, #336,
+  #338, #343, #345, #348, #352, #353, #358, #360

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -27,9 +27,15 @@ import datetime as dtm
 pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_imas2tofu_def.py')
 if os.path.isfile(pfe):
     # Make sure we load the user-specific file
-    sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
-    import _imas2tofu_def as _defimas2tofu
-    _ = sys.path.pop(1)
+    # sys.path method
+    # sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
+    # import _scripts_def as _defscripts
+    # _ = sys.path.pop(1)
+    # importlib method
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("_defimas2tofu", pfe)
+    _defimas2tofu = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(_defimas2tofu)
 else:
     try:
         import tofu.imas2tofu._def as _defimas2tofu

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -26,10 +26,10 @@ import datetime as dtm
 # tofu
 pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_imas2tofu_def.py')
 if os.path.isfile(pfe):
-    cwd = os.getcwd()
-    os.chdir(os.path.join(os.path.expanduser('~'), '.tofu'))
+    # Make sure we load the user-specific file
+    sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
     import _imas2tofu_def as _defimas2tofu
-    os.chdir(cwd)
+    _ = sys.path.pop(1)
 else:
     try:
         import tofu.imas2tofu._def as _defimas2tofu

--- a/tofu/scripts/tofucalc.py
+++ b/tofu/scripts/tofucalc.py
@@ -32,9 +32,15 @@ else:
 pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_scripts_def.py')
 if os.path.isfile(pfe):
     # Make sure we load the user-specific file
-    sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
-    import _scripts_def as _defscripts
-    _ = sys.path.pop(1)
+    # sys.path method
+    # sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
+    # import _scripts_def as _defscripts
+    # _ = sys.path.pop(1)
+    # importlib method
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("_defscripts", pfe)
+    _defscripts = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(_defscripts)
 else:
     try:
         import tofu.scripts._def as _defscripts

--- a/tofu/scripts/tofucalc.py
+++ b/tofu/scripts/tofucalc.py
@@ -31,10 +31,10 @@ else:
 # default parameters
 pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_scripts_def.py')
 if os.path.isfile(pfe):
-    cwd = os.getcwd()
-    os.chdir(os.path.join(os.path.expanduser('~'), '.tofu'))
+    # Make sure we load the user-specific file
+    sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
     import _scripts_def as _defscripts
-    os.chdir(cwd)
+    _ = sys.path.pop(1)
 else:
     try:
         import tofu.scripts._def as _defscripts

--- a/tofu/scripts/tofuplot.py
+++ b/tofu/scripts/tofuplot.py
@@ -32,9 +32,15 @@ else:
 pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_scripts_def.py')
 if os.path.isfile(pfe):
     # Make sure we load the user-specific file
-    sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
-    import _scripts_def as _defscripts
-    _ = sys.path.pop(1)
+    # sys.path method
+    # sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
+    # import _scripts_def as _defscripts
+    # _ = sys.path.pop(1)
+    # importlib method
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("_defscripts", pfe)
+    _defscripts = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(_defscripts)
 else:
     try:
         import tofu.scripts._def as _defscripts

--- a/tofu/scripts/tofuplot.py
+++ b/tofu/scripts/tofuplot.py
@@ -31,10 +31,10 @@ else:
 # default parameters
 pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_scripts_def.py')
 if os.path.isfile(pfe):
-    cwd = os.getcwd()
-    os.chdir(os.path.join(os.path.expanduser('~'), '.tofu'))
+    # Make sure we load the user-specific file
+    sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
     import _scripts_def as _defscripts
-    os.chdir(cwd)
+    _ = sys.path.pop(1)
 else:
     try:
         import tofu.scripts._def as _defscripts

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2b4-69-g3b8dc223'
+__version__ = '1.4.2b4-70-gc35b1b0d'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2b4-70-gc35b1b0d'
+__version__ = '1.4.2b4-71-g44a9874f'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2b4-67-g4784c5ba'
+__version__ = '1.4.2b4-68-g5a8d273e'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.2b4-68-g5a8d273e'
+__version__ = '1.4.2b4-69-g3b8dc223'


### PR DESCRIPTION
Realized :

os.chdir(...)
import <module>

was not robust enough, the system can chdir in a separate terminal and the import ay not see the proper module

Replaced by a more robust 
1/ temporary modification of the sys.path
2/ use of importlib library

Option 2 seems safer after some reading.

Also @lasofivec , I pushed changes to ne-doc for the bash commands, but could not build the doc because I can't install a Sphinx dependency here, could you build and push to gh-pages ?

Also: added draft for release notes for 1.4.3