### PR TITLE
Issue #473 explicit arguments for create cam

### DIFF
--- a/examples/tutorials/tuto_plot_basic.py
+++ b/examples/tutorials/tuto_plot_basic.py
@@ -29,7 +29,7 @@ import tofu as tf
 # structures. `tofu` provides pre-defined ones for your to try, so we're going
 # to do just that:
 
-configB2 = tf.load_config_config("B2")
+configB2 = tf.load_config("B2")
 
 ###############################################################################
 # The configuration can easily be visualized using the `.plot()` method:

--- a/examples/tutorials/tuto_plot_basic.py
+++ b/examples/tutorials/tuto_plot_basic.py
@@ -29,7 +29,7 @@ import tofu as tf
 # structures. `tofu` provides pre-defined ones for your to try, so we're going
 # to do just that:
 
-configB2 = tf.geom.utils.create_config("B2")
+configB2 = tf.load_config_config("B2")
 
 ###############################################################################
 # The configuration can easily be visualized using the `.plot()` method:
@@ -42,11 +42,11 @@ configB2.plot()
 
 cam1d = tf.geom.utils.create_CamLOS1D(
     config=configB2,
-    P=[3.4, 0, 0],
-    N12=100,
-    F=0.1,
-    D12=0.1,
-    angs=[np.pi, 0, 0],
+    pinhole=[3.4, 0, 0],
+    sensor_nb=100,
+    focal=0.1,
+    sensor_size=0.1,
+    orientation=[np.pi, 0, 0],
     Name="",
     Exp="",
     Diag="",
@@ -60,11 +60,11 @@ cam1d.plot_touch()
 
 cam2d = tf.geom.utils.create_CamLOS2D(
     config=configB2,
-    P=[3.4, 0, 0],
-    N12=100,
-    F=0.1,
-    D12=0.1,
-    angs=[np.pi, 0, 0],
+    pinhole=[3.4, 0, 0],
+    sensor_nb=100,
+    focal=0.1,
+    sensor_size=0.1,
+    orientation=[np.pi, 0, 0],
     Name="",
     Exp="",
     Diag="",

--- a/examples/tutorials/tuto_plot_custom_emissivity.py
+++ b/examples/tutorials/tuto_plot_custom_emissivity.py
@@ -17,11 +17,11 @@ configB2 = tf.geom.utils.create_config("B2")
 
 cam2d = tf.geom.utils.create_CamLOS2D(
     config=configB2,
-    P=[3.4, 0, 0],
-    N12=100,
-    F=0.1,
-    D12=0.1,
-    angs=[np.pi, np.pi/6, 0],
+    pinhole=[3.4, 0, 0],
+    sensor_nb=100,
+    focal=0.1,
+    sensor_size=0.1,
+    orientation=[np.pi, np.pi/6, 0],
     Name="",
     Exp="",
     Diag="",

--- a/examples/tutorials/tuto_plot_gallery_fusion_machines.py
+++ b/examples/tutorials/tuto_plot_gallery_fusion_machines.py
@@ -21,7 +21,7 @@ import tofu as tf
 # components is printed. This allows inspecting the component names, number
 # of sections, color or visibility.
 
-config = tf.geom.utils.create_config("ITER")  # create ITER configuration
+config = tf.load_config("ITER")  # create ITER configuration
 print(config)
 
 ###############################################################################
@@ -36,5 +36,5 @@ print(tf.geom.utils.get_available_config())
 
 for fusion_machine in ['ITER', 'WEST', 'JET', 'NSTX', 'AUG', 'DEMO', 'TOMAS',
                        'COMPASS', 'TCV']:
-    config = tf.geom.utils.create_config(fusion_machine)
+    config = tf.load_config(fusion_machine)
     config.plot()

--- a/tofu/geom/utils.py
+++ b/tofu/geom/utils.py
@@ -1081,6 +1081,10 @@ def _create_CamLOS_check_inputs(
     D12=None,       # Deprecated
     orientation=None,
     angs=None,      # Deprecated
+    etendues=None,
+    Etendues=None,  # Deprecated
+    surfaces=None,
+    Surfaces=None,  # Deprecated
     config=None,
     Name=None,
     nD=None,
@@ -1145,6 +1149,8 @@ def _create_CamLOS_check_inputs(
         'sensor_size': [sensor_size, D12, 'D12'],
         'sensor_nb': [sensor_nb, N12, 'N12'],
         'orientation': [orientation, angs, 'angs'],
+        'etendues': [etendues, Etendues, 'Etendues'],
+        'surfaces': [surfaces, Surfaces, 'Surfaces'],
     }
     ldprec = sorted([
         (ss, '{}  ->  {}'.format(vv[2], ss)) for ss, vv in dprecate.items()
@@ -1192,6 +1198,7 @@ def _create_CamLOS_check_inputs(
     out = [
         nD, Lim, VType, defRY,
         pinhole, focal, sensor_size, sensor_nb, orientation, nIn, Name,
+        etendues, surfaces,
     ]
 
     return out
@@ -1210,8 +1217,10 @@ def _create_CamLOS(
     orientation=None,
     angs=None,      # Deprecated
     config=None,
-    Etendues=None,
-    Surfaces=None,
+    Etendues=None,  # Deprecated
+    etendues=None,
+    Surfaces=None,  # Deprecated
+    surfaces=None,
     Exp=None,
     Diag=None,
     Name=None,
@@ -1232,6 +1241,7 @@ def _create_CamLOS(
     (
         nD, Lim, VType, defRY,
         pinhole, focal, sensor_size, sensor_nb, orientation, nIn, Name,
+        etendues, surfaces,
     ) = _create_CamLOS_check_inputs(
         case=case,
         pinhole=pinhole, P=P,
@@ -1239,6 +1249,8 @@ def _create_CamLOS(
         sensor_nb=sensor_nb, N12=N12,
         sensor_size=sensor_size, D12=D12,
         orientation=orientation, angs=angs,
+        Etendues=Etendues, etendues=etendues,
+        Surfaces=Surfaces, surfaces=surfaces,
         config=config,
         Name=Name,
         nD=nD,
@@ -1282,7 +1294,7 @@ def _create_CamLOS(
         cam = cls(
             Name=Name, Exp=Exp, Diag=Diag,
             dgeom={'pinhole': pinhole, 'D': Ds}, method=method,
-            Etendues=Etendues, Surfaces=Surfaces, dchans=dchans,
+            Etendues=etendues, Surfaces=surfaces, dchans=dchans,
             color=color, config=config, SavePath=SavePath
         )
         return cam

--- a/tofu/geom/utils.py
+++ b/tofu/geom/utils.py
@@ -993,7 +993,25 @@ _dcam = {'V1':       {'P':_P1, 'F':_F, 'D12':_D12, 'nIn':_nIn1, 'N12':[1,1]},
 
 
 
-_createCamstr = """ Create a pinhole CamLOS{0}D
+_createCamstr = """
+    Create a pinhole CamLOS{0}D
+
+    Typical use case:
+        >>> import tofu as tf
+        >>> conf = tf.load_config('WEST')
+        >>> cam1d = tf.geom.utils.create_CamLOS1D(
+            pinhole=[],
+            focal=,
+            npix=,
+            size=,
+            angles=[],
+            config=conf,
+            Etendues=,
+            Surfaces=,
+            Exp='WEST',
+            Diag='Bolo',
+            Name='Cam1',
+        )
 
     In tofu, a CamLOS is a camera described as a set of Lines of Sight (LOS),
     as opposed to a Cam, where the Volume of Sight (VOS) of all pixels are
@@ -1030,7 +1048,7 @@ _createCamstr = """ Create a pinhole CamLOS{0}D
 
     Return
     ------
-                """
+    """
 
 _createCamerr = """ Arg out, specifying the output, must be either:
         - object   : return a tofu object
@@ -1038,12 +1056,31 @@ _createCamerr = """ Arg out, specifying the output, must be either:
         - 'pinhole': return the starting points (D), pinhole (P) and the coordinates of D in the camera frame
         """
 
-def _create_CamLOS(case=None, nD=1, Etendues=None, Surfaces=None,
-                   dchans=None, Exp=None, Diag=None, Name=None, color=None,
-                   P=None, F=0.1, D12=0.1, N12=100, method=None,
-                   angs=[-np.pi,0.,0.], nIn=None, VType='Tor', dcam=_dcam,
-                   defRY=None, Lim=None, config=None, out=object,
-                   SavePath='./'):
+def _create_CamLOS(
+    case=None,
+    nD=1,
+    Etendues=None,
+    Surfaces=None,
+    dchans=None,
+    Exp=None,
+    Diag=None,
+    Name=None,
+    color=None,
+    P=None,
+    F=0.1,
+    D12=0.1,
+    N12=100,
+    method=None,
+    angs=[-np.pi,0.,0.],
+    nIn=None,
+    VType='Tor',
+    dcam=_dcam,
+    defRY=None,
+    Lim=None,
+    config=None,
+    out=object,
+    SavePath='./',
+):
     assert nD in [1,2]
     if not out in [object,'object','Du','dict',dict]:
         msg = _createCamerr.format('1')

--- a/tofu/geom/utils.py
+++ b/tofu/geom/utils.py
@@ -1148,31 +1148,31 @@ def _create_CamLOS_check_inputs(
         'orientation': [orientation, angs, 'angs'],
     }
     ldprec = sorted([
-        '{}  ->  {}'.format(vv[2], ss) for ss, vv in dprecate.items()
+        (ss, '{}  ->  {}'.format(vv[2], ss)) for ss, vv in dprecate.items()
         if vv[1] is not None
     ])
     if len(ldprec) > 0:
         msg = (
             """
-            The following arguments (left column) are deprecated:
-            {}
-            Please use the new forms (right column)
-            They are equivalent, but more explicit
-            Old forms will not work in future versions
+    The following arguments (left column) are deprecated:
+    {}
+    Please use the new forms (right column)
+    They are equivalent, but more explicit
+    Old forms will not work in future versions
             """.format(
-                '\t- ' + '\n\t- '.join(ldprec),
+                '\t- ' + '\n\t- '.join([ll[1] for ll in ldprec]),
             )
         )
-        raise DeprecationWarning(msg)
+        warnings.warn(msg, DeprecationWarning)
 
-        for ss in ldprec:
-            if ldprec[ss][0] is None:
-                ldprec[ss][0] = ldprec[ss][1]
-        pinhole = ldprec['pinhole'][0]
-        focal = ldprec['focal'][0]
-        sensor_size = ldprec['sensor_size'][0]
-        sensor_nb = ldprec['sensor_nb'][0]
-        orientation = ldprec['orientation'][0]
+        for ss, _ in ldprec:
+            if dprecate[ss][0] is None:
+                dprecate[ss][0] = dprecate[ss][1]
+        pinhole = dprecate['pinhole'][0]
+        focal = dprecate['focal'][0]
+        sensor_size = dprecate['sensor_size'][0]
+        sensor_nb = dprecate['sensor_nb'][0]
+        orientation = dprecate['orientation'][0]
 
     # returnas
     c0 = returnas in ['Du', dict, object]

--- a/tofu/geom/utils.py
+++ b/tofu/geom/utils.py
@@ -992,7 +992,6 @@ _dcam = {'V1':       {'P':_P1, 'F':_F, 'D12':_D12, 'nIn':_nIn1, 'N12':[1,1]},
          'testV': {'P':_P, 'F':_testF, 'D12':_D12, 'nIn':_nIn,'N12':[1600,625]}}
 
 
-
 _createCamstr = """
     Create a pinhole CamLOS{0}D
 
@@ -1095,7 +1094,7 @@ def _create_CamLOS_check_inputs(
     # D
     if nD is None:
         nD = 1
-    if not nD in [1, 2]:
+    if nD not in [1, 2]:
         msg = (
             """
             Arg nD must be 1 or 2
@@ -1268,8 +1267,8 @@ def _create_CamLOS(
         dout = {'D': Ds, 'pinhole': pinhole}
         if nD == 2:
             dout.update({
-                'x1': d1,'x2': d2,
-                'indflat2img': indflat2img, 'indimg2flat': indimg2flat
+                'x1': d1, 'x2': d2,
+                'indflat2img': indflat2img, 'indimg2flat': indimg2flat,
             })
         return dout
 

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.9-120-g800183db'
+__version__ = '1.4.9-122-g9620ac9d'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.9-122-g9620ac9d'
+__version__ = '1.4.9-128-g785ccd5a'


### PR DESCRIPTION
Motivations:
----------------
* Geometrical qrgument names for tf.geom.utils.create-CamLOS1D() and tf.geom.utils.create-CamLOS2D() were not clear and intuitive enough
* The docstrings did not provide enough clarification
* But args cannot be changed abruptly between 2 versions, some time has to be given to users to adapt
* 
Main changes:
--------------------
* New arguments have been implemented:
P      ->  pinhole
F      ->  focal
D12  -> sensor_size
N12  -> sensor_nb
angs -> orientation
* But old arguments are still operation, for retro-compatibility
* A DeprecationWarning is raised everytime a user passes an old argument, warning him to use a new one instead and that the old ones will not be supported in the future
* The docstr now include 2 fully operational example that can be copy-pasted directly into the console

Example:
-------------
Copy-pasting the docstr example (which includes a short comment for each arg):
```
        >>> import tofu as tf                                                   
        >>> conf = tf.load_config('WEST')                                       
        >>> cam1d = tf.geom.utils.create_CamLOS1D(                              
            pinhole=[3., 0., 0.],       # pinhole position [X, Y, Z] [m]        
            focal=0.1,                  # pinhole-sensors distance [m]          
            sensor_nb=100,              # number of sensors on sensor plane     
            sensor_size=0.1,            # size of sensor plane [m]              
            orientation=[np.pi, 0., 0.],# 3 angles orienting whole camera [rad] 
            config=conf,                # configuration (for computing LOS)     
            Etendues=None,              # Etendues (optional)                   
            Surfaces=None,              # Surfaces (optional) [m^2]             
            Exp='WEST',                 # Experiment                            
            Diag='Bolo',                # Diagnostic                            
            Name='Cam1',                # Name of this particular camera        
        )                                                                       
        >>> cam2d = tf.geom.utils.create_CamLOS2D(                              
            pinhole=[3., 0., 0.],       # pinhole position [X, Y, Z] [m]        
            focal=0.1,                  # pinhole-sensors distance [m]          
            sensor_nb=[100, 100],       # number of sensors on sensor plane     
            sensor_size=[0.1, 0.1],     # size of sensor plane [m]              
            orientation=[np.pi, 0., 0.],# 3 angles orienting whole camera [rad] 
            config=conf,                # configuration (for computing LOS)     
            Etendues=None,              # Etendues (optional)                   
            Surfaces=None,              # Surfaces (optional) [m^2]             
            Exp='WEST',                 # Experiment                            
            Diag='Bolo',                # Diagnostic                            
            Name='Cam1',                # Name of this particular camera        
        )
```

Testing the Deprecation Warning:
```
cam1d = tf.geom.utils.create_CamLOS1D(pinhole=[3., 0., 0.], F=0.1, N12=100, sensor_size=0.1, angs=[np.pi, 0., 0.], config=conf, Etendues=None, Surfaces=None, Exp='WEST', Diag='Bolo', Name='Cam1')
/home/didier/Documents/Projects/tofu/tofu/geom/utils.py:1166: DeprecationWarning: 
    The following arguments (left column) are deprecated:
    	- F  ->  focal
	- angs  ->  orientation
	- N12  ->  sensor_nb
    Please use the new forms (right column)
    They are equivalent, but more explicit
    Old forms will not work in future versions
            
  warnings.warn(msg, DeprecationWarning)
```

Note:
-------
If the warning doesn't show it may be because a warning filter has been set-up to ignore DeprecationWarnings
=> To reset it type:
```
import warnings
warnings.filterwarnings('default')
```

Issues:
---------
* Fixes, in devel, issue #473




