### PR TITLE
[doc] corrected nosetest > pytest

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -81,7 +81,7 @@ environment.
    (long) <https://www.atlassian.com/git/tutorials>`__ or `this short
    one <https://rogerdudler.github.io/git-guide/>`__
 -  Compile ``python setup.py build_ext --inplace``
--  Make sure tests are running ``nosetests``
+-  Make sure tests are running ``pytest tofu/tests``
 
 
 Where to start?

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -145,4 +145,4 @@ To install tofu as a developer, we recommend using the conda ecosystem (Minicond
 -  Run ``pip install -e .[dev]``. This will install dependencies, compile the
    tofu cython extensions and install it into your conda environment while you can still
    modify the source files in the current repository.`
--  Make sure tofu tests are running by typing ``nosetests``
+-  Make sure tofu tests are running by typing ``pytest tofu/tests``


### PR DESCRIPTION
Corrected the doc to use `pytest` instead of `nosetest`