### PR TITLE
Issue #475 Remove some easy warnings

### DIFF
--- a/tofu/data/_core.py
+++ b/tofu/data/_core.py
@@ -3107,21 +3107,21 @@ class Plasma2D(utils.ToFuObject):
             out = ind, lid
         return out
 
-    def _get_keyingroup(self, str_, group=None, msgstr=None, raise_=False):
+    def _get_keyingroup(self, key, group=None, msgstr=None, raise_=False):
 
-        if str_ in self._ddata.keys():
-            lg = self._ddata[str_]['lgroup']
+        if key in self._ddata.keys():
+            lg = self._ddata[key]['lgroup']
             if group is None or group in lg:
-                return str_, None
+                return key, None
             else:
                 msg = ("Required data key does not have matching group:\n"
-                       + "\t- ddata[{}]['lgroup'] = {}\n".format(str_, lg)
+                       + "\t- ddata[{}]['lgroup'] = {}\n".format(key, lg)
                        + "\t- Expected group:  {}".format(group))
                 if raise_:
                     raise Exception(msg)
 
-        ind, akeys = self._get_ldata(dim=str_, quant=str_, name=str_, units=str_,
-                                     origin=str_, group=group, log='raw',
+        ind, akeys = self._get_ldata(dim=key, quant=key, name=key, units=key,
+                                     origin=key, group=group, log='raw',
                                      return_key=False)
         # Remove indref and group
         ind = ind[:5,:] & ind[-1,:]
@@ -3136,13 +3136,13 @@ class Plasma2D(utils.ToFuObject):
                 key = akeys[indkey][0]
             else:
                 lstr = "[dim,quant,name,units,origin]"
-                msg = "Several possible unique matches in %s for %s"(lstr,str_)
+                msg = "Several possible matches in {} for {}".format(lstr, key)
         else:
             lstr = "[dim,quant,name,units,origin]"
-            msg = "No unique match in %s for %s in group %s"%(lstr,str_,group)
+            msg = "No match in {} for {} in group {}".format(lstr, key, group)
 
         if msg is not None:
-            msg += "\n\nRequested %s could not be identified !\n"%msgstr
+            msg += "\n\nRequested {} could not be identified!\n".format(msgstr)
             msg += "Please provide a valid (unique) key/name/quant/dim:\n\n"
             msg += self.get_summary(verb=False, return_='msg')
             if raise_:

--- a/tofu/geom/_core.py
+++ b/tofu/geom/_core.py
@@ -4932,7 +4932,7 @@ class Rays(utils.ToFuObject):
                 else:
                     num_tot_structs += len(ss.Lim)
 
-            lsnvert = np.asarray(lsnvert, dtype=np.long)
+            lsnvert = np.asarray(lsnvert, dtype=int)
             lSPolyx = np.asarray(lSPolyx)
             lSPolyy = np.asarray(lSPolyy)
             lSVInx = np.asarray(lSVInx)
@@ -4944,7 +4944,7 @@ class Rays(utils.ToFuObject):
                         lstruct_polyx=lSPolyx,
                         lstruct_polyy=lSPolyy,
                         lstruct_lims=lSLim,
-                        lstruct_nlim=np.asarray(lSnLim, dtype=np.long),
+                        lstruct_nlim=np.asarray(lSnLim, dtype=int),
                         lstruct_normx=lSVInx,
                         lstruct_normy=lSVIny,
                         lnvert=lsnvert,
@@ -5919,7 +5919,7 @@ class Rays(utils.ToFuObject):
         if ind is not None:
             ind = np.asarray(ind)
             assert ind.ndim == 1
-            assert ind.dtype in [np.int64, np.bool_, np.long]
+            assert ind.dtype in [np.int64, np.bool_, int]
             if ind.dtype == np.bool_:
                 assert ind.size == self.nRays
                 if out is int:

--- a/tofu/geom/_def.py
+++ b/tofu/geom/_def.py
@@ -302,18 +302,10 @@ LOSdict = dict(Lax=None, Proj='All', Lplot=LOSLplot, Elt='LDIORP', EltVes='', Le
 # -------------- Figures ------------------------
 
 
-
-
-
-
 """
 #####################################################################
 ###################### Lens class  ################################
 #####################################################################
-
-
-
-
 
 
 # -------------- Figures ------------------------
@@ -330,9 +322,6 @@ def Plot_Lens_Alone_DefAxes(fs=None, wintit='tofu'):
     ax.set_xlabel(r"x (m)")
     ax.set_ylabel(r"y (m)")
     return ax
-
-
-
 
 #####################################################################
 ###################### Detect class  ################################
@@ -570,12 +559,5 @@ def Plot_GDetect_Resolution_DefAxes(VType='Tor', fs=None, wintit='tofu'):
     ax3.set_ylabel(r"Signal (mW)")
     ax1.set_aspect(aspect='equal',adjustable='datalim')
     return ax1, ax2, ax3
-
-
-
-
-
-
-
 
 """

--- a/tofu/pathfile.py
+++ b/tofu/pathfile.py
@@ -393,7 +393,7 @@ class ID(object):
         return self._Name
     @property
     def NameLTX(self):
-        return r"$"+self.Name.replace('_','\_')+r"$"
+        return r"$" + self.Name.replace('_', '\_') + r"$"
     @property
     def Exp(self):
         return self._Exp

--- a/tofu/tests/tests01_geom/test_01_GG.py
+++ b/tofu/tests/tests01_geom/test_01_GG.py
@@ -1797,16 +1797,16 @@ def test24_is_visible(debug=2):
             shot=0
         )
         s1 = tfg.PFC(Name="S1",
-                     Poly=[SP0x, SP0y],
+                     Poly=[SP0x[:-1], SP0y[:-1]],
                      Exp="Misc",
                      shot=0)
         s2 = tfg.PFC(Name="S2",
-                     Poly=[SP1x, SP1y],
+                     Poly=[SP1x[:-1], SP1y[:-1]],
                      Exp="Misc",
                      shot=0,
                      Lim=SL1)
         s3 = tfg.PFC(Name="S3",
-                     Poly=[SP2x, SP2y],
+                     Poly=[SP2x[:-1], SP2y[:-1]],
                      Exp="Misc",
                      shot=0,
                      Lim=SL2)

--- a/tofu/tests/tests02_data/test_03_core.py
+++ b/tofu/tests/tests02_data/test_03_core.py
@@ -305,7 +305,7 @@ class Test01_DataCam12D(object):
 
     def test10_dtreat_set_interp_indch(self):
         for oo in self.lobj:
-            ind = np.arange(0, oo.nch, 10, dtype=np.long)
+            ind = np.arange(0, oo.nch, 10, dtype=int)
             oo.set_dtreat_interp_indch( ind )
             assert oo._dtreat['interp-indch'].sum() == ind.size
 

--- a/tofu/utils.py
+++ b/tofu/utils.py
@@ -2143,8 +2143,11 @@ class ToFuObjectBase(object):
                         if eqk:
                             eqk = d0[k].dtype == d1[k].dtype
                             if eqk:
-                                if (issubclass(d0[k].dtype.type, int)
-                                    or issubclass(d0[k].dtype.type, float)):
+                                c0 = (
+                                    issubclass(d0[k].dtype.type, int)
+                                    or issubclass(d0[k].dtype.type, float)
+                                )
+                                if c0:
                                     eqk = np.allclose(d0[k],d1[k], equal_nan=True)
                                 else:
                                     eqk = np.all(d0[k]==d1[k])

--- a/tofu/utils.py
+++ b/tofu/utils.py
@@ -367,9 +367,9 @@ def _save_npzmat_dict(dd, sep=None):
             # None will be recreated at load time
             pass
         elif (type(dd[k]) in [int,float,bool,str]
-              or issubclass(dd[k].__class__,np.int)
-              or issubclass(dd[k].__class__,np.float)
-              or issubclass(dd[k].__class__,np.bool_)):
+              or issubclass(dd[k].__class__, int)
+              or issubclass(dd[k].__class__, float)
+              or issubclass(dd[k].__class__, np.bool_)):
             dnpzmat[k] = np.asarray([dd[k]])
         elif type(dd[k]) in [tuple,list]:
             dnpzmat[k] = np.asarray(dd[k])
