### PR TITLE
Fixing ITER-related issues

### DIFF
--- a/tofu/data/_core.py
+++ b/tofu/data/_core.py
@@ -3108,9 +3108,9 @@ class Plasma2D(utils.ToFuObject):
             if group is None or group in lg:
                 return str_, None
             else:
-                msg = "Required data key does not have matching group:\n"
-                msg += "    - ddata[%s]['lgroup'] = %s\n"%(str_, lg)
-                msg += "    - Expected group:  %s"%group
+                msg = ("Required data key does not have matching group:\n"
+                       + "\t- ddata[{}]['lgroup'] = {}\n".format(str_, lg)
+                       + "\t- Expected group:  {}".format(group))
                 if raise_:
                     raise Exception(msg)
 

--- a/tofu/data/_core.py
+++ b/tofu/data/_core.py
@@ -2908,9 +2908,14 @@ class Plasma2D(utils.ToFuObject):
                 c0 = type_ is dict and 'mesh' in self.ddata[k0]['lgroup']
                 c1 = not c0 and len(v0['data']) == shape[0]
                 if not (c0 or c1):
-                    msg = (k0 + '\n'
-                           + str([c0, c1, type_, len(v0['data']), shape])
-                           + "\n" + str(v0['data']))
+                    msg = ("Signal {}['data'] should be either:\n".format(k0)
+                           + "\t- dict: a mesh\n"
+                           + "\t- iterable of len() = "
+                           + "{} (shape[0] of ref)\n".format(shape[0])
+                           + "  You provided:\n"
+                           + "\t- type: {}\n".format(type_)
+                           + "\t- len(): {}\n".format(len(v0['data']))
+                           + "\t- {}['data']: {}".format(k0, v0['data']))
                     raise Exception(msg)
             else:
                 assert type(v0['data']) is np.ndarray
@@ -3104,7 +3109,7 @@ class Plasma2D(utils.ToFuObject):
                 return str_, None
             else:
                 msg = "Required data key does not have matching group:\n"
-                msg += "    - ddata[%s]['lgroup'] = %s"%(str_, lg)
+                msg += "    - ddata[%s]['lgroup'] = %s\n"%(str_, lg)
                 msg += "    - Expected group:  %s"%group
                 if raise_:
                     raise Exception(msg)
@@ -4253,10 +4258,10 @@ class Plasma2D(utils.ToFuObject):
         c0 = type(X) is str
         c1 = type(X) is list and (len(X) == 1 or len(X) == nquant)
         if not (c0 or c1):
-            msg = "X must be specified, either as :\n"
-            msg += "    - a str (name or quant)\n"
-            msg += "    - a list of str\n"
-            msg += "    Provided: %s"%str(X)
+            msg = ("X must be specified, either as :\n"
+                   + "    - a str (name or quant)\n"
+                   + "    - a list of str\n"
+                   + "    Provided: {}".format(X))
             raise Exception(msg)
         if c1 and len(X) == 1:
             X = X[0]

--- a/tofu/imas2tofu/_comp_toobjects.py
+++ b/tofu/imas2tofu/_comp_toobjects.py
@@ -364,14 +364,16 @@ def plasma_checkformat_dsig(dsig=None,
 
     # Convert to dict
     if lc[0]:
-        dsig = {}
-        dsig = {ids: sorted(set(list(dshort[ids].keys())
-                                + list(dcomp[ids].keys())))
-                for ids in lidsok}
+        dsig = dict.fromkeys(lidsok)
     elif lc[1] or lc[2]:
         if lc[1]:
             dsig = [dsig]
-        dsig = {ids: dsig for ids in lidsok}
+        dsig = dict.fromkeys(lidsok.intersection(dsig))
+
+    for ids in dsig.keys():
+        if dsig[ids] is None:
+            dsig[ids] = sorted(set(list(dshort[ids].keys())
+                                   + list(dcomp[ids].keys())))
 
     # Check content
     dout = {}

--- a/tofu/imas2tofu/_comp_toobjects.py
+++ b/tofu/imas2tofu/_comp_toobjects.py
@@ -659,7 +659,8 @@ def data_checkformat_tlim(t, tlim=None,
                + "  You provided: {}".format(tlim))
         if any([isinstance(tt, str) for tt in tlim]):
             msg += '\n\nAvailable events:\n' + str(names)
-        raise Exception(msg)
+        warnings.warn(msg)
+        tlim = False
     if tlim is None:
         tlim = False
 

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -1667,7 +1667,7 @@ class MultiIDSLoader(object):
 
         # -------------
         # Trival case
-        if len(dextra) == 0:
+        if dextra in [None, (None, None)] or len(dextra) == 0:
             if fordata:
                 return None
             else:

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -2357,7 +2357,7 @@ class MultiIDSLoader(object):
                 names, times = self.get_events(verb=False, returnas=tuple)
             except Exception as err:
                 msg = (str(err)
-                       + "\nEvents could not be loaded from ids pulse_schedule!")
+                       + "\nEvents not loaded from ids pulse_schedule!")
                 warnings.warn(msg)
         if 'pulse_schedule' in self._dids.keys():
             idd = self._dids['pulse_schedule']['idd']

--- a/tofu/imas2tofu/_def.py
+++ b/tofu/imas2tofu/_def.py
@@ -552,7 +552,10 @@ def _events(names, t):
 
 
 def _RZ2array(ptsR, ptsZ):
-    return np.array([ptsR, ptsZ]).T
+    out = np.array([ptsR, ptsZ]).T
+    if out.ndim == 1:
+        out = out[None, :]
+    return out
 
 
 def _losptsRZP(*pt12RZP):


### PR DESCRIPTION
Motivation:
--------------
*exporting to a Plasma2D instance from a MultiIDSLoader should work on ITER, even with quasi-empty equilibrium and only one time slice

Main changes:
--------------------
* Multi.to_Plasma2D() is now more robust, the user can pick the desired ids, the error messages are more detailed, and the user can exclude any dextra
* The Multi.get_data() method is now less verbose and more compact

Working example:
------------------------
```
In[9]: multi = tf.imas2tofu.MultiIDSLoader(ids=['edge_sources', 'edge_profiles', 'equilibrium'], shot=134000, run=30, tokamak='iter', user='public')
Getting ids     [occ]  tokamak  user    version  shot    run  refshot  refrun
--------------  -----  -------  ------  -------  ------  ---  -------  ------
edge_profiles   [0]    iter     public  3        134000  30   -1       -1    
edge_sources    [0]    "        "       "        "       "    "        "     
equilibrium     [0]    "        "       "        "       "    "        "     
pulse_schedule  [0]    "        "       "        "       "    "        "     
wall            [0]    "        "       "        "       "    "        "     

In [10]: plasma = multi.to_Plasma2D(dsig=['edge_sources', 'edge_profiles'], dextra=False)
```

Issues:
---------
Fixes, in devel, issue #429 
