### PR TITLE
Issue #403 : Single tofu bash command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,8 @@ install:
 script:
 - cd $HOME
 - nosetests tofu.tests --nocapture -v --with-id --with-timer --with-coverage --cover-package=tofu
-- tofu-version
-- tofu-custom
+- tofu --version
+- tofu custom
 
 after_success:
 - codecov

--- a/scripts/_dparser.py
+++ b/scripts/_dparser.py
@@ -205,6 +205,7 @@ def parser_plot():
     _LIDS_DIAG = MultiIDSLoader._lidsdiag
     _LIDS_PLASMA = tf.imas2tofu.MultiIDSLoader._lidsplasma
     _LIDS = _LIDS_DIAG + _LIDS_PLASMA + tf.utils._LIDS_CUSTOM
+
     msg = """Fast interactive visualization tool for diagnostics data in
     imas
 
@@ -300,6 +301,42 @@ def parser_plot():
 
 def parser_calc():
 
+    tf, MultiIDSLoader, _defscripts = get_mods()
+
+    _LIDS_DIAG = MultiIDSLoader._lidsdiag
+    _LIDS_PLASMA = tf.imas2tofu.MultiIDSLoader._lidsplasma
+    _LIDS = _LIDS_DIAG + _LIDS_PLASMA + tf.utils._LIDS_CUSTOM
+
+    # Parse input arguments
+    msg = """Fast interactive visualization tool for diagnostics data in
+    imas
+
+    This is merely a wrapper around the function tofu.calc_from_imas()
+    It calculates synthetic signal (from imas) and displays it from the following
+    ids:
+        %s
+    """%repr(_LIDS)
+
+    ddef = {
+        # User-customizable
+        'run': _defscripts._TFCALC_RUN,
+        'user': _defscripts._TFCALC_USER,
+        'tokamak': _defscripts._TFCALC_TOKAMAK,
+        'version': _defscripts._TFCALC_VERSION,
+        't0': _defscripts._TFCALC_T0,
+        'tlim': None,
+        'sharex': _defscripts._TFCALC_SHAREX,
+        'bck': _defscripts._TFCALC_BCK,
+        'extra': _defscripts._TFCALC_EXTRA,
+        'indch_auto': _defscripts._TFCALC_INDCH_AUTO,
+        'coefs': None,
+
+        # Non user-customizable
+        'lids_plasma': _LIDS_PLASMA,
+        'lids_diag': _LIDS_DIAG,
+        'lids': _LIDS,
+    }
+
     parser = argparse.ArgumentParser(description = msg)
 
     # Main idd parameters
@@ -386,7 +423,7 @@ def parser_calc():
     parser.add_argument('-bck', '--background', type=_str2bool, required=False,
                         help='Plot data enveloppe as grey background ?',
                         default=ddef['bck'], const=True, nargs='?')
-    return parser
+    return ddef, parser
 
 
 # #############################################################################

--- a/scripts/_dparser.py
+++ b/scripts/_dparser.py
@@ -1,0 +1,402 @@
+import sys
+import os
+import getpass
+import argparse
+
+
+# tofu
+# test if in a tofu git repo
+_HERE = os.path.abspath(os.path.dirname(__file__))
+_TOFUPATH = os.path.dirname(_HERE)
+
+
+def get_mods():
+    istofugit = False
+    if '.git' in os.listdir(_TOFUPATH) and 'tofu' in _TOFUPATH:
+        istofugit = True
+
+    if istofugit:
+        # Make sure we load the corresponding tofu
+        sys.path.insert(1, _TOFUPATH)
+        import tofu as tf
+        from tofu.imas2tofu import MultiIDSLoader
+        _ = sys.path.pop(1)
+    else:
+        import tofu as tf
+        from tofu.imas2tofu import MultiIDSLoader
+
+
+    # default parameters
+    pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_scripts_def.py')
+    if os.path.isfile(pfe):
+        # Make sure we load the user-specific file
+        # sys.path method
+        # sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
+        # import _scripts_def as _defscripts
+        # _ = sys.path.pop(1)
+        # importlib method
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("_defscripts", pfe)
+        _defscripts = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(_defscripts)
+    else:
+        try:
+            import tofu.entrypoints._def as _defscripts
+        except Exception as err:
+            from . import _def as _defscripts
+    return tf, MultiIDSLoader, _defscripts
+
+
+# #############################################################################
+#       utility functions
+# #############################################################################
+
+
+def _str2bool(v):
+    if isinstance(v, bool):
+        return v
+    elif v.lower() in ['yes', 'true', 'y', 't', '1']:
+        return True
+    elif v.lower() in ['no', 'false', 'n', 'f', '0']:
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected!')
+
+
+def _str2boolstr(v):
+    if isinstance(v, bool):
+        return v
+    elif isinstance(v, str):
+        if v.lower() in ['yes', 'true', 'y', 't', '1']:
+            return True
+        elif v.lower() in ['no', 'false', 'n', 'f', '0']:
+            return False
+        elif v.lower() == 'none':
+            return None
+        else:
+            return v
+    else:
+        raise argparse.ArgumentTypeError('Boolean or str expected!')
+
+
+def _str2tlim(v):
+    c0 = (v.isdigit()
+          or ('.' in v
+              and len(v.split('.')) == 2
+              and all([vv.isdigit() for vv in v.split('.')])))
+    if c0 is True:
+        v = float(v)
+    elif v.lower() == 'none':
+        v = None
+    return v
+
+
+# #############################################################################
+#       Parser for tofu version
+# #############################################################################
+
+
+def parser_version():
+    msg = """ Get tofu version from bash optionally set an enviroment variable
+
+    If run from a git repo containing tofu, simply returns git describe
+    Otherwise reads the tofu version stored in tofu/version.py
+
+    """
+    ddef = {
+        'path': os.path.join(_TOFUPATH, 'tofu'),
+        'envvar': False,
+        'verb': True,
+        'warn': True,
+        'force': False,
+        'name': 'TOFU_VERSION',
+    }
+
+    # Instanciate parser
+    parser = argparse.ArgumentParser(description=msg)
+
+    # Define input arguments
+    parser.add_argument('-p', '--path',
+                        type=str,
+                        help='tofu source directory where version.py is found',
+                        required=False, default=ddef['path'])
+    parser.add_argument('-v', '--verb',
+                        type=_str2bool,
+                        help='flag indicating whether to print the version',
+                        required=False, default=ddef['verb'])
+    parser.add_argument('-ev', '--envvar',
+                        type=_str2boolstr,
+                        help='name of the environment variable to set, if any',
+                        required=False, default=ddef['envvar'])
+    parser.add_argument('-w', '--warn',
+                        type=_str2bool,
+                        help=('flag indicatin whether to print a warning when'
+                              + 'the desired environment variable (envvar)'
+                              + 'already exists'),
+                        required=False, default=ddef['warn'])
+    parser.add_argument('-f', '--force',
+                        type=_str2bool,
+                        help=('flag indicating whether to force the update of '
+                              + 'the desired environment variable (envvar)'
+                              + ' even if it already exists'),
+                        required=False, default=ddef['force'])
+
+    return ddef, parser
+
+
+# #############################################################################
+#       Parser for tofu custom
+# #############################################################################
+
+
+def parser_custom():
+    msg = """ Create a local copy of tofu default parameters
+
+    This creates a local copy, in your home, of tofu default parameters
+    A directory .tofu is created in your home directory
+    In this directory, modules containing default parameters are copied
+    You can then customize them without impacting other users
+
+    """
+    _USER = getpass.getuser()
+    _USER_HOME = os.path.expanduser('~')
+
+    ddef = {
+        'target': os.path.join(_USER_HOME, '.tofu'),
+        'source': os.path.join(_TOFUPATH, 'tofu'),
+        'files': ['_imas2tofu_def.py', '_entrypoints_def.py'],
+        'directories': ['openadas2tofu'],
+    }
+
+    # Instanciate parser
+    parser = argparse.ArgumentParser(description=msg)
+
+    # Define input arguments
+    parser.add_argument('-s', '--source',
+                        type=str,
+                        help='tofu source directory',
+                        required=False,
+                        default=ddef['source'])
+    parser.add_argument('-t', '--target',
+                        type=str,
+                        help=('directory where .tofu/ should be created'
+                              + ' (default: {})'.format(ddef['target'])),
+                        required=False,
+                        default=ddef['target'])
+    parser.add_argument('-f', '--files',
+                        type=str,
+                        help='list of files to be copied',
+                        required=False,
+                        nargs='+',
+                        default=ddef['files'],
+                        choices=ddef['files'])
+    return ddef, parser
+
+
+# #############################################################################
+#       Parser for tofu plot
+# #############################################################################
+
+
+def parser_plot():
+
+    tf, MultiIDSLoader, _defscripts = get_mods()
+
+    _LIDS_DIAG = MultiIDSLoader._lidsdiag
+    _LIDS_PLASMA = tf.imas2tofu.MultiIDSLoader._lidsplasma
+    _LIDS = _LIDS_DIAG + _LIDS_PLASMA + tf.utils._LIDS_CUSTOM
+    msg = """Fast interactive visualization tool for diagnostics data in
+    imas
+
+    This is merely a wrapper around the function tofu.load_from_imas()
+    It loads (from imas) and displays diagnostics data from the following
+    ids:
+        %s
+    """%repr(_LIDS)
+
+    ddef = {
+        # User-customizable
+        'run': _defscripts._TFPLOT_RUN,
+        'user': _defscripts._TFPLOT_USER,
+        'tokamak': _defscripts._TFPLOT_TOKAMAK,
+        'version': _defscripts._TFPLOT_VERSION,
+        't0': _defscripts._TFPLOT_T0,
+        'tlim': None,
+        'sharex': _defscripts._TFPLOT_SHAREX,
+        'bck': _defscripts._TFPLOT_BCK,
+        'extra': _defscripts._TFPLOT_EXTRA,
+        'indch_auto': _defscripts._TFPLOT_INDCH_AUTO,
+
+        # Non user-customizable
+        'lids_plasma': _LIDS_PLASMA,
+        'lids_diag': _LIDS_DIAG,
+        'lids': _LIDS,
+    }
+
+    parser = argparse.ArgumentParser(description = msg)
+
+    parser.add_argument('-s', '--shot', type=int,
+                        help='shot number', required=False, nargs='+')
+    msg = 'username of the DB where the datafile is located'
+    parser.add_argument('-u','--user',help=msg, required=False,
+                        default=ddef['user'])
+    msg = 'tokamak name of the DB where the datafile is located'
+    parser.add_argument('-tok', '--tokamak', help=msg, required=False,
+                        default=ddef['tokamak'])
+    parser.add_argument('-r', '--run', help='run number',
+                        required=False, type=int,
+                        default=ddef['run'])
+    parser.add_argument('-v', '--version', help='version number',
+                        required=False, type=str,
+                        default=ddef['version'])
+
+    msg = ("ids from which to load diagnostics data,"
+           + " can be:\n%s"%repr(ddef['lids']))
+    parser.add_argument('-i', '--ids', type=str, required=True,
+                        help=msg, nargs='+', choices=ddef['lids'])
+    parser.add_argument('-q', '--quantity', type=str, required=False,
+                        help='Desired quantity from the plasma ids',
+                        nargs='+', default=None)
+    parser.add_argument('-X', '--X', type=str, required=False,
+                        help='Quantity from the plasma ids to use for abscissa',
+                        nargs='+', default=None)
+    parser.add_argument('-t0', '--t0', type=str, required=False,
+                        help='Reference time event setting t = 0',
+                        default=ddef['t0'])
+    parser.add_argument('-t', '--t', type=float, required=False,
+                        help='Input time when needed')
+    parser.add_argument('-tl', '--tlim', type=_str2tlim,
+                        required=False,
+                        help='limits of the time interval',
+                        nargs='+', default=ddef['tlim'])
+    parser.add_argument('-dR_sep', '--dR_sep', type=float, required=False,
+                        help='Distance to separatrix from r_ext to plot'
+                        + ' 10 magnetic field lines')
+    parser.add_argument('-init', '--init', type=float, required=False, nargs=3,
+                        help='Manual coordinates of point that a RED magnetic'
+                        + ' field line will cross on graphics,'
+                        + ' give coordinates as: R [m], Phi [rad], Z [m]')
+    parser.add_argument('-ich', '--indch', type=int, required=False,
+                        help='indices of channels to be loaded',
+                        nargs='+', default=None)
+    parser.add_argument('-ichauto', '--indch_auto', type=_str2bool,
+                        required=False,
+                        help='automatically determine indices of'
+                        + ' channels to be loaded', default=ddef['indch_auto'])
+    parser.add_argument('-e', '--extra', type=_str2bool, required=False,
+                        help='If True loads separatrix and heating power',
+                        default=ddef['extra'])
+    parser.add_argument('-sx', '--sharex', type=_str2bool, required=False,
+                        help='Should X axis be shared between diag ids ?',
+                        default=ddef['sharex'], const=True, nargs='?')
+    parser.add_argument('-bck', '--background', type=_str2bool, required=False,
+                        help='Plot data enveloppe as grey background ?',
+                        default=ddef['bck'], const=True, nargs='?')
+    return ddef, parser
+
+# #############################################################################
+#       Parser for tofu calc
+# #############################################################################
+
+def parser_calc():
+
+    parser = argparse.ArgumentParser(description = msg)
+
+    # Main idd parameters
+    parser.add_argument('-s', '--shot', type=int,
+                        help='shot number', required=True)
+    msg = 'username of the DB where the datafile is located'
+    parser.add_argument('-u', '--user',
+                        help=msg, required=False, default=ddef['user'])
+    msg = 'tokamak name of the DB where the datafile is located'
+    parser.add_argument('-tok', '--tokamak', help=msg, required=False,
+                        default=ddef['tokamak'])
+    parser.add_argument('-r', '--run', help='run number',
+                        required=False, type=int, default=ddef['run'])
+    parser.add_argument('-v', '--version', help='version number',
+                        required=False, type=str, default=ddef['version'])
+
+    # Equilibrium idd parameters
+    parser.add_argument('-s_eq', '--shot_eq', type=int,
+                        help='shot number for equilibrium, defaults to -s',
+                        required=False, default=None)
+    msg = 'username for the equilibrium, defaults to -u'
+    parser.add_argument('-u_eq', '--user_eq',
+                        help=msg, required=False, default=None)
+    msg = 'tokamak for the equilibrium, defaults to -tok'
+    parser.add_argument('-tok_eq', '--tokamak_eq',
+                        help=msg, required=False, default=None)
+    parser.add_argument('-r_eq', '--run_eq',
+                        help='run number for the equilibrium, defaults to -r',
+                        required=False, type=int, default=None)
+
+    # Profile idd parameters
+    parser.add_argument('-s_prof', '--shot_prof', type=int,
+                        help='shot number for profiles, defaults to -s',
+                        required=False, default=None)
+    msg = 'username for the profiles, defaults to -u'
+    parser.add_argument('-u_prof', '--user_prof',
+                        help=msg, required=False, default=None)
+    msg = 'tokamak for the profiles, defaults to -tok'
+    parser.add_argument('-tok_prof', '--tokamak_prof',
+                        help=msg, required=False, default=None)
+    parser.add_argument('-r_prof', '--run_prof',
+                        help='run number for the profiles, defaults to -r',
+                        required=False, type=int, default=None)
+
+    msg = ("ids from which to load diagnostics data,"
+           + " can be:\n%s"%repr(ddef['lids']))
+    parser.add_argument('-i', '--ids', type=str, required=True,
+                        help=msg, nargs='+', choices=ddef['lids'])
+    parser.add_argument('-B', '--Brightness', type=bool, required=False,
+                        help='Whether to express result as brightness',
+                        default=None)
+    parser.add_argument('-res', '--res', type=float, required=False,
+                        help='Space resolution for the LOS-discretization',
+                        default=None)
+    parser.add_argument('-t0', '--t0', type=str, required=False,
+                        help='Reference time event setting t = 0',
+                        default=ddef['t0'])
+    parser.add_argument('-tl', '--tlim', type=_str2tlim,
+                        required=False,
+                        help='limits of the time interval',
+                        nargs='+', default=ddef['tlim'])
+    parser.add_argument('-c', '--coefs', type=float, required=False,
+                        help='Corrective coefficient, if any',
+                        default=ddef['coefs'])
+    parser.add_argument('-ich', '--indch', type=int, required=False,
+                        help='indices of channels to be loaded',
+                        nargs='+', default=None)
+    parser.add_argument('-ichauto', '--indch_auto', type=bool, required=False,
+                        help=('automatically determine indices '
+                              + 'of channels to be loaded'),
+                        default=ddef['indch_auto'])
+    parser.add_argument('-e', '--extra', type=_str2bool, required=False,
+                        help='If True loads separatrix and heating power',
+                        default=ddef['extra'])
+    parser.add_argument('-sx', '--sharex', type=_str2bool, required=False,
+                        help='Should X axis be shared between diag ids?',
+                        default=ddef['sharex'], const=True, nargs='?')
+    parser.add_argument('-if', '--input_file', type=str, required=False,
+                        help='mat file from which to load core_profiles',
+                        default=None)
+    parser.add_argument('-of', '--output_file', type=str, required=False,
+                        help='mat file into which to save synthetic signal',
+                        default=None)
+    parser.add_argument('-bck', '--background', type=_str2bool, required=False,
+                        help='Plot data enveloppe as grey background ?',
+                        default=ddef['bck'], const=True, nargs='?')
+    return parser
+
+
+# #############################################################################
+#       Parser dict
+# #############################################################################
+
+
+_DPARSER = {
+    'version': parser_version,
+    'custom': parser_custom,
+    'plot': parser_plot,
+    'calc': parser_calc,
+}

--- a/scripts/_dparser.py
+++ b/scripts/_dparser.py
@@ -25,7 +25,6 @@ def get_mods():
         import tofu as tf
         from tofu.imas2tofu import MultiIDSLoader
 
-
     # default parameters
     pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_scripts_def.py')
     if os.path.isfile(pfe):
@@ -212,8 +211,8 @@ def parser_plot():
     This is merely a wrapper around the function tofu.load_from_imas()
     It loads (from imas) and displays diagnostics data from the following
     ids:
-        %s
-    """%repr(_LIDS)
+        {}
+    """.format(_LIDS)
 
     ddef = {
         # User-customizable
@@ -234,12 +233,12 @@ def parser_plot():
         'lids': _LIDS,
     }
 
-    parser = argparse.ArgumentParser(description = msg)
+    parser = argparse.ArgumentParser(description=msg)
 
     parser.add_argument('-s', '--shot', type=int,
                         help='shot number', required=False, nargs='+')
     msg = 'username of the DB where the datafile is located'
-    parser.add_argument('-u','--user',help=msg, required=False,
+    parser.add_argument('-u', '--user', help=msg, required=False,
                         default=ddef['user'])
     msg = 'tokamak name of the DB where the datafile is located'
     parser.add_argument('-tok', '--tokamak', help=msg, required=False,
@@ -252,14 +251,14 @@ def parser_plot():
                         default=ddef['version'])
 
     msg = ("ids from which to load diagnostics data,"
-           + " can be:\n%s"%repr(ddef['lids']))
+           + " can be:\n{}".format(ddef['lids']))
     parser.add_argument('-i', '--ids', type=str, required=True,
                         help=msg, nargs='+', choices=ddef['lids'])
     parser.add_argument('-q', '--quantity', type=str, required=False,
                         help='Desired quantity from the plasma ids',
                         nargs='+', default=None)
     parser.add_argument('-X', '--X', type=str, required=False,
-                        help='Quantity from the plasma ids to use for abscissa',
+                        help='Quantity from the plasma ids for abscissa',
                         nargs='+', default=None)
     parser.add_argument('-t0', '--t0', type=str, required=False,
                         help='Reference time event setting t = 0',
@@ -295,9 +294,11 @@ def parser_plot():
                         default=ddef['bck'], const=True, nargs='?')
     return ddef, parser
 
+
 # #############################################################################
 #       Parser for tofu calc
 # #############################################################################
+
 
 def parser_calc():
 
@@ -312,10 +313,10 @@ def parser_calc():
     imas
 
     This is merely a wrapper around the function tofu.calc_from_imas()
-    It calculates synthetic signal (from imas) and displays it from the following
+    It calculates and dsplays synthetic signal (from imas) from the following
     ids:
-        %s
-    """%repr(_LIDS)
+        {}
+    """.format(_LIDS)
 
     ddef = {
         # User-customizable
@@ -337,7 +338,7 @@ def parser_calc():
         'lids': _LIDS,
     }
 
-    parser = argparse.ArgumentParser(description = msg)
+    parser = argparse.ArgumentParser(description=msg)
 
     # Main idd parameters
     parser.add_argument('-s', '--shot', type=int,
@@ -382,7 +383,7 @@ def parser_calc():
                         required=False, type=int, default=None)
 
     msg = ("ids from which to load diagnostics data,"
-           + " can be:\n%s"%repr(ddef['lids']))
+           + " can be:\n{}".format(ddef['lids']))
     parser.add_argument('-i', '--ids', type=str, required=True,
                         help=msg, nargs='+', choices=ddef['lids'])
     parser.add_argument('-B', '--Brightness', type=bool, required=False,

--- a/scripts/tofu_bash.py
+++ b/scripts/tofu_bash.py
@@ -4,7 +4,6 @@
 import sys
 import os
 import argparse
-import warnings
 
 
 # import parser dict
@@ -61,8 +60,10 @@ def tofu_bash(option=None, ddef=None, **kwdargs):
         tofuplot.call_tfloadimas(ddef=ddef, **kwdargs)
 
     elif option == 'calc':
-        import pdb; pdb.set_trace()     # DB
-        pass
+        sys.path.insert(1, _ENTRYPOINTS_PATH)
+        import tofucalc
+        _ = sys.path.pop(1)
+        tofucalc.call_tfcalcimas(ddef=ddef, **kwdargs)
 
 
 ###################################################

--- a/scripts/tofu_bash.py
+++ b/scripts/tofu_bash.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+# Built-in
+import sys
+import os
+import argparse
+import warnings
+
+
+# import parser dict
+from _dparser import _DPARSER
+
+
+_HERE = os.path.abspath(os.path.dirname(__file__))
+_TOFUPATH = os.path.dirname(_HERE)
+_ENTRYPOINTS_PATH = os.path.join(_TOFUPATH, 'tofu', 'entrypoints')
+
+
+###################################################
+###################################################
+#       default values
+###################################################
+
+
+_LOPTIONS = ['--version', 'custom', 'plot', 'calc']
+_LOPSTRIP = [ss.strip('--') for ss in _LOPTIONS]
+
+
+###################################################
+###################################################
+#       function
+###################################################
+
+
+def tofu_bash(option=None, ddef=None, **kwdargs):
+    """ Print tofu version and / or store in environment variable """
+
+
+    # --------------
+    # Check inputs
+    if option not in _LOPSTRIP:
+        msg = ("Provided option is not acceptable:\n"
+               + "\t- available: {}\n".format(_LOPSTRIP)
+               + "\t- provided:  {}".format(option))
+        raise Exception(msg)
+
+    # --------------
+    # call corresponding bash command
+    if option == 'version':
+        import tofuversion
+        tofuversion.get_version(ddef=ddef, **kwdargs)
+
+    elif option == 'custom':
+        import tofucustom
+        tofucustom.custom(ddef=ddef, **kwdargs)
+
+    elif option == 'plot':
+        sys.path.insert(1, _ENTRYPOINTS_PATH)
+        import tofuplot
+        _ = sys.path.pop(1)
+        tofuplot.call_tfloadimas(ddef=ddef, **kwdargs)
+
+    elif option == 'calc':
+        import pdb; pdb.set_trace()     # DB
+        pass
+
+
+###################################################
+###################################################
+#       bash call (main)
+###################################################
+
+
+def main():
+    # Parse input arguments
+    msg = """ Get tofu version from bash optionally set an enviroment variable
+
+    If run from a git repo containing tofu, simply returns git describe
+    Otherwise reads the tofu version stored in tofu/version.py
+
+    """
+
+    # Instanciate parser
+    parser = argparse.ArgumentParser(description=msg)
+
+    # Define input arguments
+    parser.add_argument('option',
+                        nargs='?',
+                        type=str,
+                        default='None')
+    parser.add_argument('-v', '--version',
+                        help='get tofu current version',
+                        required=False,
+                        action='store_true')
+    parser.add_argument('kwd', nargs='?', type=str, default='None')
+
+    if sys.argv[1] not in _LOPTIONS:
+        msg = ("Provided option is not acceptable:\n"
+               + "\t- available: {}\n".format(_LOPTIONS)
+               + "\t- provided:  {}".format(sys.argv[1]))
+        raise Exception(msg)
+    if len(sys.argv) > 2:
+        if any([ss in sys.argv[2:] for ss in _LOPTIONS]):
+            lopt = [ss for ss in sys.argv[1:] if ss in _LOPTIONS]
+            msg = ("Only one option can be provided!\n"
+                   + "\t- provided: {}".format(lopt))
+            raise Exception(msg)
+
+    option = sys.argv[1].strip('--')
+    ddef, parser = _DPARSER[option]()
+    if len(sys.argv) > 2:
+        kwdargs = dict(parser.parse_args(sys.argv[2:])._get_kwargs())
+    else:
+        kwdargs = {}
+
+    # Call function
+    tofu_bash(option=option, ddef=ddef, **kwdargs)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tofu_bash.py
+++ b/scripts/tofu_bash.py
@@ -34,7 +34,6 @@ _LOPSTRIP = [ss.strip('--') for ss in _LOPTIONS]
 def tofu_bash(option=None, ddef=None, **kwdargs):
     """ Print tofu version and / or store in environment variable """
 
-
     # --------------
     # Check inputs
     if option not in _LOPSTRIP:

--- a/scripts/tofu_bash.py
+++ b/scripts/tofu_bash.py
@@ -7,6 +7,7 @@ import argparse
 
 
 # import parser dict
+print(sys.path[:3])
 from _dparser import _DPARSER
 
 

--- a/scripts/tofu_bash.py
+++ b/scripts/tofu_bash.py
@@ -48,11 +48,15 @@ def tofu_bash(option=None, ddef=None, **kwdargs):
     # --------------
     # call corresponding bash command
     if option == 'version':
+        sys.path.insert(1, _HERE)
         import tofuversion
+        _ = sys.path.pop(1)
         tofuversion.get_version(ddef=ddef, **kwdargs)
 
     elif option == 'custom':
+        sys.path.insert(1, _HERE)
         import tofucustom
+        _ = sys.path.pop(1)
         tofucustom.custom(ddef=ddef, **kwdargs)
 
     elif option == 'plot':

--- a/scripts/tofu_bash.py
+++ b/scripts/tofu_bash.py
@@ -6,12 +6,14 @@ import os
 import argparse
 
 
-# import parser dict
-print(sys.path[:3])
-from _dparser import _DPARSER
-
-
 _HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+# import parser dict
+sys.path.insert(1, _HERE)
+from _dparser import _DPARSER
+_ = sys.path.pop(1)
+
 _TOFUPATH = os.path.dirname(_HERE)
 _ENTRYPOINTS_PATH = os.path.join(_TOFUPATH, 'tofu', 'entrypoints')
 

--- a/scripts/tofucustom.py
+++ b/scripts/tofucustom.py
@@ -7,19 +7,8 @@ from shutil import copyfile
 import argparse
 
 
-###################################################
-###################################################
-#       default values
-###################################################
-
-
-_SOURCE = os.path.join(os.path.abspath(os.path.join(
-    os.path.dirname(__file__), '..')), 'tofu')
-_USER = getpass.getuser()
-_USER_HOME = os.path.expanduser('~')
-_TARGET = os.path.join(_USER_HOME, '.tofu')
-_LF = ['_imas2tofu_def.py', '_entrypoints_def.py']
-_LD = ['openadas2tofu']
+# import parser dict
+from _dparser import _DPARSER
 
 
 ###################################################
@@ -28,19 +17,30 @@ _LD = ['openadas2tofu']
 ###################################################
 
 
-def custom(target=_TARGET, source=_SOURCE,
-           files=_LF, directories=_LD):
+def custom(target=None, source=None,
+           files=None, directories=None, ddef=None):
+
+    # --------------
+    # Check inputs
+    kwd = locals()
+    for k0 in set(ddef.keys()).intersection(kwd.keys()):
+        if kwd[k0] is None:
+            kwd[k0] = ddef[k0]
+    target, source = kwd['target'], kwd['source']
+    files, directories = kwd['files'], kwd['directories']
 
     # Caveat (up to now only relevant for _TARGET)
-    if target != _TARGET:
+    if target != ddef['target']:
         msg = ""
         raise Exception(msg)
 
     # Check files
     if isinstance(files, str):
         files = [files]
-    if not isinstance(files, list) or any([ff not in _LF for ff in files]):
-        msg = "All files should be in {}".format(_LF)
+    c0 = (not isinstance(files, list)
+          or any([ff not in ddef['files'] for ff in files]))
+    if c0 is True:
+        msg = "All files should be in {}".format(ddef['files'])
         raise Exception(msg)
 
     # Try creating directory and copying modules
@@ -82,43 +82,14 @@ def custom(target=_TARGET, source=_SOURCE,
 
 def main():
     # Parse input arguments
-    msg = """ Create a local copy of tofu default parameters
-
-    This creates a local copy, in your home, of tofu default parameters
-    A directory .tofu is created in your home directory
-    In this directory, modules containing default parameters are copied
-    You can then customize them without impacting other users
-
-    """
-
     # Instanciate parser
-    parser = argparse.ArgumentParser(description=msg)
-
-    # Define input arguments
-    parser.add_argument('-s', '--source',
-                        type=str,
-                        help='tofu source directory',
-                        required=False,
-                        default=_SOURCE)
-    parser.add_argument('-t', '--target',
-                        type=str,
-                        help=('directory where .tofu/ should be created'
-                              + ' (default: {})'.format(_TARGET)),
-                        required=False,
-                        default=_TARGET)
-    parser.add_argument('-f', '--files',
-                        type=str,
-                        help='list of files to be copied',
-                        required=False,
-                        nargs='+',
-                        default=_LF,
-                        choices=_LF)
+    ddef, parser = _DPARSER['custom']()
 
     # Parse arguments
     args = parser.parse_args()
 
     # Call function
-    custom(**dict(args._get_kwargs()))
+    custom(ddef=ddef, **dict(args._get_kwargs()))
 
 
 if __name__ == '__main__':

--- a/scripts/tofucustom.py
+++ b/scripts/tofucustom.py
@@ -2,9 +2,7 @@
 
 # Built-in
 import os
-import getpass
 from shutil import copyfile
-import argparse
 
 
 # import parser dict
@@ -79,6 +77,7 @@ def custom(target=None, source=None,
 ###################################################
 #       bash call (main)
 ###################################################
+
 
 def main():
     # Parse input arguments

--- a/scripts/tofuversion.py
+++ b/scripts/tofuversion.py
@@ -6,17 +6,8 @@ import argparse
 import warnings
 
 
-###################################################
-###################################################
-#       default values
-###################################################
-
-
-# _TOFUPATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-_TOFUPATH = os.path.join(os.path.join(os.path.dirname(__file__), '..'), 'tofu')
-_DBOOL = {'verb': True, 'warn': True, 'force': False}
-_ENVVAR = False
-_NAME = 'TOFU_VERSION'
+# import parser dict
+from _dparser import _DPARSER
 
 
 ###################################################
@@ -26,36 +17,40 @@ _NAME = 'TOFU_VERSION'
 
 
 def get_version(verb=None, envvar=None,
-                path=_TOFUPATH, warn=None, force=None):
+                path=None, warn=None, force=None, ddef=None):
     """ Print tofu version and / or store in environment variable """
 
     # --------------
     # Check inputs
+    kwd = locals()
+    for k0 in set(ddef.keys()).intersection(kwd.keys()):
+        if kwd[k0] is None:
+            kwd[k0] = ddef[k0]
+    verb, envvar, path = kwd['verb'], kwd['envvar'], kwd['path']
+    warn, force = kwd['warn'], kwd['force']
 
     # verb, warn, force
     dbool = {'verb': verb, 'warn': warn, 'force': force}
     for k0, v0 in dbool.items():
         if v0 is None:
-            dbool[k0] = _DBOOL[k0]
+            dbool[k0] = ddef[k0]
         if not isinstance(dbool[k0], bool):
             msg = ("Arg {} must be a bool\n".format(k0)
                    + "\t- provided: {}".format(dbool[k0]))
             raise Exception(msg)
 
     # envvar
-    if envvar is None:
-        envvar = _ENVVAR
     if isinstance(envvar, bool):
         if envvar is True:
-            envvar = _NAME
+            envvar = ddef['name']
     elif isinstance(envvar, str):
         envvar = envvar.upper()
     else:
         msg = ("Arg envvar must be either:\n"
-               + "\t- None:   set to default ({})\n".format(_ENVVAR)
-               + "\t- False:  no setting of environment variable\n"
-               + "\t- True:   set default env. variable ({})\n".format(_NAME)
-               + "\t- str:    set provided env. variable\n\n"
+               + "\t- None:  set to default ({})\n".format(ddef['envvar'])
+               + "\t- False: no setting of environment variable\n"
+               + "\t- True:  set default env. var. ({})\n".format(ddef['name'])
+               + "\t- str:   set provided env. variable\n\n"
                + " you provided: {}".format(envvar))
         raise Exception(msg)
 
@@ -100,81 +95,17 @@ def get_version(verb=None, envvar=None,
 ###################################################
 
 
-def _str2bool(v):
-    if isinstance(v, bool):
-        return v
-    elif v.lower() in ['yes', 'true', 'y', 't', '1']:
-        return True
-    elif v.lower() in ['no', 'false', 'n', 'f', '0']:
-        return False
-    else:
-        raise argparse.ArgumentTypeError('Boolean value expected!')
-
-
-def _str2boolstr(v):
-    if isinstance(v, bool):
-        return v
-    elif isinstance(v, str):
-        if v.lower() in ['yes', 'true', 'y', 't', '1']:
-            return True
-        elif v.lower() in ['no', 'false', 'n', 'f', '0']:
-            return False
-        elif v.lower() == 'none':
-            return None
-        else:
-            return v
-    else:
-        raise argparse.ArgumentTypeError('Boolean or str expected!')
-
-
 def main():
     # Parse input arguments
-    msg = """ Get tofu version from bash optionally set an enviroment variable
 
