### PR TITLE
Issue #401: tofucalc bck kwdarg propagation

### DIFF
--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -2961,13 +2961,13 @@ class MultiIDSLoader(object):
                 if err_comp:
                     raise Exception(msg)
                 sig._dlabels = data.dlabels
-                data.plot_compare(sig)
+                data.plot_compare(sig, bck=bck)
             else:
-                sig.plot()
+                sig.plot(bck=bck)
             c0 = (plot_plasma
                   and dq.get('quant') is not None and '1d' in dq['quant'])
             if c0 is True:
-                plasma.plot(dq['quant'], X=dq['ref1d'])
+                plasma.plot(dq['quant'], X=dq['ref1d'], bck=bck)
         return sig
 
 

--- a/tofu/utils.py
+++ b/tofu/utils.py
@@ -1329,7 +1329,7 @@ def calc_from_imas(
                                       interp_t=interp_t,
                                       indch_auto=indch_auto,
                                       t0=t0, dextra=dextra,
-                                      coefs=coefs, plot=True,
+                                      coefs=coefs, plot=True, bck=bck,
                                       plot_compare=plot_compare)
 
     else:
@@ -1364,7 +1364,7 @@ def calc_from_imas(
                                                 quant='core_profiles.1dbrem',
                                                 ref1d='core_profiles.1drhotn',
                                                 ref2d='equilibrium.2drhotn',
-                                                coefs=coefs,
+                                                coefs=coefs, bck=bck,
                                                 Brightness=True, plot=plot)[0]
         if output_file is not None:
             try:

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.6-2-g7a0d42d4'
+__version__ = '1.4.6-12-g5f544677'


### PR DESCRIPTION
The bck kwdarg lets the user decide whether he/she wants all time steps / profiles to be displayed as a grey background on interactive plots.
This background is useful for working, but is not very pretty for publication figures, hence the introduction of bck to let the user choose whether to have the background or not.

tofucalc was not correctly using the kwdarg bck.

It was due to the fact bck had been correctly propagated to functions called by tofucalc

Example (IRFM intra only):
-----------------------------

With background (default)
```
./tofu/entrypoints/tofucalc.py -s 55323 -i bolometer -u_eq CB165101 -r_eq 1 -u_prof CB165101 -r_prof 1 &
```
![issues401_1](https://user-images.githubusercontent.com/5929562/84273750-58cf1380-ab2f-11ea-9f73-fe9ce15c5606.png)


Without background:
```
./tofu/entrypoints/tofucalc.py -s 55323 -i bolometer -u_eq CB165101 -r_eq 1 -u_prof CB165101 -r_prof 1 -bck False &
```
![issues401_2](https://user-images.githubusercontent.com/5929562/84273767-5e2c5e00-ab2f-11ea-8ae8-a86fd6f324e7.png)



Issues:
--------
Fixes, in devel, issue #401 