### PR TITLE
Issue #373 tofucalc multiple idd

### DIFF
--- a/release_notes/release_notes_144.rst
+++ b/release_notes/release_notes_144.rst
@@ -1,0 +1,66 @@
+====================
+What's new in 1.4.4
+====================
+
+tofu 1.4.4 is a minor upgrade from 1.4.3
+
+Main changes:
+=============
+
+- Bug fix in deployment workflow #371
+- Bug fix in installation with pip #370
+- More robust bash commands for IMAS interfacing #374
+- Introduced movements for geometry objects #372
+- More informative error messages
+- Better PEP8 compliance
+
+
+Detailed changes:
+=================
+
+Installation / portability:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- conditions for deploying of each platform are more strict (one-liner) #371
+- Includes _updateversion.py and .pxd files in sdist for pip installs #370
+
+scripts:
+~~~~~~~~
+- bash command tofucalc now accepts up to 3 sets of IMAS idd identifiers
+  (tokamak, user, shot, run) offering more flexibility to choose the idd for
+  geometry, equilibrium and profiles #374
+
+
+Geom classes (Struct, Config, CamLOS1D, CamLOS2D...):
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- Parent class now provides basic movement methods: rotations and translations
+  All Struct, Rays and CrystalBragg subclasses can use them
+  They can have an instance-grade predefined custom default movement #372
+
+
+Miscellaneous:
+~~~~~~~~~~~~~~
+- Better PEP8 compliance
+
+
+Contributors:
+=============
+Many thanks to all developpers:
+- Didier Vezinet (@Didou09)
+- Laura Mendoza (@lasofivec)
+
+
+What's next (indicative):
+=========================
+- Migrating from nosetests (ongoing for @lasofivec : issues #95 and #232 )
+- Easier binary and source installs from pip and conda for all platforms, including unit tests on alla platforms (ongoing for @lasofivec and @flothesof : issue #92 and #259 )
+- Solid angles for Volume-Of-Sight and radiative heat loads computation (ongoing for @lasofivec : Issues #71, #72, #73, #74, #75, #76, #77, #78 )
+- Tools and classes to handle 2D Bragg X-Ray crystal spectrometer (ongoing for @Didou09 : Issues #202 and #263)
+- Generic data class to incorporate plateau-finding, data analysis and 1d Bayesian fitting routines and classes (ongoing for @Didou09 and @jmoralesFusion and @MohammadKozeiha: issues #208, #260 and #262)
+- More general magnetic field line tracing workflow
+- Better unit tests coverage
+- More complete documentation
+
+
+List of PR merged into this release:
+====================================
+- PR: #370, #371, #372, #374

--- a/tofu/data/_plot.py
+++ b/tofu/data/_plot.py
@@ -1309,8 +1309,10 @@ def _DataCam12D_plot_spectral(lData, key=None,
     c0 = lData[0]._dgeom['config'] is not None
     c1 = c0 and lData[0]._dgeom['lCam'] is not None
     if c0:
-        out = lData[0]._dgeom['config'].plot(lax=[dax['cross'][0], dax['hor'][0]],
-                                             element='P', dLeg=None, draw=False)
+        out = lData[0]._dgeom['config'].plot(lax=[dax['cross'][0],
+                                                  dax['hor'][0]],
+                                             element='P', dLeg=None,
+                                             tit=False, draw=False)
         dax['cross'][0], dax['hor'][0] = out
         if c1 and 'LOS' in lData[0]._dgeom['lCam'][0].Id.Cls:
             lCross, lHor, llab = [], [], []
@@ -1329,12 +1331,12 @@ def _DataCam12D_plot_spectral(lData, key=None,
                     dax['cross'][0].plot(crossbck[0,:], crossbck[1,:],
                                          c=cbck, ls='-', lw=1.)
                     dax['hor'][0].plot(horbck[0,:], horbck[1,:],
-                                         c=cbck, ls='-', lw=1.)
+                                       c=cbck, ls='-', lw=1.)
                 elif bck:
                     out = cc.plot(lax=[dax['cross'][0], dax['hor'][0]],
                                   element='L', Lplot=Lplot,
                                   dL={'c':(0.4,0.4,0.4,0.4),'lw':0.5},
-                                  dLeg=None, draw=False)
+                                  dLeg=None, tit=False, draw=False)
                     dax['cross'][0], dax['hor'][0] = out
 
             lHor = np.stack(lHor)
@@ -2001,8 +2003,10 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
     # conf
     c0 = lData[0]._dgeom['config'] is not None
     if c0:
-        dax['hor'][0] = lData[0]._dgeom['config'].plot(lax=dax['hor'][0], proj='hor',
-                                                       element='P', dLeg=None, draw=False)
+        dax['hor'][0] = lData[0]._dgeom['config'].plot(lax=dax['hor'][0],
+                                                       proj='hor', element='P',
+                                                       tit=False, dLeg=None,
+                                                       draw=False)
 
     # dextra
     if lData[0].dextra is not None:
@@ -2035,7 +2039,8 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
         if c0:
             dax['cross'][ii] = lData[ii].config.plot(lax=dax['cross'][ii],
                                                      element='P', dLeg=None,
-                                                     proj='cross', draw=False)
+                                                     proj='cross', tit=False,
+                                                     draw=False)
 
         # los
         c1 = lData[ii]._dgeom['lCam'] is not None

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -2014,9 +2014,9 @@ class MultiIDSLoader(object):
                 if crit is None:
                     crit = v0['params'][imasstr]
                 elif crit != v0['params'][imasstr]:
-                    ss = '%s : %s'%(idd,str(v0['params'][imasstr]))
-                    msg = "All idd should refer to the same %s !\n"%imasstr
-                    msg += "    - " + ss
+                    ss = '{} : {}'.format(idd, str(v0['params'][imasstr]))
+                    msg = ("All idd refer to different {}!\n".format(imasstr)
+                           + "\t- {}".format(ss))
                     if err:
                         raise Exception(msg)
                     else:
@@ -2106,8 +2106,9 @@ class MultiIDSLoader(object):
 
         # ---------------------------
         # Preliminary checks on data source consistency
-        lids, lidd, shot, Exp = self._get_lidsidd_shotExp(lidsok, errshot=True,
-                                                          errExp=True,
+        lids, lidd, shot, Exp = self._get_lidsidd_shotExp(lidsok,
+                                                          errshot=False,
+                                                          errExp=False,
                                                           upper=True)
         # ----------------
         #   Trivial case
@@ -2771,7 +2772,8 @@ class MultiIDSLoader(object):
         # ---------------------------
         # Preliminary checks on data source consistency
         _, _, shot, Exp = self._get_lidsidd_shotExp(lids, upper=True,
-                                                    errshot=True, errExp=True)
+                                                    errshot=False,
+                                                    errExp=False)
         # get data
         out0 = self.get_data_all(dsig=dsig)
 
@@ -3327,7 +3329,8 @@ class MultiIDSLoader(object):
         # ---------------------------
         # Preliminary checks on data source consistency
         _, _, shot, Exp = self._get_lidsidd_shotExp([ids], upper=True,
-                                                    errshot=True, errExp=True)
+                                                    errshot=False,
+                                                    errExp=False)
         # -------------
         #   Input dicts
 
@@ -3574,7 +3577,8 @@ class MultiIDSLoader(object):
         # ---------------------------
         # Preliminary checks on data source consistency
         _, _, shot, Exp = self._get_lidsidd_shotExp([ids], upper=True,
-                                                    errshot=True, errExp=True)
+                                                    errshot=False,
+                                                    errExp=False)
         # -------------
         #   Input dicts
 

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -1120,7 +1120,7 @@ class MultiIDSLoader(object):
             set(ids).intersection(lidssynth).intersection(self._dids.keys()))
         if len(ids) == 0:
             msg = ("The provided ids must be:\n"
-                   + "\t- an is name (str)\n"
+                   + "\t- an ids name (str)\n"
                    + "\t- a list of ids names\n"
                    + "\t- an ids instance\n"
                    + "\t- None\n"
@@ -3083,6 +3083,12 @@ class MultiIDSLoader(object):
             msg = "ids {} has no attribute with '[chan]' index!".format(ids)
             raise Exception(msg)
         nch = len(getattr(self._dids[ids]['ids'][0], lch[ind[0]]))
+        if nch == 0:
+            msg = ('ids {} has 0 channels:\n'.format(ids)
+                   + '\t- len({}.{}) = 0\n'.format(ids, lch[ind[0]])
+                   + '\t- idd: {}'.format(self._dids[ids]['idd']))
+            raise Exception(msg)
+
 
         datacls, geomcls, dsig = self._checkformat_Data_dsig(ids, dsig,
                                                              data=data, X=X,
@@ -3114,23 +3120,27 @@ class MultiIDSLoader(object):
                     import pdb          # DB
                     pdb.set_trace()     # DB
                 continue
-            if isinstance(v0[0], np.ndarray):
-                dout[k0] = {'shapes': np.array([vv.shape for vv in v0]),
-                            'isnan': np.array([np.any(np.isnan(vv))
-                                               for vv in v0])}
-                if k0 == 'los_ptsRZPhi':
-                    dout[k0]['equal'] = np.array([np.allclose(vv[0, ...],
-                                                              vv[1, ...])
-                                                 for vv in v0])
-            elif type(v0[0]) in [int, float, np.int, np.float, str]:
-                dout[k0] = {'value': np.asarray(v0).ravel()}
-            else:
-                typv = type(v0[0])
-                k0str = (self._dshort[ids][k0]['str']
-                         if k0 in self._dshort[ids].keys() else k0)
-                msg = ("\nUnknown data type:\n"
-                       + "\ttype({}) = {}".format(k0str, typv))
-                raise Exception(msg)
+            try:
+                if isinstance(v0[0], np.ndarray):
+                    dout[k0] = {'shapes': np.array([vv.shape for vv in v0]),
+                                'isnan': np.array([np.any(np.isnan(vv))
+                                                   for vv in v0])}
+                    if k0 == 'los_ptsRZPhi':
+                        dout[k0]['equal'] = np.array([np.allclose(vv[0, ...],
+                                                                  vv[1, ...])
+                                                     for vv in v0])
+                elif type(v0[0]) in [int, float, np.int, np.float, str]:
+                    dout[k0] = {'value': np.asarray(v0).ravel()}
+                else:
+                    typv = type(v0[0])
+                    k0str = (self._dshort[ids][k0]['str']
+                             if k0 in self._dshort[ids].keys() else k0)
+                    msg = ("\nUnknown data type:\n"
+                           + "\ttype({}) = {}".format(k0str, typv))
+                    raise Exception(msg)
+            except Exception as err:
+                import pdb; pdb.set_trace() # DB
+                pass
 
         lsig = sorted(set(lsig).intersection(dout.keys()))
         lsigshape = sorted(set(lsigshape).intersection(dout.keys()))

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -3122,27 +3122,23 @@ class MultiIDSLoader(object):
                     import pdb          # DB
                     pdb.set_trace()     # DB
                 continue
-            try:
-                if isinstance(v0[0], np.ndarray):
-                    dout[k0] = {'shapes': np.array([vv.shape for vv in v0]),
-                                'isnan': np.array([np.any(np.isnan(vv))
-                                                   for vv in v0])}
-                    if k0 == 'los_ptsRZPhi':
-                        dout[k0]['equal'] = np.array([np.allclose(vv[0, ...],
-                                                                  vv[1, ...])
-                                                     for vv in v0])
-                elif type(v0[0]) in [int, float, np.int, np.float, str]:
-                    dout[k0] = {'value': np.asarray(v0).ravel()}
-                else:
-                    typv = type(v0[0])
-                    k0str = (self._dshort[ids][k0]['str']
-                             if k0 in self._dshort[ids].keys() else k0)
-                    msg = ("\nUnknown data type:\n"
-                           + "\ttype({}) = {}".format(k0str, typv))
-                    raise Exception(msg)
-            except Exception as err:
-                import pdb; pdb.set_trace() # DB
-                pass
+            if isinstance(v0[0], np.ndarray):
+                dout[k0] = {'shapes': np.array([vv.shape for vv in v0]),
+                            'isnan': np.array([np.any(np.isnan(vv))
+                                               for vv in v0])}
+                if k0 == 'los_ptsRZPhi':
+                    dout[k0]['equal'] = np.array([np.allclose(vv[0, ...],
+                                                              vv[1, ...])
+                                                 for vv in v0])
+            elif type(v0[0]) in [int, float, np.int, np.float, str]:
+                dout[k0] = {'value': np.asarray(v0).ravel()}
+            else:
+                typv = type(v0[0])
+                k0str = (self._dshort[ids][k0]['str']
+                         if k0 in self._dshort[ids].keys() else k0)
+                msg = ("\nUnknown data type:\n"
+                       + "\ttype({}) = {}".format(k0str, typv))
+                raise Exception(msg)
 
         lsig = sorted(set(lsig).intersection(dout.keys()))
         lsigshape = sorted(set(lsigshape).intersection(dout.keys()))

--- a/tofu/imas2tofu/_def.py
+++ b/tofu/imas2tofu/_def.py
@@ -424,7 +424,7 @@ _didsdiag = {
                       'ref2d': 'equilibrium.2drhotn'},
                             'dsig': {'core_sources': ['t'],
                                      'equilibrium': ['t']},
-                            'Brightness': True}},
+                            'Brightness': False}},
     'soft_x_rays': {'datacls': 'DataCam1D',
                     'geomcls': 'CamLOS1D',
                     'sig': {'t': 't',

--- a/tofu/scripts/tofucalc.py
+++ b/tofu/scripts/tofucalc.py
@@ -163,13 +163,14 @@ def main():
     parser.add_argument('-s', '--shot', type=int,
                         help='shot number', required=True)
     msg = 'username of the DB where the datafile is located'
-    parser.add_argument('-u','--user',help=msg, required=False, default=_USER)
+    parser.add_argument('-u', '--user',
+                        help=msg, required=False, default=_USER)
     msg = 'tokamak name of the DB where the datafile is located'
-    parser.add_argument('-tok','--tokamak',help=msg, required=False,
+    parser.add_argument('-tok', '--tokamak', help=msg, required=False,
                         default=_TOKAMAK)
-    parser.add_argument('-r','--run',help='run number',
+    parser.add_argument('-r', '--run',help='run number',
                         required=False, type=int, default=_RUN)
-    parser.add_argument('-v','--version',help='version number',
+    parser.add_argument('-v', '--version', help='version number',
                         required=False, type=str, default=_VERSION)
 
     # Equilibrium idd parameters
@@ -177,12 +178,12 @@ def main():
                         help='shot number for equilibrium, defaults to -s',
                         required=False, default=None)
     msg = 'username for the equilibrium, defaults to -u'
-    parser.add_argument('-u_eq','--user_eq',
+    parser.add_argument('-u_eq', '--user_eq',
                         help=msg, required=False, default=None)
     msg = 'tokamak for the equilibrium, defaults to -tok'
-    parser.add_argument('-tok_eq','--tokamak_eq',
+    parser.add_argument('-tok_eq', '--tokamak_eq',
                         help=msg, required=False, default=None)
-    parser.add_argument('-r_eq','--run_eq',
+    parser.add_argument('-r_eq', '--run_eq',
                         help='run number for the equilibrium, defaults to -r',
                         required=False, type=int, default=None)
 
@@ -191,12 +192,12 @@ def main():
                         help='shot number for profiles, defaults to -s',
                         required=False, default=None)
     msg = 'username for the profiles, defaults to -u'
-    parser.add_argument('-u_prof','--user_prof',
+    parser.add_argument('-u_prof', '--user_prof',
                         help=msg, required=False, default=None)
     msg = 'tokamak for the profiles, defaults to -tok'
-    parser.add_argument('-tok_prof','--tokamak_prof',
+    parser.add_argument('-tok_prof', '--tokamak_prof',
                         help=msg, required=False, default=None)
-    parser.add_argument('-r_prof','--run_prof',
+    parser.add_argument('-r_prof', '--run_prof',
                         help='run number for the profiles, defaults to -r',
                         required=False, type=int, default=None)
 

--- a/tofu/scripts/tofucalc.py
+++ b/tofu/scripts/tofucalc.py
@@ -168,7 +168,7 @@ def main():
     msg = 'tokamak name of the DB where the datafile is located'
     parser.add_argument('-tok', '--tokamak', help=msg, required=False,
                         default=_TOKAMAK)
-    parser.add_argument('-r', '--run',help='run number',
+    parser.add_argument('-r', '--run', help='run number',
                         required=False, type=int, default=_RUN)
     parser.add_argument('-v', '--version', help='version number',
                         required=False, type=str, default=_VERSION)

--- a/tofu/scripts/tofucalc.py
+++ b/tofu/scripts/tofucalc.py
@@ -100,6 +100,10 @@ def _get_exception(q, ids, qtype='quantity'):
 
 def call_tfcalcimas(shot=None, run=_RUN, user=_USER,
                     tokamak=_TOKAMAK, version=_VERSION,
+                    tokamak_eq=None, user_eq=None,
+                    shot_eq=None, run_eq=None,
+                    tokamak_prof=None, user_prof=None,
+                    shot_prof=None, run_prof=None,
                     ids=None, t0=_T0, extra=_EXTRA,
                     plot_compare=True, Brightness=None,
                     res=None, interp_t=None,
@@ -112,6 +116,10 @@ def call_tfcalcimas(shot=None, run=_RUN, user=_USER,
 
     tf.calc_from_imas(shot=shot, run=run, user=user,
                       tokamak=tokamak, version=version,
+                      tokamak_eq=tokamak_eq, user_eq=user_eq,
+                      shot_eq=shot_eq, run_eq=run_eq,
+                      tokamak_prof=tokamak_prof, user_prof=user_prof,
+                      shot_prof=shot_prof, run_prof=run_prof,
                       ids=ids, indch=indch, indch_auto=indch_auto,
                       plot_compare=plot_compare, extra=extra,
                       Brightness=Brightness, res=res, interp_t=interp_t,
@@ -151,17 +159,46 @@ def main():
     """%repr(_LIDS)
     parser = argparse.ArgumentParser(description = msg)
 
+    # Main idd parameters
     parser.add_argument('-s', '--shot', type=int,
                         help='shot number', required=True)
     msg = 'username of the DB where the datafile is located'
     parser.add_argument('-u','--user',help=msg, required=False, default=_USER)
     msg = 'tokamak name of the DB where the datafile is located'
-    parser.add_argument('-t','--tokamak',help=msg, required=False,
+    parser.add_argument('-tok','--tokamak',help=msg, required=False,
                         default=_TOKAMAK)
     parser.add_argument('-r','--run',help='run number',
                         required=False, type=int, default=_RUN)
     parser.add_argument('-v','--version',help='version number',
                         required=False, type=str, default=_VERSION)
+
+    # Equilibrium idd parameters
+    parser.add_argument('-s_eq', '--shot_eq', type=int,
+                        help='shot number for equilibrium, defaults to -s',
+                        required=False, default=None)
+    msg = 'username for the equilibrium, defaults to -u'
+    parser.add_argument('-u_eq','--user_eq',
+                        help=msg, required=False, default=None)
+    msg = 'tokamak for the equilibrium, defaults to -tok'
+    parser.add_argument('-tok_eq','--tokamak_eq',
+                        help=msg, required=False, default=None)
+    parser.add_argument('-r_eq','--run_eq',
+                        help='run number for the equilibrium, defaults to -r',
+                        required=False, type=int, default=None)
+
+    # Profile idd parameters
+    parser.add_argument('-s_prof', '--shot_prof', type=int,
+                        help='shot number for profiles, defaults to -s',
+                        required=False, default=None)
+    msg = 'username for the profiles, defaults to -u'
+    parser.add_argument('-u_prof','--user_prof',
+                        help=msg, required=False, default=None)
+    msg = 'tokamak for the profiles, defaults to -tok'
+    parser.add_argument('-tok_prof','--tokamak_prof',
+                        help=msg, required=False, default=None)
+    parser.add_argument('-r_prof','--run_prof',
+                        help='run number for the profiles, defaults to -r',
+                        required=False, type=int, default=None)
 
     msg = "ids from which to load diagnostics data, can be:\n%s"%repr(_LIDS)
     parser.add_argument('-i', '--ids', type=str, required=True,

--- a/tofu/scripts/tofuplot.py
+++ b/tofu/scripts/tofuplot.py
@@ -150,7 +150,7 @@ def main():
     parser = argparse.ArgumentParser(description = msg)
 
     parser.add_argument('-s', '--shot', type=int,
-                        help='shot number', required=True)
+                        help='shot number', required=True, nargs='+')
     msg = 'username of the DB where the datafile is located'
     parser.add_argument('-u','--user',help=msg, required=False, default=_USER)
     msg = 'tokamak name of the DB where the datafile is located'

--- a/tofu/utils.py
+++ b/tofu/utils.py
@@ -1045,7 +1045,6 @@ def load_from_imas(shot=None, run=None, user=None, tokamak=None, version=None,
     return dout
 
 
-
 def calc_from_imas(
     shot=None, run=None, user=None, tokamak=None, version=None,
     shot_eq=None, run_eq=None, user_eq=None, tokamak_eq=None,
@@ -1064,7 +1063,6 @@ def calc_from_imas(
     Read the profile from the same / another idd
 
     """
-
 
     # -------------------
     # import imas2tofu

--- a/tofu/utils.py
+++ b/tofu/utils.py
@@ -1055,7 +1055,8 @@ def calc_from_imas(
     Brightness=None, res=None, interp_t=None, extra=None,
     plot=None, plot_compare=True, sharex=False,
     input_file=None, output_file=None,
-    bck=True, indch_auto=True, t=None, init=None):
+    bck=True, indch_auto=True, t=None, init=None
+):
     """ Calculate syntehtic signal for a diagnostic
 
     Read the geometry from an idd (tokamak, user, shot, run)

--- a/tofu/utils.py
+++ b/tofu/utils.py
@@ -973,30 +973,34 @@ def load_from_imas(shot=None, run=None, user=None, tokamak=None, version=None,
                                          ids=lids)
 
         # export to instances
-        for ii in range(0,nids):
-            if returnas[ii] == 'Config':
-                dout[ss]['Config'].append(multi.to_Config(
-                    Name=Name, occ=occ,
-                    description_2d=description_2d, plot=False))
+        for ii in range(0, nids):
+            try:
+                if returnas[ii] == 'Config':
+                    dout[ss]['Config'].append(multi.to_Config(
+                        Name=Name, occ=occ,
+                        description_2d=description_2d, plot=False))
 
-            elif returnas[ii] == 'Plasma2D':
-                dout[ss]['Plasma2D'].append(multi.to_Plasma2D(Name=Name, occ=occ,
-                                                              tlim=tlim, dsig=dsig, t0=t0,
-                                                              plot=False, plot_sig=plot_sig,
-                                                              dextra=dextra, plot_X=plot_X,
-                                                              config=config,
-                                                              bck=bck))
-            elif returnas[ii] == 'Cam':
-                dout[ss]['Cam'].append(multi.to_Cam(Name=Name, occ=occ,
-                                                    ids=lids[ii], indch=indch, config=config,
-                                                    plot=False))
-            elif returnas[ii] == "Data":
-                dout[ss]['Data'].append(multi.to_Data(Name=Name, occ=occ,
-                                                      ids=lids[ii], tlim=tlim, dsig=dsig,
-                                                      config=config, data=data, X=X, indch=indch,
-                                                      indch_auto=indch_auto, t0=t0,
-                                                      dextra=dextra,
-                                                      plot=False, bck=bck))
+                elif returnas[ii] == 'Plasma2D':
+                    dout[ss]['Plasma2D'].append(multi.to_Plasma2D(
+                        Name=Name, occ=occ,
+                        tlim=tlim, dsig=dsig, t0=t0,
+                        plot=False, plot_sig=plot_sig,
+                        dextra=dextra, plot_X=plot_X,
+                        config=config, bck=bck))
+                elif returnas[ii] == 'Cam':
+                    dout[ss]['Cam'].append(multi.to_Cam(
+                        Name=Name, occ=occ,
+                        ids=lids[ii], indch=indch, config=config,
+                        plot=False))
+                elif returnas[ii] == "Data":
+                    dout[ss]['Data'].append(multi.to_Data(
+                        Name=Name, occ=occ,
+                        ids=lids[ii], tlim=tlim, dsig=dsig,
+                        config=config, data=data, X=X, indch=indch,
+                        indch_auto=indch_auto, t0=t0,
+                        dextra=dextra, plot=False, bck=bck))
+            except Exception as err:
+                warnings.warn('{}: {}'.format(lids[ii], str(err)))
 
     # -------------------
     # plot if relevant
@@ -1023,11 +1027,15 @@ def load_from_imas(shot=None, run=None, user=None, tokamak=None, version=None,
         elif nshot == 1 and nDat == 1:
             dout[shot[0]]['Data'][0].plot(bck=bck)
         elif nshot > 1 and nDat == 1:
+            tit = "{} - {}".format(dout[shot[0]]['Data'][0].Id.Exp,
+                                   dout[shot[0]]['Data'][0].Id.Diag)
             ld = [dout[ss]['Data'][0] for ss in shot[1:]]
-            dout[shot[0]]['Data'][0].plot_compare(ld, bck=bck)
+            dout[shot[0]]['Data'][0].plot_compare(ld, bck=bck, tit=tit)
         elif nshot == 1 and nDat > 1:
+            tit = multi._dids[dout[shot[0]]['Data'][0].Id.Diag]['idd']
             ld = dout[shot[0]]['Data'][1:]
-            dout[shot[0]]['Data'][0].plot_combine(ld, sharex=sharex, bck=bck)
+            dout[shot[0]]['Data'][0].plot_combine(ld, sharex=sharex,
+                                                  bck=bck, tit=tit)
 
     # return
     if nshot == 1 and nDat == 1:

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.3b4-25-gbeb454e8'
+__version__ = '1.4.3b4-26-gb6063651'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.3b4-18-geb488f73'
+__version__ = '1.4.3b4-21-g599d496f'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.3b4-21-g599d496f'
+__version__ = '1.4.3b4-22-g5c9d7ba7'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.3b4-16-g97538dff'
+__version__ = '1.4.3b4-18-geb488f73'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.3b4-27-gacaf2888'
+__version__ = '1.4.3b4-28-g91c648a7'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.3b4-23-g5e415fa4'
+__version__ = '1.4.3b4-24-g0306af83'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.3b4-26-gb6063651'
+__version__ = '1.4.3b4-27-gacaf2888'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.3b4-22-g5c9d7ba7'
+__version__ = '1.4.3b4-23-g5e415fa4'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.3b4-24-g0306af83'
+__version__ = '1.4.3b4-25-gbeb454e8'


### PR DESCRIPTION
Motivations:
--------------
* IMAS users may want to calculate synthetic signal using:
     - diagnostic geometry from an idd (tokamak / user / shot / run)
     - equilibrium from a different idd
     - 1d profiles from a third idd, or from a .mat file
* Also, the data visualization was not very robust when mutiple ids were called, it would fail if a single ids would fail loading

Main changes:
----------------
* Keeping in mind the correspondence betweeb short and long versions of the arguments:
   -tok = --tokamak
   - u = --user
   - s = --shot
   - r = --run
   - i = --ids

* Minor change: short version of --tokamak changed from -t to -tok
 
* Users of tofucalc can now provide:
     - (-tok, -u, -s, -r) for the geometry
     - (-tok_eq, -u_eq, -s_eq, -r_eq) for the equilibrium
     - (-tok_prof, -u_prof, -s_prof, -r_prof) for the profile

* tofucalc is consequently more flexible (warnings instead of errors if different shot or Exp)

* The data loading / visualization is now more robust (try / except)

* Minor bug fix: change Brightness to False in imas2tofu/_def.py for bolometer

Examples (IRFM intra only):
------------------------------
```
(base) [ DV226270 spica ~] module purge
(base) [ DV226270 spica ~] module load tools_dc/4
(base) [ DV226270 spica ~] tofuplot –s 55983 –i ece interferometer reflectometer_profile
(base) [ DV226270 spica ~] tofucalc –s 55983 –i interferometer
(base) [ DV226270 spica ~] tofucalc –s 55983 –i bremsstrahlung_visible –input_file path/to/input_file –output_file path/to/output_file
(base) [ DV226270 spica ~] tofucalc.py -s 55580 -i bolometer  -s_prof 55580 -r_prof 4 -u_prof CB165101 
```

Issues:
-------
Fixes, in devel, issue #373 