### PR TITLE
Issue #442 read ids wall iter

### DIFF
--- a/scripts/_dparser.py
+++ b/scripts/_dparser.py
@@ -201,9 +201,10 @@ def parser_plot():
 
     tf, MultiIDSLoader, _defscripts = get_mods()
 
+    _LIDS_CONFIG = MultiIDSLoader._lidsconfig
     _LIDS_DIAG = MultiIDSLoader._lidsdiag
     _LIDS_PLASMA = tf.imas2tofu.MultiIDSLoader._lidsplasma
-    _LIDS = _LIDS_DIAG + _LIDS_PLASMA + tf.utils._LIDS_CUSTOM
+    _LIDS = _LIDS_CONFIG + _LIDS_DIAG + _LIDS_PLASMA + tf.utils._LIDS_CUSTOM
 
     msg = """Fast interactive visualization tool for diagnostics data in
     imas

--- a/tofu/imas2tofu/_comp_toobjects.py
+++ b/tofu/imas2tofu/_comp_toobjects.py
@@ -317,6 +317,7 @@ def config_extract_lS(ids, occ, wall, description_2d, mod,
             if name == '':
                 name = 'unit{:02.0f}'.format(ii)
             if '_' in name:
+                name = name.strip('_')
                 ln = name.split('_')
                 if len(ln) == 2:
                     cls, name = ln
@@ -324,6 +325,14 @@ def config_extract_lS(ids, occ, wall, description_2d, mod,
                     cls, name, mobi = ln
                 else:
                     name = name.replace('_', '')
+            if ' ' in name:
+                name = name.strip(' ')
+                ln = name.split(' ')
+                if len(ln) > 1:
+                    for ii, nn in enumerate(ln[1:]):
+                        if nn[0].islower():
+                            ln[ii+1] = nn.capitalize()
+                    name = ''.join(ln)
             if cls is None:
                 if ii == nunits - 1:
                     cls = 'Ves'

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -267,6 +267,8 @@ class MultiIDSLoader(object):
                 if not all([iids in self._IDS_BASE
                             for iids in self._dids.keys()]):
                     ids_base = True
+                else:
+                    ids_base = False
             if not isinstance(ids_base, bool):
                 msg = ("Arg ids_base must be bool:\n"
                        + "\t- False: adds no ids\n"

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -147,6 +147,7 @@ class MultiIDSLoader(object):
     # Known short version of signal str
     _dshort = _defimas2tofu._dshort
     _didsdiag = _defimas2tofu._didsdiag
+    _lidsconfig = _defimas2tofu._lidsconfig
     _lidsdiag = _defimas2tofu._lidsdiag
     _lidslos = _defimas2tofu._lidslos
     _lidssynth = _defimas2tofu._lidssynth

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -1634,6 +1634,22 @@ class MultiIDSLoader(object):
             Name = wall.type.name
             if Name == '':
                 Name = 'imas wall'
+        if '_' in Name:
+            Name = Name.strip('_')
+            ln = Name.split('_')
+            if len(ln) > 1:
+                for ii, nn in enumerate(ln[1:]):
+                    if nn[0].islower():
+                        ln[ii+1] = nn.capitalize()
+                Name = ''.join(ln)
+        if ' ' in Name:
+            Name = Name.strip(' ')
+            ln = Name.split(' ')
+            if len(ln) > 1:
+                for ii, nn in enumerate(ln[1:]):
+                    if nn[0].islower():
+                        ln[ii+1] = nn.capitalize()
+                Name = ''.join(ln)
         config = mod.Config(lStruct=lS, Name=Name, **kwargs)
 
         # Output

--- a/tofu/imas2tofu/_def.py
+++ b/tofu/imas2tofu/_def.py
@@ -509,7 +509,7 @@ _didsdiag = {
 #
 # ############################################################################
 
-
+_lidsconfig = ['wall']
 _lidsdiag = sorted([kk for kk, vv in _didsdiag.items() if 'sig' in vv.keys()])
 _lidslos = list(_lidsdiag)
 for ids_ in _lidsdiag:

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.10'
+__version__ = '1.4.9-146-gfea62254'


### PR DESCRIPTION
Motivation:
------------
* tofuplot was not able to load ids wall 
* The names of the structures stored in ids wall are non-conform (include blank spaces and underscores) and are not handled correctly by tofu

Main change:
---------------
* tofuplot can now handlle ids wall
* All names are now scanned for ' ' and '_' , which are removed and the various parts of the names are capitalized

Example (on hpc-login02):
-----------------------------
./tofu/entrypoints/tofuplot.py -i wall -tok ITER_MD -u public -r 17 -s 1180

![image](https://user-images.githubusercontent.com/5929562/110474466-fd42ae00-80df-11eb-8cb8-793deff31e9f.png)

Issues:
-------
* Issue #442 is fixed in devel
* Issue #485 is opened to address the fact that the polygons stored in IMAS are not closed and represent 2 parts of the same polygon.