### PR TITLE
Issue #480 Added requests to setup.py, requiremens.txt and conda_recipe/meta.yaml

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - Cython >=0.26
     - pytest
     - pygments
+    - requests
 
 test:
   requires:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 numpy
 scipy
 matplotlib
+requests
 
 ######## Requirements with Version Specifier ########
 Cython>=0.26

--- a/setup.py
+++ b/setup.py
@@ -335,7 +335,13 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=["numpy", "scipy", "matplotlib", "cython>=0.26"],
+    install_requires=[
+        "numpy",
+        "scipy",
+        "matplotlib",
+        "requests",
+        "cython>=0.26",
+    ],
     python_requires=">=3.6",
 
     # List additional groups of dependencies here (e.g. development

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.9-131-g81452aff'
+__version__ = '1.4.9-135-g11043340'


### PR DESCRIPTION
Motivations:
--------------
* I realised one dependency was missing: the library `requests`
* It necessary only for the subpackage `openadas2tofu`, which is rarley used and not tested yet, which explains why we did notice it before

Main changes:
----------------
* Added to `setup.py`
* Added to `requirements.txt`
* Added to the run-time section of `conda_recipe/meta.yaml`

I think that's it, except if it is also needed in `pyproject.toml`?
@lasofivec, can you double-check whether all dependencies need to be in `pyproject.toml`? 
Currently `scipy`, `matplotlib` and `requests` are not in there.

Issues:
-------
* Fixes in devel issue #480 