-    If run from a git repo containing tofu, simply returns git describe
-    Otherwise reads the tofu version stored in tofu/version.py
-
-    """
-
-    # Instanciate parser
-    parser = argparse.ArgumentParser(description=msg)
-
-    # Define input arguments
-    parser.add_argument('-p', '--path',
-                        type=str,
-                        help='tofu source directory where version.py is found',
-                        required=False,
-                        default=_TOFUPATH)
-    parser.add_argument('-v', '--verb',
-                        type=_str2bool,
-                        help='flag indicating whether to print the version',
-                        required=False,
-                        default=_DBOOL['verb'])
-    parser.add_argument('-ev', '--envvar',
-                        type=_str2boolstr,
-                        help='name of the environment variable to set, if any',
-                        required=False,
-                        default=_ENVVAR)
-    parser.add_argument('-w', '--warn',
-                        type=_str2bool,
-                        help=('flag indicating whether to print a warning when'
-                              + ' the desired environment variable (envvar) '
-                              + 'already exists'),
-                        required=False,
-                        default=_DBOOL['warn'])
-    parser.add_argument('-f', '--force',
-                        type=_str2bool,
-                        help=('flag indicating whether to force the update of '
-                              + ' the desired environment variable (envvar) '
-                              + 'even if it already exists'),
-                        required=False,
-                        default=_DBOOL['force'])
+    # Parse arguments
+    ddef, parser = _DPARSER['version']()
 
     # Parse arguments
     args = parser.parse_args()
 
     # Call function
-    get_version(**dict(args._get_kwargs()))
+    get_version(ddef=ddef, **dict(args._get_kwargs()))
 
 
 if __name__ == '__main__':

--- a/scripts/tofuversion.py
+++ b/scripts/tofuversion.py
@@ -2,7 +2,6 @@
 
 # Built-in
 import os
-import argparse
 import warnings
 
 

--- a/setup.py
+++ b/setup.py
@@ -390,6 +390,7 @@ setup(
             'tofucalc=tofu.entrypoints.tofucalc:main',
             'tofu-version=scripts.tofuversion:main',
             'tofu-custom=scripts.tofucustom:main',
+            'tofu=scripts.tofu_bash:main',
         ],
     },
 

--- a/tofu/entrypoints/tofucalc.py
+++ b/tofu/entrypoints/tofucalc.py
@@ -11,6 +11,12 @@ plt.switch_backend('Qt5Agg')
 plt.ioff()
 
 
+# import parser dict
+sys.path.insert(1, _TOFUPATH)
+from scripts._dparser import _DPARSER
+_ = sys.path.pop(1)
+
+
 # tofu
 # test if in a tofu git repo
 _HERE = os.path.abspath(os.path.dirname(__file__))
@@ -26,12 +32,6 @@ if istofugit:
     _ = sys.path.pop(1)
 else:
     import tofu as tf
-
-
-# import parser dict
-sys.path.insert(1, _TOFUPATH)
-from scripts._dparser import _DPARSER
-_ = sys.path.pop(1)
 
 
 # tforigin = tf.__file__

--- a/tofu/entrypoints/tofucalc.py
+++ b/tofu/entrypoints/tofucalc.py
@@ -3,12 +3,13 @@
 # Built-in
 import sys
 import os
-import argparse
+
 
 # Generic
 import matplotlib.pyplot as plt
 plt.switch_backend('Qt5Agg')
 plt.ioff()
+
 
 # tofu
 # test if in a tofu git repo
@@ -22,11 +23,10 @@ if istofugit:
     # Make sure we load the corresponding tofu
     sys.path.insert(1, _TOFUPATH)
     import tofu as tf
-    from tofu.imas2tofu import MultiIDSLoader
     _ = sys.path.pop(1)
 else:
     import tofu as tf
-    from tofu.imas2tofu import MultiIDSLoader
+
 
 # import parser dict
 sys.path.insert(1, _TOFUPATH)
@@ -34,28 +34,10 @@ from scripts._dparser import _DPARSER
 _ = sys.path.pop(1)
 
 
-# default parameters
-pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_scripts_def.py')
-if os.path.isfile(pfe):
-    # Make sure we load the user-specific file
-    # sys.path method
-    # sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
-    # import _scripts_def as _defscripts
-    # _ = sys.path.pop(1)
-    # importlib method
-    import importlib.util
-    spec = importlib.util.spec_from_file_location("_defscripts", pfe)
-    _defscripts = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(_defscripts)
-else:
-    try:
-        import tofu.entrypoints._def as _defscripts
-    except Exception as err:
-        from . import _def as _defscripts
+# tforigin = tf.__file__
+# tfversion = tf.__version__
+# print(tforigin, tfversion)
 
-tforigin = tf.__file__
-tfversion = tf.__version__
-print(tforigin, tfversion)
 
 if 'imas2tofu' not in dir(tf):
     msg = "imas does not seem to be available\n"
@@ -64,31 +46,10 @@ if 'imas2tofu' not in dir(tf):
     raise Exception(msg)
 
 
-
 ###################################################
 ###################################################
 #       default values
 ###################################################
-
-
-# _DDEF = {
-    # # User-customizable
-    # 'run': _defscripts._TFCALC_RUN,
-    # 'user': _defscripts._TFCALC_USER,
-    # 'tokamak': _defscripts._TFCALC_TOKAMAK,
-    # 'version': _defscripts._TFCALC_VERSION,
-    # 't0': _defscripts._TFCALC_T0,
-    # 'tlim': None,
-    # 'sharex': _defscripts._TFCALC_SHAREX,
-    # 'bck': _defscripts._TFCALC_BCK,
-    # 'extra': _defscripts._TFCALC_EXTRA,
-    # 'indch_auto': _defscripts._TFCALC_INDCH_AUTO,
-    # 'coefs': None,
-
-    # # Non user-customizable
-    # 'lids_diag': MultiIDSLoader._lidsdiag,
-    # 'lids': MultiIDSLoader._lidsdiag,
-# }
 
 
 _DCONVERT = {
@@ -100,17 +61,6 @@ _DCONVERT = {
 ###################################################
 #       function
 ###################################################
-
-def _get_exception(q, ids, qtype='quantity'):
-    msg = MultiIDSLoader._shortcuts(ids=ids,
-                                    verb=False, return_=True)
-    col = ['ids', 'shortcut', 'long version']
-    msg = MultiIDSLoader._getcharray(msg, col)
-    msg = """\nArgs quantity and quant_X must be valid tofu shortcuts
-    to quantities in ids %s\n\n"""
-    msg += "Available shortcuts are:\n"""%ids + msg
-    msg += "\n\nProvided:\n    - %s: %s\n"%(qtype,str(qq))
-    raise Exception(msg)
 
 
 def call_tfcalcimas(shot=None, run=None, user=None,
@@ -124,17 +74,18 @@ def call_tfcalcimas(shot=None, run=None, user=None,
                     res=None, interp_t=None, coefs=None,
                     sharex=None, indch=None, indch_auto=None,
                     input_file=None, output_file=None,
-                    background=None):
+                    background=None, ddef=None):
 
     # --------------
     # Check inputs
     kwd = locals()
