### PR TITLE
Issue422 tools dc5

### DIFF
--- a/tofu/data/_plot.py
+++ b/tofu/data/_plot.py
@@ -1895,10 +1895,10 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
     lx1, lx2, lindr, lextent = zip(*[lData[ii].get_X12plot('imshow') if lis2D[ii]
                                      else (None, None, None, None)
                                      for ii in range(0,nDat)])
-    lidx12 = [id((x1,x2)) if x1 not in [None, False] else None
-              for x1,x2 in zip(lx1,lx2)]
-    ln12 = [(x1.size,x2.size) if x1 not in [None, False] else None
-            for x1,x2 in zip(lx1,lx2)]
+    lidx12 = [id((x1, x2)) if x1 is not None else None
+              for x1, x2 in zip(lx1, lx2)]
+    ln12 = [(x1.size, x2.size) if x1 is not None else None
+            for x1, x2 in zip(lx1, lx2)]
 
 
     # dchans
@@ -1943,7 +1943,8 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
                 dmarker[lkEq_temp[0]] = str(dmarker[k0])
                 del dmarker[k0]
 
-    lkEq = sorted([vv for vv in dEq_corres.values() if vv not in [None, False]])
+    lkEq = sorted([vv for vv in dEq_corres.values()
+                   if vv not in [None, False]])
     kSep = dEq_corres['sep']
     lkEqmap = lkEq + ['map']
 
@@ -1993,8 +1994,8 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
                                    lis2D=lis2D, fldict=fldict, sharex=sharex)
     fig  = dax['t'][0].figure
     if tit is None:
-        tit = [str(getattr(lData[0].Id,aa)) for aa in ['Exp','Diag','shot']
-               if getattr(lData[0].Id,aa) not in [None, False]]
+        tit = [str(getattr(lData[0].Id, aa)) for aa in ['Exp', 'Diag', 'shot']
+               if getattr(lData[0].Id, aa) not in [None, False]]
         tit = ' - '.join(tit)
     if tit != False:
         fig.suptitle(tit)

