### PR TITLE
Update python-package-pip-testing.yml

### DIFF
--- a/.github/workflows/python-package-pip-testing.yml
+++ b/.github/workflows/python-package-pip-testing.yml
@@ -38,7 +38,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: install tofu
       run: |
-        pip install -e ".[dev]"
+        pip install -e ".[dev]" --no-build-isolation
     - name: Test with pytest and coverage
       run: |
         coverage run --source=tofu/ -m pytest tofu/tests -v --durations=10


### PR DESCRIPTION
There seems to be a big issue with the cython/numpy versions 
https://github.com/scikit-learn-contrib/hdbscan/issues/457#issuecomment-773671043

i'm trying one of the solutions suggested, if it's not working will probably have to force numpy to 1.20