-    for k0 in set(_DDEF.keys()).intersection(kwd.keys()):
+    for k0 in set(ddef.keys()).intersection(kwd.keys()):
         if kwd[k0] is None:
-            kwd[k0] = _DDEF[k0]
+            kwd[k0] = ddef[k0]
     for k0 in set(_DCONVERT.keys()).intersection(kwd.keys()):
         kwd[_DCONVERT[k0]] = kwd[k0]
         del kwd[k0]
+    del kwd['ddef']
 
     if isinstance(kwd['t0'], str) and kwd['t0'].lower() == 'none':
         kwd['t0'] = None
@@ -151,7 +102,6 @@ def call_tfcalcimas(shot=None, run=None, user=None,
     plt.show(block=True)
 
 
-
 ###################################################
 ###################################################
 #       bash call (main)
@@ -160,21 +110,15 @@ def call_tfcalcimas(shot=None, run=None, user=None,
 
 # if __name__ == '__main__':
 def main():
-    # Parse input arguments
-    msg = """Fast interactive visualization tool for diagnostics data in
-    imas
 
-    This is merely a wrapper around the function tofu.calc_from_imas()
-    It calculates synthetic signal (from imas) and displays it from the following
-    ids:
-        %s
-    """%repr(_DDEF['lids'])
+    # Instanciate parser
+    ddef, parser = _DPARSER['calc']()
 
-    parser = _DPARSER['calc'](_DDEF, msg)
+    # Parse arguments
     args = parser.parse_args()
 
     # Call wrapper function
-    call_tfcalcimas(**dict(args._get_kwargs()))
+    call_tfcalcimas(ddef=ddef, **dict(args._get_kwargs()))
 
 
 # Add this to make sure it remains executable even without install

--- a/tofu/entrypoints/tofuplot.py
+++ b/tofu/entrypoints/tofuplot.py
@@ -11,6 +11,12 @@ plt.switch_backend('Qt5Agg')
 plt.ioff()
 
 
+# import parser dict
+sys.path.insert(1, _TOFUPATH)
+from scripts._dparser import _DPARSER
+_ = sys.path.pop(1)
+
+
 # tofu
 # test if in a tofu git repo
 _HERE = os.path.abspath(os.path.dirname(__file__))
@@ -26,12 +32,6 @@ if istofugit:
     _ = sys.path.pop(1)
 else:
     import tofu as tf
-
-
-# import parser dict
-sys.path.insert(1, _TOFUPATH)
-from scripts._dparser import _DPARSER
-_ = sys.path.pop(1)
 
 
 # tforigin = tf.__file__

--- a/tofu/entrypoints/tofuplot.py
+++ b/tofu/entrypoints/tofuplot.py
@@ -22,40 +22,38 @@ if istofugit:
     # Make sure we load the corresponding tofu
     sys.path.insert(1, _TOFUPATH)
     import tofu as tf
-    from tofu.imas2tofu import MultiIDSLoader
     _ = sys.path.pop(1)
 else:
     import tofu as tf
-    from tofu.imas2tofu import MultiIDSLoader
 
-# default parameters
-pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_scripts_def.py')
-if os.path.isfile(pfe):
-    # Make sure we load the user-specific file
-    # sys.path method
-    # sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
-    # import _scripts_def as _defscripts
-    # _ = sys.path.pop(1)
-    # importlib method
-    import importlib.util
-    spec = importlib.util.spec_from_file_location("_defscripts", pfe)
-    _defscripts = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(_defscripts)
-else:
-    try:
-        import tofu.entrypoints._def as _defscripts
-    except Exception as err:
-        from . import _def as _defscripts
+# # default parameters
+# pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_scripts_def.py')
+# if os.path.isfile(pfe):
+    # # Make sure we load the user-specific file
+    # # sys.path method
+    # # sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
+    # # import _scripts_def as _defscripts
+    # # _ = sys.path.pop(1)
+    # # importlib method
+    # import importlib.util
+    # spec = importlib.util.spec_from_file_location("_defscripts", pfe)
+    # _defscripts = importlib.util.module_from_spec(spec)
+    # spec.loader.exec_module(_defscripts)
+# else:
+    # try:
+        # import tofu.entrypoints._def as _defscripts
+    # except Exception as err:
+        # from . import _def as _defscripts
 
-tforigin = tf.__file__
-tfversion = tf.__version__
-print(tforigin, tfversion)
+# tforigin = tf.__file__
+# tfversion = tf.__version__
+# print(tforigin, tfversion)
 
-if 'imas2tofu' not in dir(tf):
-    msg = ("imas does not seem to be available\n"
-           + "  => tf.imas2tofu not available\n"
-           + "  => tofuplot not available")
-    raise Exception(msg)
+# if 'imas2tofu' not in dir(tf):
+    # msg = ("imas does not seem to be available\n"
+           # + "  => tf.imas2tofu not available\n"
+           # + "  => tofuplot not available")
+    # raise Exception(msg)
 
 
 
@@ -65,22 +63,29 @@ if 'imas2tofu' not in dir(tf):
 ###################################################
 
 
-# User-customizable
-_RUN = _defscripts._TFPLOT_RUN
-_USER = _defscripts._TFPLOT_USER
-_TOKAMAK = _defscripts._TFPLOT_TOKAMAK
-_VERSION = _defscripts._TFPLOT_VERSION
-_T0 = _defscripts._TFPLOT_T0
-_TLIM = None
-_SHAREX = _defscripts._TFPLOT_SHAREX
-_BCK = _defscripts._TFPLOT_BCK
-_EXTRA = _defscripts._TFPLOT_EXTRA
-_INDCH_AUTO = _defscripts._TFPLOT_INDCH_AUTO
+# # User-customizable
+# _RUN = _defscripts._TFPLOT_RUN
+# _USER = _defscripts._TFPLOT_USER
+# _TOKAMAK = _defscripts._TFPLOT_TOKAMAK
+# _VERSION = _defscripts._TFPLOT_VERSION
+# _T0 = _defscripts._TFPLOT_T0
+# _TLIM = None
+# _SHAREX = _defscripts._TFPLOT_SHAREX
+# _BCK = _defscripts._TFPLOT_BCK
+# _EXTRA = _defscripts._TFPLOT_EXTRA
+# _INDCH_AUTO = _defscripts._TFPLOT_INDCH_AUTO
 
-# Not user-customizable
-_LIDS_DIAG = MultiIDSLoader._lidsdiag
-_LIDS_PLASMA = tf.imas2tofu.MultiIDSLoader._lidsplasma
-_LIDS = _LIDS_DIAG + _LIDS_PLASMA + tf.utils._LIDS_CUSTOM
+# # Not user-customizable
+# _LIDS_DIAG = MultiIDSLoader._lidsdiag
+# _LIDS_PLASMA = tf.imas2tofu.MultiIDSLoader._lidsplasma
+# _LIDS = _LIDS_DIAG + _LIDS_PLASMA + tf.utils._LIDS_CUSTOM
+
+
+_DCONVERT = {
+    'background': 'bck',
+    'quantity': 'plot_sig',
+    'X': 'plot_X',
+}
 
 
 ###################################################
@@ -88,41 +93,48 @@ _LIDS = _LIDS_DIAG + _LIDS_PLASMA + tf.utils._LIDS_CUSTOM
 #       function
 ###################################################
 
-def _get_exception(q, ids, qtype='quantity'):
-    msg = MultiIDSLoader._shortcuts(ids=ids,
-                                    verb=False, return_=True)
-    col = ['ids', 'shortcut', 'long version']
-    msg = MultiIDSLoader._getcharray(msg, col)
-    msg = """\nArgs quantity and quant_X must be valid tofu shortcuts
-    to quantities in ids %s\n\n"""
-    msg += "Available shortcuts are:\n"""%ids + msg
-    msg += "\n\nProvided:\n    - %s: %s\n"%(qtype,str(qq))
-    raise Exception(msg)
+# def _get_exception(q, ids, qtype='quantity'):
+    # msg = MultiIDSLoader._shortcuts(ids=ids,
+                                    # verb=False, return_=True)
+    # col = ['ids', 'shortcut', 'long version']
+    # msg = MultiIDSLoader._getcharray(msg, col)
+    # msg = """\nArgs quantity and quant_X must be valid tofu shortcuts
+    # to quantities in ids %s\n\n"""
+    # msg += "Available shortcuts are:\n"""%ids + msg
+    # msg += "\n\nProvided:\n    - %s: %s\n"%(qtype, str(qq))
+    # raise Exception(msg)
 
 
-def call_tfloadimas(shot=None, run=_RUN, user=_USER,
-                    tokamak=_TOKAMAK, version=_VERSION, extra=_EXTRA,
-                    ids=None, quantity=None, X=None, t0=_T0, tlim=_TLIM,
-                    sharex=_SHAREX, indch=None, indch_auto=_INDCH_AUTO,
-                    background=_BCK, t=None, dR_sep=None, init=None):
+def call_tfloadimas(shot=None, run=None, user=None,
+                    tokamak=None, version=None, extra=None,
+                    ids=None, quantity=None, X=None, t0=None, tlim=None,
+                    sharex=None, indch=None, indch_auto=None,
+                    background=None, t=None, dR_sep=None, init=None,
+                    ddef=None):
 
-    lidspla = [ids_ for ids_ in ids if ids_ in _LIDS_PLASMA]
-    if t0.lower() == 'none':
-        t0 = None
-    if tlim is not None and len(tlim) == 1:
-        tlim = [tlim, None]
-    if tlim is not None and len(tlim) != 2:
+    # --------------
+    # Check inputs
+    kwd = locals()
+    for k0 in set(ddef.keys()).intersection(kwd.keys()):
+        if kwd[k0] is None:
+            kwd[k0] = ddef[k0]
+    for k0 in set(_DCONVERT.keys()).intersection(kwd.keys()):
+        kwd[_DCONVERT[k0]] = kwd[k0]
+        del kwd[k0]
+    del kwd['ddef']
+
+    if isinstance(kwd['t0'], str) and kwd['t0'].lower() == 'none':
+        kwd['t0'] = None
+    if kwd['tlim'] is not None and len(kwd['tlim']) == 1:
+        kwd['tlim'] = [kwd['tlim'], None]
+    if kwd['tlim'] is not None and len(kwd['tlim']) != 2:
         msg = ("tlim must contain 2 limits:\n"
-               + "\t- provided: {}".format(tlim))
+               + "\t- provided: {}".format(kwd['tlim']))
         raise Exception(msg)
 
-    tf.load_from_imas(shot=shot, run=run, user=user,
-                      tokamak=tokamak, version=version,
-                      ids=ids, indch=indch, indch_auto=indch_auto,
-                      plot_sig=quantity, plot_X=X, extra=extra,
-                      t0=t0, plot=True, sharex=sharex, bck=background,
-                      t=t, tlim=tlim, dR_sep=dR_sep, init=init)
-
+    # --------------
+    # run
+    tf.load_from_imas(plot=True, **kwd)
     plt.show(block=True)
 
 
@@ -132,98 +144,97 @@ def call_tfloadimas(shot=None, run=_RUN, user=_USER,
 #       bash call (main)
 ###################################################
 
-def _str2bool(v):
-    if isinstance(v, bool):
-        return v
-    elif v.lower() in ['yes','true','y','t','1']:
-        return True
-    elif v.lower() in ['no','false','n','f','0']:
-        return False
-    else:
-        raise argparse.ArgumentTypeError('Boolean value expected !')
+# def _str2bool(v):
+    # if isinstance(v, bool):
+        # return v
+    # elif v.lower() in ['yes','true','y','t','1']:
+        # return True
+    # elif v.lower() in ['no','false','n','f','0']:
+        # return False
+    # else:
+        # raise argparse.ArgumentTypeError('Boolean value expected !')
 
 
-def _str2tlim(v):
-    c0 = (v.isdigit()
-          or ('.' in v
-              and len(v.split('.')) == 2
-              and all([vv.isdigit() for vv in v.split('.')])))
-    if c0 is True:
-        v = float(v)
-    elif v.lower() == 'none':
-        v = None
-    return v
+# def _str2tlim(v):
+    # c0 = (v.isdigit()
+          # or ('.' in v
+              # and len(v.split('.')) == 2
+              # and all([vv.isdigit() for vv in v.split('.')])))
+    # if c0 is True:
+        # v = float(v)
+    # elif v.lower() == 'none':
+        # v = None
+    # return v
 
 
 # if __name__ == '__main__':
 def main():
     # Parse input arguments
-    msg = """Fast interactive visualization tool for diagnostics data in
-    imas
+    # parser = argparse.ArgumentParser(description = msg)
 
-    This is merely a wrapper around the function tofu.load_from_imas()
-    It loads (from imas) and displays diagnostics data from the following
-    ids:
-        %s
-    """%repr(_LIDS)
-    parser = argparse.ArgumentParser(description = msg)
+    # parser.add_argument('-s', '--shot', type=int,
+                        # help='shot number', required=False, nargs='+')
+    # msg = 'username of the DB where the datafile is located'
+    # parser.add_argument('-u','--user',help=msg, required=False, default=_USER)
+    # msg = 'tokamak name of the DB where the datafile is located'
+    # parser.add_argument('-tok', '--tokamak', help=msg, required=False,
+                        # default=_TOKAMAK)
+    # parser.add_argument('-r', '--run', help='run number',
+                        # required=False, type=int, default=_RUN)
+    # parser.add_argument('-v', '--version', help='version number',
+                        # required=False, type=str, default=_VERSION)
 
-    parser.add_argument('-s', '--shot', type=int,
-                        help='shot number', required=False, nargs='+')
-    msg = 'username of the DB where the datafile is located'
-    parser.add_argument('-u','--user',help=msg, required=False, default=_USER)
-    msg = 'tokamak name of the DB where the datafile is located'
-    parser.add_argument('-tok', '--tokamak', help=msg, required=False,
-                        default=_TOKAMAK)
-    parser.add_argument('-r', '--run', help='run number',
-                        required=False, type=int, default=_RUN)
-    parser.add_argument('-v', '--version', help='version number',
-                        required=False, type=str, default=_VERSION)
+    # msg = "ids from which to load diagnostics data, can be:\n%s"%repr(_LIDS)
+    # parser.add_argument('-i', '--ids', type=str, required=True,
+                        # help=msg, nargs='+', choices=_LIDS)
+    # parser.add_argument('-q', '--quantity', type=str, required=False,
+                        # help='Desired quantity from the plasma ids',
+                        # nargs='+', default=None)
+    # parser.add_argument('-X', '--X', type=str, required=False,
+                        # help='Quantity from the plasma ids to use for abscissa',
+                        # nargs='+', default=None)
+    # parser.add_argument('-t0', '--t0', type=str, required=False,
+                        # help='Reference time event setting t = 0', default=_T0)
+    # parser.add_argument('-t', '--t', type=float, required=False,
+                        # help='Input time when needed')
+    # parser.add_argument('-tl', '--tlim', type=_str2tlim,
+                        # required=False,
+                        # help='limits of the time interval',
+                        # nargs='+', default=_TLIM)
+    # parser.add_argument('-dR_sep', '--dR_sep', type=float, required=False,
+                        # help='Distance to separatrix from r_ext to plot'
+                        # + ' 10 magnetic field lines')
+    # parser.add_argument('-init', '--init', type=float, required=False, nargs=3,
+                        # help='Manual coordinates of point that a RED magnetic'
+                        # + ' field line will cross on graphics,'
+                        # + ' give coordinates as: R [m], Phi [rad], Z [m]')
+    # parser.add_argument('-ich', '--indch', type=int, required=False,
+                        # help='indices of channels to be loaded',
+                        # nargs='+', default=None)
+    # parser.add_argument('-ichauto', '--indch_auto', type=_str2bool, required=False,
+                        # help='automatically determine indices of'
+                        # + ' channels to be loaded', default=_INDCH_AUTO)
+    # parser.add_argument('-e', '--extra', type=_str2bool, required=False,
+                        # help='If True loads separatrix and heating power',
+                        # default=_EXTRA)
+    # parser.add_argument('-sx', '--sharex', type=_str2bool, required=False,
+                        # help='Should X axis be shared between diagnostics ids ?',
+                        # default=_SHAREX, const=True, nargs='?')
+    # parser.add_argument('-bck', '--background', type=_str2bool, required=False,
+                        # help='Plot data enveloppe as grey background ?',
+                        # default=_BCK, const=True, nargs='?')
 
-    msg = "ids from which to load diagnostics data, can be:\n%s"%repr(_LIDS)
-    parser.add_argument('-i', '--ids', type=str, required=True,
-                        help=msg, nargs='+', choices=_LIDS)
-    parser.add_argument('-q', '--quantity', type=str, required=False,
-                        help='Desired quantity from the plasma ids',
-                        nargs='+', default=None)
-    parser.add_argument('-X', '--X', type=str, required=False,
-                        help='Quantity from the plasma ids to use for abscissa',
-                        nargs='+', default=None)
-    parser.add_argument('-t0', '--t0', type=str, required=False,
-                        help='Reference time event setting t = 0', default=_T0)
-    parser.add_argument('-t', '--t', type=float, required=False,
-                        help='Input time when needed')
-    parser.add_argument('-tl', '--tlim', type=_str2tlim,
-                        required=False,
-                        help='limits of the time interval',
-                        nargs='+', default=_TLIM)
-    parser.add_argument('-dR_sep', '--dR_sep', type=float, required=False,
-                        help='Distance to separatrix from r_ext to plot'
-                        + ' 10 magnetic field lines')
-    parser.add_argument('-init', '--init', type=float, required=False, nargs=3,
-                        help='Manual coordinates of point that a RED magnetic'
-                        + ' field line will cross on graphics,'
-                        + ' give coordinates as: R [m], Phi [rad], Z [m]')
-    parser.add_argument('-ich', '--indch', type=int, required=False,
-                        help='indices of channels to be loaded',
-                        nargs='+', default=None)
-    parser.add_argument('-ichauto', '--indch_auto', type=_str2bool, required=False,
-                        help='automatically determine indices of'
-                        + ' channels to be loaded', default=_INDCH_AUTO)
-    parser.add_argument('-e', '--extra', type=_str2bool, required=False,
-                        help='If True loads separatrix and heating power',
-                        default=_EXTRA)
-    parser.add_argument('-sx', '--sharex', type=_str2bool, required=False,
-                        help='Should X axis be shared between diagnostics ids ?',
-                        default=_SHAREX, const=True, nargs='?')
-    parser.add_argument('-bck', '--background', type=_str2bool, required=False,
-                        help='Plot data enveloppe as grey background ?',
-                        default=_BCK, const=True, nargs='?')
+    # args = parser.parse_args()
 
+    # Parse input arguments
+    # Instanciate parser
+    ddef, parser = _DPARSER['plot']()
+
+    # Parse arguments
     args = parser.parse_args()
 
     # Call wrapper function
-    call_tfloadimas(**dict(args._get_kwargs()))
+    call_tfloadimas(ddef=ddef, **dict(args._get_kwargs()))
 
 
 # Add this to make sure it remains executable even without install

--- a/tofu/entrypoints/tofuplot.py
+++ b/tofu/entrypoints/tofuplot.py
@@ -3,12 +3,13 @@
 # Built-in
 import sys
 import os
-import argparse
+
 
 # Generic
 import matplotlib.pyplot as plt
 plt.switch_backend('Qt5Agg')
 plt.ioff()
+
 
 # tofu
 # test if in a tofu git repo
@@ -26,59 +27,29 @@ if istofugit:
 else:
     import tofu as tf
 
-# # default parameters
-# pfe = os.path.join(os.path.expanduser('~'), '.tofu', '_scripts_def.py')
-# if os.path.isfile(pfe):
-    # # Make sure we load the user-specific file
-    # # sys.path method
-    # # sys.path.insert(1, os.path.join(os.path.expanduser('~'), '.tofu'))
-    # # import _scripts_def as _defscripts
-    # # _ = sys.path.pop(1)
-    # # importlib method
-    # import importlib.util
-    # spec = importlib.util.spec_from_file_location("_defscripts", pfe)
-    # _defscripts = importlib.util.module_from_spec(spec)
-    # spec.loader.exec_module(_defscripts)
-# else:
-    # try:
-        # import tofu.entrypoints._def as _defscripts
-    # except Exception as err:
-        # from . import _def as _defscripts
+
+# import parser dict
+sys.path.insert(1, _TOFUPATH)
+from scripts._dparser import _DPARSER
+_ = sys.path.pop(1)
+
 
 # tforigin = tf.__file__
 # tfversion = tf.__version__
 # print(tforigin, tfversion)
 
-# if 'imas2tofu' not in dir(tf):
-    # msg = ("imas does not seem to be available\n"
-           # + "  => tf.imas2tofu not available\n"
-           # + "  => tofuplot not available")
-    # raise Exception(msg)
 
+if 'imas2tofu' not in dir(tf):
+    msg = ("imas does not seem to be available\n"
+           + "  => tf.imas2tofu not available\n"
+           + "  => tofuplot not available")
+    raise Exception(msg)
 
 
 ###################################################
 ###################################################
 #       default values
 ###################################################
-
-
-# # User-customizable
-# _RUN = _defscripts._TFPLOT_RUN
-# _USER = _defscripts._TFPLOT_USER
-# _TOKAMAK = _defscripts._TFPLOT_TOKAMAK
-# _VERSION = _defscripts._TFPLOT_VERSION
-# _T0 = _defscripts._TFPLOT_T0
-# _TLIM = None
-# _SHAREX = _defscripts._TFPLOT_SHAREX
-# _BCK = _defscripts._TFPLOT_BCK
-# _EXTRA = _defscripts._TFPLOT_EXTRA
-# _INDCH_AUTO = _defscripts._TFPLOT_INDCH_AUTO
-
-# # Not user-customizable
-# _LIDS_DIAG = MultiIDSLoader._lidsdiag
-# _LIDS_PLASMA = tf.imas2tofu.MultiIDSLoader._lidsplasma
-# _LIDS = _LIDS_DIAG + _LIDS_PLASMA + tf.utils._LIDS_CUSTOM
 
 
 _DCONVERT = {
@@ -92,17 +63,6 @@ _DCONVERT = {
 ###################################################
 #       function
 ###################################################
-
-# def _get_exception(q, ids, qtype='quantity'):
-    # msg = MultiIDSLoader._shortcuts(ids=ids,
-                                    # verb=False, return_=True)
-    # col = ['ids', 'shortcut', 'long version']
-    # msg = MultiIDSLoader._getcharray(msg, col)
-    # msg = """\nArgs quantity and quant_X must be valid tofu shortcuts
-    # to quantities in ids %s\n\n"""
-    # msg += "Available shortcuts are:\n"""%ids + msg
-    # msg += "\n\nProvided:\n    - %s: %s\n"%(qtype, str(qq))
-    # raise Exception(msg)
 
 
 def call_tfloadimas(shot=None, run=None, user=None,
@@ -138,94 +98,14 @@ def call_tfloadimas(shot=None, run=None, user=None,
     plt.show(block=True)
 
 
-
 ###################################################
 ###################################################
 #       bash call (main)
 ###################################################
 
-# def _str2bool(v):
-    # if isinstance(v, bool):
-        # return v
-    # elif v.lower() in ['yes','true','y','t','1']:
-        # return True
-    # elif v.lower() in ['no','false','n','f','0']:
-        # return False
-    # else:
-        # raise argparse.ArgumentTypeError('Boolean value expected !')
-
-
-# def _str2tlim(v):
-    # c0 = (v.isdigit()
-          # or ('.' in v
-              # and len(v.split('.')) == 2
-              # and all([vv.isdigit() for vv in v.split('.')])))
-    # if c0 is True:
-        # v = float(v)
-    # elif v.lower() == 'none':
-        # v = None
-    # return v
-
 
 # if __name__ == '__main__':
 def main():
-    # Parse input arguments
-    # parser = argparse.ArgumentParser(description = msg)
-
-    # parser.add_argument('-s', '--shot', type=int,
-                        # help='shot number', required=False, nargs='+')
-    # msg = 'username of the DB where the datafile is located'
-    # parser.add_argument('-u','--user',help=msg, required=False, default=_USER)
-    # msg = 'tokamak name of the DB where the datafile is located'
-    # parser.add_argument('-tok', '--tokamak', help=msg, required=False,
-                        # default=_TOKAMAK)
-    # parser.add_argument('-r', '--run', help='run number',
-                        # required=False, type=int, default=_RUN)
-    # parser.add_argument('-v', '--version', help='version number',
-                        # required=False, type=str, default=_VERSION)
-
-    # msg = "ids from which to load diagnostics data, can be:\n%s"%repr(_LIDS)
-    # parser.add_argument('-i', '--ids', type=str, required=True,
-                        # help=msg, nargs='+', choices=_LIDS)
-    # parser.add_argument('-q', '--quantity', type=str, required=False,
-                        # help='Desired quantity from the plasma ids',
-                        # nargs='+', default=None)
-    # parser.add_argument('-X', '--X', type=str, required=False,
-                        # help='Quantity from the plasma ids to use for abscissa',
-                        # nargs='+', default=None)
-    # parser.add_argument('-t0', '--t0', type=str, required=False,
-                        # help='Reference time event setting t = 0', default=_T0)
-    # parser.add_argument('-t', '--t', type=float, required=False,
-                        # help='Input time when needed')
-    # parser.add_argument('-tl', '--tlim', type=_str2tlim,
-                        # required=False,
-                        # help='limits of the time interval',
-                        # nargs='+', default=_TLIM)
-    # parser.add_argument('-dR_sep', '--dR_sep', type=float, required=False,
-                        # help='Distance to separatrix from r_ext to plot'
-                        # + ' 10 magnetic field lines')
-    # parser.add_argument('-init', '--init', type=float, required=False, nargs=3,
-                        # help='Manual coordinates of point that a RED magnetic'
-                        # + ' field line will cross on graphics,'
-                        # + ' give coordinates as: R [m], Phi [rad], Z [m]')
-    # parser.add_argument('-ich', '--indch', type=int, required=False,
-                        # help='indices of channels to be loaded',
-                        # nargs='+', default=None)
-    # parser.add_argument('-ichauto', '--indch_auto', type=_str2bool, required=False,
-                        # help='automatically determine indices of'
-                        # + ' channels to be loaded', default=_INDCH_AUTO)
-    # parser.add_argument('-e', '--extra', type=_str2bool, required=False,
-                        # help='If True loads separatrix and heating power',
-                        # default=_EXTRA)
-    # parser.add_argument('-sx', '--sharex', type=_str2bool, required=False,
-                        # help='Should X axis be shared between diagnostics ids ?',
-                        # default=_SHAREX, const=True, nargs='?')
-    # parser.add_argument('-bck', '--background', type=_str2bool, required=False,
-                        # help='Plot data enveloppe as grey background ?',
-                        # default=_BCK, const=True, nargs='?')
-
-    # args = parser.parse_args()
-
     # Parse input arguments
     # Instanciate parser
     ddef, parser = _DPARSER['plot']()

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.6-13-g27f196d2'
+__version__ = '1.4.6-14-g5db5a33b'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.6-12-g5f544677'
+__version__ = '1.4.6-13-g27f196d2'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.6-16-ga19e10d4'
+__version__ = '1.4.6-17-g15450573'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.6-2-g7a0d42d4'
+__version__ = '1.4.6-12-g5f544677'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.6-17-g15450573'
+__version__ = '1.4.6-18-g0f9e1e25'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.6-14-g5db5a33b'
+__version__ = '1.4.6-15-gbec8fae2'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.6-15-gbec8fae2'
+__version__ = '1.4.6-16-ga19e10d4'


### PR DESCRIPTION
Motivation:
-------------
* Since the last release, tofu offers several bash commands:

- `tofu-version`:     to get the current version number
- `tofu-custom`:     to create a local hidden .tofu repo for user-spefific default values
- `tofuplot`:            to load and plot diagnostic data from imas
- `tofucalc`:            to load profiles, diag geometry and equilibrium from imas, calculate synthetic diag data and plot it

* In order to make it easier for users and to mimic standard conventions, it makes sense to implement a single tofu command, and the arguments will determine which of the sub-commands above is called:
- `tofu --version`     for tofu-version
- `tofu custom`        for tofu-custom
- `tofu plot` ....         for tofuplot ...
- `tofu calc`...           for tofucalc ...

Issues:
-------
Fixes, in devel, issue #403 