--- a/tofu/data/_plot.py
+++ b/tofu/data/_plot.py
@@ -495,7 +495,7 @@ def _DataCam12D_plot(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
     dlextra = dict([(k,[None for ii in range(0,nDat)]) for k in lkEqmap])
     dteq = dict([(ii,{}) for ii in range(0,nDat)])
     for ii in range(0,nDat):
-        if lData[ii].dextra is not None:
+        if lData[ii].dextra not in [None, False]:
             for k in set(lkEqmap).intersection(lData[ii].dextra.keys()):
                 idteq = id(lData[ii].dextra[k]['t'])
 
@@ -539,11 +539,11 @@ def _DataCam12D_plot(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
     fig  = dax['t'][0].figure
     if tit is None:
         tit = []
-        if lData[0].Id.Exp is not None:
+        if lData[0].Id.Exp not in [None, False]:
             tit.append(lData[0].Id.Exp)
-        if lData[0].Id.Diag is not None:
+        if lData[0].Id.Diag not in [None, False]:
             tit.append(lData[0].Id.Diag)
-        if lData[0].Id.shot is not None:
+        if lData[0].Id.shot not in [None, False]:
             tit.append(r"{0:05.0f}".format(lData[0].Id.shot))
         tit = ' - '.join(tit)
     if tit != False:
@@ -552,8 +552,8 @@ def _DataCam12D_plot(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
 
     # -----------------
     # Plot conf and bck
-    c0 = lData[0]._dgeom['config'] is not None
-    c1 = c0 and lData[0]._dgeom['lCam'] is not None
+    c0 = lData[0]._dgeom['config'] not in [None, False]
+    c1 = c0 and lData[0]._dgeom['lCam'] not in [None, False]
     if c0:
         out = lData[0]._dgeom['config'].plot(lax=[dax['cross'][0], dax['hor'][0]],
                                              element='P',
@@ -612,7 +612,7 @@ def _DataCam12D_plot(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
 
     # Static extra (time traces)
     for ii in range(0,nDat):
-        if lData[ii].dextra is not None:
+        if lData[ii].dextra not in [None, False]:
             lk = [k for k in lData[ii].dextra.keys() if k not in lkEqmap]
             for kk in lk:
                 dd = lData[ii].dextra[kk]
@@ -683,19 +683,19 @@ def _DataCam12D_plot(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
     ddat = dict([(liddata[ii], {'val':ldata[ii], 'refids':[lidt[ii],lidX[ii]]})
                  for ii in range(0,nDat)])
     ddat[idchans] = {'val':dchans, 'refids':[lidX[0]]}
-    if lCross is not None:
+    if lCross not in [None, False]:
         ddat[idlCross] = {'val':lCross, 'refids':[lidX[0]]}
         ddat[idlHor] = {'val':lHor, 'refids':[lidX[0]]}
     if nD == 2:
         ddat[idx12] = {'val':(x1,x2), 'refids':[lidX[0]]}
 
-    if dlextra['map'][0] is not None:
+    if dlextra['map'][0] not in [None, False]:
         ddat[dlextra['map'][0]['id']] = {'val':dlextra['map'][0]['data2D'],
                                          'refids':[dlextra['map'][0]['idt']]}
 
     for ii in range(0,nDat):
         for k in set(lkEq).intersection(dlextra.keys()):
-            if dlextra[k][ii] is not None:
+            if dlextra[k][ii] not in [None, False]:
                 ddat[dlextra[k][ii]['id']] = {'val':dlextra[k][ii]['data2D'],
                                               'refids':[dlextra[k][ii]['idt']]}
 
@@ -733,7 +733,7 @@ def _DataCam12D_plot(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
 
     # -------------
     # One-shot and one-time 2D map
-    if dlextra['map'][0] is not None:
+    if dlextra['map'][0] not in [None, False]:
         map_ = dlextra['map'][0]['data2D']
         if normt_map:
             map_ = map_ / np.nanmax(map_,axis=0)[np.newaxis,:,:]
@@ -804,7 +804,7 @@ def _DataCam12D_plot(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
                 dobj[l0] = {'dupdate':{'ydata':{'id':liddata[ii],
                                                 'lrid':[lidt[ii]]}},
                             'drefid':{lidt[ii]:jj}}
-                if lXother[ii] is not None:
+                if lXother[ii] not in [None, False]:
                     dobj[l0]['dupdate']['xdata'] = {'id':lidX[ii],
                                                     'lrid':[lXother[ii]]}
             else:
@@ -817,7 +817,7 @@ def _DataCam12D_plot(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
                             'drefid':{lidt[ii]:jj}}
 
             # Time equilibrium and map
-            if lData[ii].dextra is not None:
+            if lData[ii].dextra not in [None, False]:
                 for kk in set(lkEq).intersection(lData[ii].dextra.keys()):
                     id_ = dlextra[kk][ii]['id']
                     idt = dlextra[kk][ii]['idt']
@@ -960,7 +960,7 @@ def _init_DataCam12D_spectral(fs=None, dmargin=None,
         else:
             laxp = [fig.add_subplot(gs1[9:,2:-1], fc='w', sharey=shy)]
 
-    if laxp is not None and nD == 2:
+    if laxp not in [None, False] and nD == 2:
         laxp[0].set_aspect('equal', adjustable='datalim')
         from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
         ax_divider = make_axes_locatable(laxp[0])
@@ -1036,7 +1036,7 @@ def _init_DataCam12D_spectral(fs=None, dmargin=None,
 
     # Format all axes
     for kk in dax.keys():
-        if dax[kk] is not None:
+        if dax[kk] not in [None, False]:
             for ii in range(0,len(dax[kk])):
                 dax[kk][ii].tick_params(labelsize=fontsize)
                 if 'txt' in kk:
@@ -1247,7 +1247,7 @@ def _DataCam12D_plot_spectral(lData, key=None,
     dlextra = dict([(k,[None for ii in range(0,nDat)]) for k in lkEqmap])
     dteq = dict([(ii,{}) for ii in range(0,nDat)])
     for ii in range(0,nDat):
-        if lData[ii].dextra is not None:
+        if lData[ii].dextra not in [None, False]:
             for k in set(lkEqmap).intersection(lData[ii].dextra.keys()):
                 idteq = id(lData[ii].dextra[k]['t'])
 
@@ -1293,11 +1293,11 @@ def _DataCam12D_plot_spectral(lData, key=None,
     fig  = dax['t'][0].figure
     if tit is None:
         tit = []
-        if lData[0].Id.Exp is not None:
+        if lData[0].Id.Exp not in [None, False]:
             tit.append(lData[0].Id.Exp)
-        if lData[0].Id.Diag is not None:
+        if lData[0].Id.Diag not in [None, False]:
             tit.append(lData[0].Id.Diag)
-        if lData[0].Id.shot is not None:
+        if lData[0].Id.shot not in [None, False]:
             tit.append(r"{0:05.0f}".format(lData[0].Id.shot))
         tit = ' - '.join(tit)
     if tit != False:
@@ -1306,8 +1306,8 @@ def _DataCam12D_plot_spectral(lData, key=None,
 
     # -----------------
     # Plot conf and bck
-    c0 = lData[0]._dgeom['config'] is not None
-    c1 = c0 and lData[0]._dgeom['lCam'] is not None
+    c0 = lData[0]._dgeom['config'] not in [None, False]
+    c1 = c0 and lData[0]._dgeom['lCam'] not in [None, False]
     if c0:
         out = lData[0]._dgeom['config'].plot(lax=[dax['cross'][0],
                                                   dax['hor'][0]],
@@ -1352,7 +1352,7 @@ def _DataCam12D_plot_spectral(lData, key=None,
     # Background (optional)
     if bck:
         if nD == 1:
-            if lData[0].ddata['nnch'] == 1 and dax['X'] is not None:
+            if lData[0].ddata['nnch'] == 1 and dax['X'] not in [None, False]:
                 env = [np.nanmin(ldataint[0],axis=0), np.nanmax(ldataint[0],axis=0)]
                 dax['X'][0].fill_between(lX[0].ravel(), env[0], env[1], facecolor=cbck)
             tbck = np.tile(np.r_[lt[0], np.nan], nch)
@@ -1365,7 +1365,7 @@ def _DataCam12D_plot_spectral(lData, key=None,
 
     # Static extra (time traces)
     for ii in range(0,nDat):
-        if lData[ii].dextra is not None:
+        if lData[ii].dextra not in [None, False]:
             lk = [k for k in lData[ii].dextra.keys() if k not in lkEqmap]
             for kk in lk:
                 dd = lData[ii].dextra[kk]
@@ -1409,7 +1409,7 @@ def _DataCam12D_plot_spectral(lData, key=None,
     dgroup = {'time':      {'nMax':ntMax, 'key':'f1',
                             'defid':lidt[0], 'defax':dax['t'][1]}}
 
-    if dax['X'] is not None:
+    if dax['X'] not in [None, False]:
         dgroup['channel'] = {'nMax':nchMax, 'key':'f2',
                              'defid':lidX[0], 'defax':dax['X'][0]}
 
@@ -1453,19 +1453,19 @@ def _DataCam12D_plot_spectral(lData, key=None,
                  for ii in range(0,nDat)]))
     ddat[idchans] = {'val':dchans, 'refids':[lidX[0]]}
 
-    if lCross is not None:
+    if lCross not in [None, False]:
         ddat[idlCross] = {'val':lCross, 'refids':[lidX[0]]}
         ddat[idlHor] = {'val':lHor, 'refids':[lidX[0]]}
     if nD == 2:
         ddat[idx12] = {'val':(x1,x2), 'refids':[lidX[0]]}
 
-    if dlextra['map'][0] is not None:
+    if dlextra['map'][0] not in [None, False]:
         ddat[dlextra['map'][0]['id']] = {'val':dlextra['map'][0]['data2D'],
                                          'refids':[dlextra['map'][0]['idt']]}
 
     for ii in range(0,nDat):
         for k in set(lkEq).intersection(dlextra.keys()):
-            if dlextra[k][ii] is not None:
+            if dlextra[k][ii] not in [None, False]:
                 ddat[dlextra[k][ii]['id']] = {'val':dlextra[k][ii]['data2D'],
                                               'refids':[dlextra[k][ii]['idt']]}
 
@@ -1492,7 +1492,7 @@ def _DataCam12D_plot_spectral(lData, key=None,
                                          'graph':{lidlamb[0]:'x'}})
                       for ii in range(0,len(dax['lamb']))]))
 
-    if nD == 1 and dax['X'] is not None:
+    if nD == 1 and dax['X'] not in [None, False]:
         dax2.update({dax['X'][0]: {'ref':dict([(idX,'x') for idX in lidX]),
                                    'graph':{lidX[0]:'x'}}})
     elif nD == 2:
@@ -1511,7 +1511,7 @@ def _DataCam12D_plot_spectral(lData, key=None,
 
     # -------------
     # One-shot and one-time 2D map
-    if dlextra['map'][0] is not None:
+    if dlextra['map'][0] not in [None, False]:
         map_ = dlextra['map'][0]['data2D']
         if normt_map:
             map_ = map_ / np.nanmax(map_,axis=0)[np.newaxis,:,:]
@@ -1606,7 +1606,7 @@ def _DataCam12D_plot_spectral(lData, key=None,
                     dobj[l0] = {'dupdate':{'ydata':{'id':liddataint[ii],
                                                     'lrid':[lidt[ii]]}},
                                 'drefid':{lidt[ii]:jj}}
-                    if lXother[ii] is not None:
+                    if lXother[ii] not in [None, False]:
                         dobj[l0]['dupdate']['xdata'] = {'id':lidX[ii],
                                                         'lrid':[lXother[ii]]}
                 else:
@@ -1619,7 +1619,7 @@ def _DataCam12D_plot_spectral(lData, key=None,
                                 'drefid':{lidt[ii]:jj}}
 
             # Time equilibrium and map
-            if lData[ii].dextra is not None:
+            if lData[ii].dextra not in [None, False]:
                 for kk in set(lkEq).intersection(lData[ii].dextra.keys()):
                     id_ = dlextra[kk][ii]['id']
                     idt = dlextra[kk][ii]['idt']
@@ -1817,7 +1817,7 @@ def _init_DataCam12D_combine(fs=None, dmargin=None,
     # Format all axes
     for kk in dax.keys():
         for ii in range(0,len(dax[kk])):
-            if dax[kk][ii] is not None:
+            if dax[kk][ii] not in [None, False]:
                 dax[kk][ii].tick_params(labelsize=fontsize)
                 if 'txt' in kk:
                     dax[kk][ii].patch.set_alpha(0.)
@@ -1892,9 +1892,9 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
     lx1, lx2, lindr, lextent = zip(*[lData[ii].get_X12plot('imshow') if lis2D[ii]
                                      else (None, None, None, None)
                                      for ii in range(0,nDat)])
-    lidx12 = [id((x1,x2)) if x1 is not None else None
+    lidx12 = [id((x1,x2)) if x1 not in [None, False] else None
               for x1,x2 in zip(lx1,lx2)]
-    ln12 = [(x1.size,x2.size) if x1 is not None else None
+    ln12 = [(x1.size,x2.size) if x1 not in [None, False] else None
             for x1,x2 in zip(lx1,lx2)]
 
 
@@ -1940,14 +1940,14 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
                 dmarker[lkEq_temp[0]] = str(dmarker[k0])
                 del dmarker[k0]
 
-    lkEq = sorted([vv for vv in dEq_corres.values() if vv is not None])
+    lkEq = sorted([vv for vv in dEq_corres.values() if vv not in [None, False]])
     kSep = dEq_corres['sep']
     lkEqmap = lkEq + ['map']
 
     dlextra = dict([(k,[None for ii in range(0,nDat)]) for k in lkEqmap])
     dteq = dict([(ii,{}) for ii in range(0,nDat)])
     for ii in range(0,nDat):
-        if lData[ii].dextra is not None:
+        if lData[ii].dextra not in [None, False]:
             for k in set(lkEqmap).intersection(lData[ii].dextra.keys()):
                 idteq = id(lData[ii].dextra[k]['t'])
 
@@ -1991,7 +1991,7 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
     fig  = dax['t'][0].figure
     if tit is None:
         tit = [str(getattr(lData[0].Id,aa)) for aa in ['Exp','Diag','shot']
-               if getattr(lData[0].Id,aa) is not None]
+               if getattr(lData[0].Id,aa) not in [None, False]]
         tit = ' - '.join(tit)
     if tit != False:
         fig.suptitle(tit)
@@ -2001,7 +2001,7 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
     # Plot ref dextra and ref conf H
 
     # conf
-    c0 = lData[0]._dgeom['config'] is not None
+    c0 = lData[0]._dgeom['config'] not in [None, False]
     if c0:
         dax['hor'][0] = lData[0]._dgeom['config'].plot(lax=dax['hor'][0],
                                                        proj='hor', element='P',
@@ -2009,7 +2009,7 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
                                                        draw=False)
 
     # dextra
-    if lData[0].dextra is not None:
+    if lData[0].dextra not in [None, False]:
         lk = [k for k in lData[0].dextra.keys() if k not in lkEqmap]
         for kk in lk:
             dd = lData[0].dextra[kk]
@@ -2035,7 +2035,7 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
     for ii in range(0,nDat):
 
         # cross config
-        c0 = lData[0]._dgeom['config'] is not None
+        c0 = lData[0]._dgeom['config'] not in [None, False]
         if c0:
             dax['cross'][ii] = lData[ii].config.plot(lax=dax['cross'][ii],
                                                      element='P', dLeg=None,
@@ -2043,7 +2043,7 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
                                                      draw=False)
 
         # los
-        c1 = lData[ii]._dgeom['lCam'] is not None
+        c1 = lData[ii]._dgeom['lCam'] not in [None, False]
         c2 = c1 and lData[ii]._isLOS
         if c2:
             llCross[ii] = [None for jj in range(0,len(lData[ii]._dgeom['lCam']))]
@@ -2154,18 +2154,18 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
         ddat[liddata[ii]] = {'val':ldata[ii], 'refids':[lidt[ii],lidX[ii]]}
         ddat[lidchans[ii]] = {'val':ldchans[ii], 'refids':[lidX[ii]]}
 
-        if llCross[ii] is not None:
+        if llCross[ii] not in [None, False]:
             ddat[lidCross[ii]] = {'val':llCross[ii], 'refids':[lidX[ii]]}
             ddat[lidHor[ii]] = {'val':llHor[ii], 'refids':[lidX[ii]]}
         if lis2D[ii]:
             ddat[lidx12[ii]] = {'val':(lx1[ii],lx2[ii]), 'refids':[lidX[ii]]}
 
-        if dlextra['map'][ii] is not None:
+        if dlextra['map'][ii] not in [None, False]:
             ddat[dlextra['map'][ii]['id']] = {'val':dlextra['map'][ii]['data2D'],
                                               'refids':[dlextra['map'][ii]['idt']]}
 
         for k in set(lkEq).intersection(dlextra.keys()):
-            if dlextra[k][ii] is not None:
+            if dlextra[k][ii] not in [None, False]:
                 ddat[dlextra[k][ii]['id']] = {'val':dlextra[k][ii]['data2D'],
                                               'refids':[dlextra[k][ii]['idt']]}
 
@@ -2195,7 +2195,7 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
     # -------------
     # One-shot and one-time 2D map
     for ii in range(0,nDat):
-        if dlextra['map'][ii] is not None:
+        if dlextra['map'][ii] not in [None, False]:
             map_ = dlextra['map'][ii]['data2D']
             if normt_map:
                 map_ = map_ / np.nanmax(map_,axis=0)[np.newaxis,:,:]
@@ -2284,12 +2284,12 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
                 dobj[l0] = {'dupdate':{'ydata':{'id':liddata[ii],
                                                 'lrid':[lidt[ii]]}},
                             'drefid':{lidt[ii]:jj}}
-                if lXother[ii] is not None:
+                if lXother[ii] not in [None, False]:
                     dobj[l0]['dupdate']['xdata'] = {'id':lidX[ii],
                                                     'lrid':[lXother[ii]]}
 
             # Time equilibrium and map
-            if lData[ii].dextra is not None:
+            if lData[ii].dextra not in [None, False]:
                 for kk in set(lkEq).intersection(lData[ii].dextra.keys()):
                     id_ = dlextra[kk][ii]['id']
                     idt = dlextra[kk][ii]['idt']
@@ -2627,19 +2627,19 @@ def _Data1D_plot_spectrogram(Data, tf, f, lpsd, lang,
 
     if tit is None:
         tit = []
-        if Data.Id.Exp is not None:
+        if Data.Id.Exp not in [None, False]:
             tit.append(Data.Id.Exp)
-        if Data.Id.Diag is not None:
+        if Data.Id.Diag not in [None, False]:
             tit.append(Data.Id.Diag)
-        if Data.Id.shot is not None:
+        if Data.Id.shot not in [None, False]:
             tit.append(r"{0:05.0f}".format(Data.Id.shot))
         tit = ' - '.join(tit)
     if tit != False:
         fig.suptitle(tit)
 
     # Plot vessel
-    c0 = Data._dgeom['config'] is not None
-    c1 = c0 and Data._dgeom['lCam'] is not None
+    c0 = Data._dgeom['config'] not in [None, False]
+    c1 = c0 and Data._dgeom['lCam'] not in [None, False]
     if c0:
         out = Data._dgeom['config'].plot(lax=[dax['cross'][0], dax['hor'][0]],
                                          element='P', dLeg=None, draw=False)
@@ -2778,7 +2778,7 @@ def _Data1D_plot_spectrogram(Data, tf, f, lpsd, lang,
             idlpsd_norm: {'val':lpsd_norm, 'refids':[idX,idf,idtf]},
             idlang: {'val':lang, 'refids':[idX,idf,idtf]},
             idchans:{'val':dchans, 'refids':[idX]}}
-    if lCross is not None:
+    if lCross not in [None, False]:
         ddat[idlCross] = {'val':lCross, 'refids':[idX]}
         ddat[idlHor] = {'val':lHor, 'refids':[idX]}
     if nD == 2:
@@ -2891,7 +2891,7 @@ def _Data1D_plot_spectrogram(Data, tf, f, lpsd, lang,
                                    c=lct[jj], ls='-', lw=1.)
             dobj[l0] = {'dupdate':{'ydata':{'id':iddata, 'lrid':[idt]}},
                         'drefid':{idt:jj}}
-            if Xother is not None:
+            if Xother not in [None, False]:
                 dobj[l0]['dupdate']['xdata'] = {'id':idX, 'lrid':[Xother]}
 
             # lpsd and ang profiles
@@ -2905,7 +2905,7 @@ def _Data1D_plot_spectrogram(Data, tf, f, lpsd, lang,
                 dobj[l1] = {'dupdate':{'ydata':{'id':idlang, 'lrid':[idtf,idf]}},
                             'drefid':{idtf:jj, idf:ii}}
 
-                if Xother is not None:
+                if Xother not in [None, False]:
                     dobj[l0]['dupdate']['xdata'] = {'id':idX, 'lrid':[Xother]}
                     dobj[l0]['drefid'][Xother] = jj
                     dobj[l1]['dupdate']['xdata'] = {'id':idX, 'lrid':[Xother]}
@@ -3281,11 +3281,11 @@ def _Data_plot_svd(Data, chronos, s, topos, modes=None,
 
     if tit is None:
         tit = []
-        if Data.Id.Exp is not None:
+        if Data.Id.Exp not in [None, False]:
             tit.append(Data.Id.Exp)
-        if Data.Id.Diag is not None:
+        if Data.Id.Diag not in [None, False]:
             tit.append(Data.Id.Diag)
-        if Data.Id.shot is not None:
+        if Data.Id.shot not in [None, False]:
             tit.append(r"{0:05.0f}".format(Data.Id.shot))
         tit = ' - '.join(tit)
     if tit != False:
@@ -3296,8 +3296,8 @@ def _Data_plot_svd(Data, chronos, s, topos, modes=None,
     ############
 
     # Config and LOS
-    c0 = Data._dgeom['config'] is not None
-    c1 = c0 and Data._dgeom['lCam'] is not None
+    c0 = Data._dgeom['config'] not in [None, False]
+    c1 = c0 and Data._dgeom['lCam'] not in [None, False]
     if c0:
         out = Data._dgeom['config'].plot(lax=[dax['cross'][0], dax['hor'][0]],
                                          element='P', dLeg=None, draw=False)
@@ -3436,7 +3436,7 @@ def _Data_plot_svd(Data, chronos, s, topos, modes=None,
             idchans:{'val':dchans, 'refids':[idX]},
             idchronos: {'val':chronos.T, 'refids':[idm]},
             idtopos: {'val':topos, 'refids':[idm]}}
-    if lCross is not None:
+    if lCross not in [None, False]:
         ddat[idlCross] = {'val':lCross, 'refids':[idX]}
         ddat[idlHor] = {'val':lHor, 'refids':[idX]}
     if nD == 2:
@@ -3532,7 +3532,7 @@ def _Data_plot_svd(Data, chronos, s, topos, modes=None,
                                    c=lct[jj], ls='-', lw=1.)
             dobj[l0] = {'dupdate':{'ydata':{'id':iddata, 'lrid':[idt]}},
                         'drefid':{idt:jj}}
-            if Xother is not None:
+            if Xother not in [None, False]:
                 dobj[l0]['dupdate']['xdata'] = {'id':idX, 'lrid':[Xother]}
 
         else:
@@ -3571,7 +3571,7 @@ def _Data_plot_svd(Data, chronos, s, topos, modes=None,
                                    c=lcm[jj%2], ls='-', lw=1.)
             dobj[l0] = {'dupdate':{'ydata':{'id':idtopos, 'lrid':[idm]}},
                         'drefid':{idm:jj}}
-            if Xother is not None:
+            if Xother not in [None, False]:
                 dobj[l0]['dupdate']['xdata'] = {'id':idX, 'lrid':[Xother]}
 
         else:

--- a/tofu/data/_plot.py
+++ b/tofu/data/_plot.py
@@ -552,8 +552,10 @@ def _DataCam12D_plot(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
 
     # -----------------
     # Plot conf and bck
-    c0 = lData[0]._dgeom['config'] not in [None, False]
-    c1 = c0 and lData[0]._dgeom['lCam'] not in [None, False]
+    c0 = (lData[0]._dgeom['config'] is not None
+          and lData[0]._dgeom['config'] is not False)
+    c1 = (c0 and lData[0]._dgeom['lCam'] is not None
+          and lData[0]._dgeom['lCam'] is not False)
     if c0:
         out = lData[0]._dgeom['config'].plot(lax=[dax['cross'][0], dax['hor'][0]],
                                              element='P',
@@ -1306,8 +1308,10 @@ def _DataCam12D_plot_spectral(lData, key=None,
 
     # -----------------
     # Plot conf and bck
-    c0 = lData[0]._dgeom['config'] not in [None, False]
-    c1 = c0 and lData[0]._dgeom['lCam'] not in [None, False]
+    c0 = (lData[0]._dgeom['config'] is not None
+          and lData[0]._dgeom['config'] is not False)
+    c1 = (c0 and lData[0]._dgeom['lCam'] is not None
+          and lData[0]._dgeom['lCam'] is not False)
     if c0:
         out = lData[0]._dgeom['config'].plot(lax=[dax['cross'][0],
                                                   dax['hor'][0]],
@@ -1853,7 +1857,6 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
         lData[0], lData[indref] = lData[indref], lData[0]
     nDat = len(lData)
 
-
     # ---------
     # Get time
     lt = [dd.t for dd in lData]
@@ -1996,12 +1999,12 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
     if tit != False:
         fig.suptitle(tit)
 
-
     # -----------------
     # Plot ref dextra and ref conf H
 
     # conf
-    c0 = lData[0]._dgeom['config'] not in [None, False]
+    c0 = (lData[0]._dgeom['config'] is not None
+          and lData[0]._dgeom['config'] is not False)
     if c0:
         dax['hor'][0] = lData[0]._dgeom['config'].plot(lax=dax['hor'][0],
                                                        proj='hor', element='P',
@@ -2035,7 +2038,8 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
     for ii in range(0,nDat):
 
         # cross config
-        c0 = lData[0]._dgeom['config'] not in [None, False]
+        c0 = (lData[0]._dgeom['config'] is not None
+              and lData[0]._dgeom['config'] is not False)
         if c0:
             dax['cross'][ii] = lData[ii].config.plot(lax=dax['cross'][ii],
                                                      element='P', dLeg=None,
@@ -2043,7 +2047,8 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
                                                      draw=False)
 
         # los
-        c1 = lData[ii]._dgeom['lCam'] not in [None, False]
+        c1 = (lData[ii]._dgeom['lCam'] is not None
+              and lData[ii]._dgeom['lCam'] is not False)
         c2 = c1 and lData[ii]._isLOS
         if c2:
             llCross[ii] = [None for jj in range(0,len(lData[ii]._dgeom['lCam']))]
@@ -2089,7 +2094,6 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
             tbck = np.tile(np.r_[lt[ii], np.nan], lnch[ii])
             dbck = np.vstack((ldata[ii], np.full((1,lnch[ii]),np.nan))).T.ravel()
             dax['t'][ii+1].plot(tbck, dbck, lw=1., ls='-', c=cbck)
-
 
 
     # ---------------
@@ -2188,7 +2192,6 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
     dobj = {}
 
 
-
     ##################
     # Populating dobj
 
@@ -2253,7 +2256,6 @@ def _DataCam12D_plot_combine(lData, key=None, nchMax=_nchMax, ntMax=_ntMax,
         dobj[l0] = {'dupdate':{'txt':{'id':lidt[0], 'lrid':[lidt[0]],
                                       'bstr':'{0:%s} s'%fmt_t}},
                     'drefid':{lidt[0]:jj}}
-
 
     # -------------
     # Data-specific
@@ -2638,8 +2640,10 @@ def _Data1D_plot_spectrogram(Data, tf, f, lpsd, lang,
         fig.suptitle(tit)
 
     # Plot vessel
-    c0 = Data._dgeom['config'] not in [None, False]
-    c1 = c0 and Data._dgeom['lCam'] not in [None, False]
+    c0 = (Data._dgeom['config'] is not None
+          and Data._dgeom['config'] is not False)
+    c1 = (c0 and Data._dgeom['lCam'] is not None
+          and Data._dgeom['lCam'] is not False)
     if c0:
         out = Data._dgeom['config'].plot(lax=[dax['cross'][0], dax['hor'][0]],
                                          element='P', dLeg=None, draw=False)
@@ -3296,8 +3300,10 @@ def _Data_plot_svd(Data, chronos, s, topos, modes=None,
     ############
 
     # Config and LOS
-    c0 = Data._dgeom['config'] not in [None, False]
-    c1 = c0 and Data._dgeom['lCam'] not in [None, False]
+    c0 = (Data._dgeom['config'] is not None
+          and Data._dgeom['config'] is not False)
+    c1 = (c0 and Data._dgeom['lCam'] is not None
+          and Data._dgeom['lCam'] is not False)
     if c0:
         out = Data._dgeom['config'].plot(lax=[dax['cross'][0], dax['hor'][0]],
                                          element='P', dLeg=None, draw=False)

--- a/tofu/entrypoints/_def.py
+++ b/tofu/entrypoints/_def.py
@@ -4,7 +4,7 @@
 #                   tofuplot parameters
 # #############################################################################
 
-_TFPLOT_CONFIG = False
+_TFPLOT_CONFIG = None
 _TFPLOT_TOSOLEDGE3X = False
 _TFPLOT_RUN = 0
 _TFPLOT_USER = 'imas_public'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.7-13-g3d4a5875'
+__version__ = '1.4.7-15-gf9cd239'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.7-16-g44d9062d'
+__version__ = '1.4.7-17-g6eac287'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.7-17-g6eac287'
+__version__ = '1.4.7-18-g04c84673'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.7-15-gf9cd239'
+__version__ = '1.4.7-16-g44d9062d'


### PR DESCRIPTION
Motivations:
--------------
* standard tofu bash commands were not woking anymore since the last release

Main changes:
----------------
* The issue was that default config for tofuplot was set to False => reset to None

Example (on intra only):
--------------------------

```
[~/] ./tofu/entrypoints/tofuplot.py -i ece interferometer -s 55178

Getting ids     [occ]  tokamak  user         version  shot   run  refshot  refrun
--------------  -----  -------  -----------  -------  -----  ---  -------  ------
ece             [0]    west     imas_public  3        55178  0    -1       -1    
equilibrium     [0]    "        "            "        "      "    "        "     
ic_antennas     [0]    "        "            "        "      "    "        "     
interferometer  [0]    "        "            "        "      "    "        "     
lh_antennas     [0]    "        "            "        "      "    "        "     
pulse_schedule  [0]    "        "            "        "      "    "        "     
wall            [0]    "        "            "        "      "    "        "     
/Home/DV226270/ToFu_All/tofu_git/tofu/tofu/imas2tofu/_comp_toobjects.py:513: UserWarning: indch has to be changed, some data may be missing
	- indch: [0 1 2 3 4 5 6 7 8 9]
	- indch recommended: [2 3 4 5 6 7 9]

  => check self.inspect_channels() for details
  warnings.warn(msg)
qt.qpa.xcb: X server does not support XInput 2
failed to get the current screen resources
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-DV226270'
qt.qpa.xcb: QXcbConnection: XCB error: 1 (BadRequest), sequence: 167, resource id: 87, major code: 131 (Unknown), minor code: 47
qt.qpa.xcb: QXcbConnection: XCB error: 173 (Unknown), sequence: 181, resource id: 87, major code: 150 (Unknown), minor code: 20
```




Issues:
-------
Fixes, in devel, issue #422 