@@ -2143,8 +2143,8 @@ class ToFuObjectBase(object):
                         if eqk:
                             eqk = d0[k].dtype == d1[k].dtype
                             if eqk:
-                                if (issubclass(d0[k].dtype.type, np.int)
-                                    or issubclass(d0[k].dtype.type, np.float)):
+                                if (issubclass(d0[k].dtype.type, int)
+                                    or issubclass(d0[k].dtype.type, float)):
                                     eqk = np.allclose(d0[k],d1[k], equal_nan=True)
                                 else:
                                     eqk = np.all(d0[k]==d1[k])
@@ -2800,7 +2800,7 @@ class ID(ToFuObjectBase):
         return self._dall['Name']
     @property
     def NameLTX(self):
-        return r"$"+self.Name.replace('_','\_')+r"$"
+        return r"$" + self.Name.replace('_', '\_') + r"$"
     @property
     def Exp(self):
         return self._dall['Exp']

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.9-130-g957cb0b8'
+__version__ = '1.4.9-131-g81452aff'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.9-128-g785ccd5a'
+__version__ = '1.4.9-130-g957cb0b8'


### PR DESCRIPTION
Motivations:
--------------
* The unit tests in [GA](https://github.com/ToFuProject/tofu/runs/2004133116?check_suite_focus=true) showed a few warnings that seemed easy to remove

Main changes:
----------------
* A few minor changes (in particular several occurences of `np.int`  or `np.long` replaced by `int` as recommended [here](https://numpy.org/devdocs/release/1.20.0-notes.html)).

Issues:
-------
* Fixes, in devel, issue #475 