### PR TITLE
[#500] Openadas on ITER

### DIFF
--- a/tofu/openadas2tofu/_requests.py
+++ b/tofu/openadas2tofu/_requests.py
@@ -31,6 +31,14 @@ _CREATE_CUSTOM = True
 _INCLUDE_PARTIAL = True
 
 
+_DCERTIFICATES_BUNDLE = {
+    'ITER': {
+        'host': 'iter.org',
+        'bund': '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',
+    },
+}
+
+
 # #############################################################################
 #                           Utility functions
 # #############################################################################
@@ -99,12 +107,43 @@ def _getcharray(ar, col=None, sep='  ', line='-', just='l',
 
 
 # #############################################################################
-#                          online search
+#                          online search - utilities
 # #############################################################################
 
 
 class FileAlreayExistsException(Exception):
     pass
+
+
+def _try_request_handle_ITER_SSL_step01(url=None):
+    try:
+        resp = requests.get(url)
+    except requests.exceptions.SSLError as err:
+        if 'certificate' in str(err):
+            lbund = [
+                vv['bund'] for kk, vv in _DCERTIFICATES_BUNDLE.items()
+                if os.uname()[1].endswith(vv['host'])
+            ]
+            if len(lbund) == 1:
+                resp = requests.get(url, verify=lbund[0])
+            else:
+                msg = (
+                    str(err)
+                    + "\n\nLooks like a certificate error occured!\n"
+                    + "=> try changing the certificate bundle of requests\n"
+                    + "=> ask your admin which certificate bundle to use!"
+                )
+                raise Exception(msg)
+        else:
+            raise err
+    except Exception as err:
+        raise err
+    return resp
+
+
+# #############################################################################
+#                          online search
+# #############################################################################
 
 
 def step01_search_online(
@@ -139,7 +178,7 @@ def step01_search_online(
                           for kk in searchstr.split(' ')])
 
     total_url = '{}{}&{}'.format(_URL_SEARCH, searchurl, 'searching=1')
-    resp = requests.get(total_url)
+    resp = _try_request_handle_ITER_SSL_step01(url=total_url)
 
     # Extract response from html
     out = resp.text.split('\n')
@@ -307,7 +346,7 @@ def step01_search_online_by_wavelengthA(
                           'resolveby={}'.format(resolveby)])
 
     total_url = '{}{}&{}'.format(_URL_SEARCH_WAVL, searchurl, 'searching=1')
-    resp = requests.get(total_url)
+    resp = _try_request_handle_ITER_SSL_step01(url=total_url)
 
     # Extract response from html
     out = resp.text.split('\n')
@@ -434,8 +473,48 @@ def step01_search_online_by_wavelengthA(
 
 
 # #############################################################################
-#                          Download
+#                          Download - utilities
 # #############################################################################
+
+
+def _try_request_handle_ITER_SSL_step02(url=None, pfe=None):
+    try:
+        with requests.get(url, stream=True) as rr:
+            rr.raise_for_status()
+            with open(pfe, 'wb') as ff:
+                for chunk in rr.iter_content(chunk_size=8192):
+                    # filter-out keep-alive new chunks
+                    if chunk:
+                        ff.write(chunk)
+                        # ff.flush()
+    except requests.exceptions.SSLError as err:
+        if 'certificate' in str(err):
+            lbund = [
+                vv['bund'] for kk, vv in _DCERTIFICATES_BUNDLE.items()
+                if os.uname()[1].endswith(vv['host'])
+            ]
+            if len(lbund) == 1:
+                with requests.get(url, stream=True, verify=lbund[0]) as rr:
+                    rr.raise_for_status()
+                    with open(pfe, 'wb') as ff:
+                        for chunk in rr.iter_content(chunk_size=8192):
+                            # filter-out keep-alive new chunks
+                            if chunk:
+                                ff.write(chunk)
+                                # ff.flush()
+            else:
+                msg = (
+                    str(err)
+                    + "\n\nLooks like a certificate error occured!\n"
+                    + "=> try changing the certificate bundle of requests\n"
+                    + "=> ask your admin which certificate bundle to use!"
+                )
+                raise Exception(msg)
+        else:
+            raise err
+    except Exception as err:
+        raise err
+
 
 
 def _check_exists(filename, update=None, create_custom=None):
@@ -483,6 +562,11 @@ def _check_exists(filename, update=None, create_custom=None):
             return True, pfe
     else:
         return False, pfe
+
+
+# #############################################################################
+#                          Download
+# #############################################################################
 
 
 def step02_download(
@@ -535,14 +619,7 @@ def step02_download(
     # ---------------------------
     # Download
     # Note the stream=True parameter below
-    with requests.get(url, stream=True) as rr:
-        rr.raise_for_status()
-        with open(pfe, 'wb') as ff:
-            for chunk in rr.iter_content(chunk_size=8192):
-                # filter-out keep-alive new chunks
-                if chunk:
-                    ff.write(chunk)
-                    # ff.flush()
+    _try_request_handle_ITER_SSL_step02(url=url, pfe=pfe)
 
     if verb is True:
         msg = ("file {} was copied to:\n".format(filename)


### PR DESCRIPTION
Motivations:
-----------------
* the submodule `openadas2tofu` directly sends a request online to [openadas](https://open.adas.ac.uk/) using the built-in library `requests`, read the answer (html), parse it and extract the info of interest
* It works fine at CEA and on my own laptop (and in unit tests on Travis and Github), but not on ITER clusters

Main Changes
--------------------
* A [ticket](https://jira.iter.org/browse/IMAS-3698?filter=-2) was opened to ask ITER admins their feeling about it
* It lead to the creation of a second [ticket](https://jira.iter.org/servicedesk/customer/portal/1/ITSD-191846) to the IT team
* It seems the requests library used, has its own list (bundle) of certificates for ssl connections, and apparently, for some unknown reason, this bundle of certificates does not include openadas's certificate on ITER's python intsllation
* The admin recommend to replace the library's bundle of certificates by the ITER server's bundle of certificates
* Instead of doing it from the bash command line, I implemented inside tofu.openadas2tofu a subrotuine that automatically tries to connect, and changes to the server's bundle of certiciates if the first attempt fails.
* This way it is transparent for the user who does not have to care about this

Example:
-------------
```
In [3]: tf.openadas2tofu.step01_search_online_by_wavelengthA(lambmin=3.94, lambmax=4, element='ar')
Wavelength  Element  Charge  Data Type  Transition                               Full file name                          
----------  -------  ------  ---------  ---------------------------------------  ----------------------------------------
3.94817     Ar       16+     ADF15      11513 ^{1}P_{1.0} -> 21 ^{1}S_{0.0}      /adf15/pec40][ar/pec40][ar_ic][ar16.dat 
3.94817     Ar       16+     ADF15      11513 ^{1}P_{1.0} -> 21 ^{1}S_{0.0}      /adf15/pec40][ar/pec40][ar_ls][ar16.dat 
3.96042     Ar       16+     ADF15      11513 ^{0}S_{5.5} -> 21 ^{0}S_{0.0}      /adf15/pec40][ar/pec40][ar_cl][ar16.dat 
3.96042     Ar       16+     ADF15      11513 ^{0}S_{5.5} -> 21 ^{0}S_{0.0}      /adf15/pec40][ar/pec40][ar_ca][ar16.dat 
3.96445     Ar       16+     ADF15      11513 ^{3}P_{4.0} -> 21 ^{1}S_{0.0}      /adf15/pec40][ar/pec40][ar_ls][ar16.dat 
3.96626     Ar       16+     ADF15      11513 ^{3}P_{1.0} -> 21 ^{1}S_{0.0}      /adf15/pec40][ar/pec40][ar_ic][ar16.dat 
3.96731     Ar       15+     ADF15      11512513 ^{2}P_{1.5} -> 12 ^{2}S_{0.5}   /adf15/pec40][ar/pec40][ar_ic][ar15.dat 
3.96832     Ar       15+     ADF15      11512513 ^{2}P_{0.5} -> 12 ^{2}S_{0.5}   /adf15/pec40][ar/pec40][ar_ic][ar15.dat 
3.97233     Ar       15+     ADF15      11512513 ^{2}P_{2.5} -> 12 ^{2}S_{0.5}   /adf15/pec40][ar/pec40][ar_ls][ar15.dat 
3.97612     Ar       15+     ADF15      11512513 ^{2}P_{2.5} -> 12 ^{2}S_{0.5}   /adf15/pec40][ar/pec40][ar_ls][ar15.dat 
3.98011     Ar       15+     ADF15      11512513 ^{2}P_{1.5} -> 12 ^{2}S_{0.5}   /adf15/pec40][ar/pec40][ar_ic][ar15.dat 
3.98225     Ar       15+     ADF15      11512513 ^{2}P_{0.5} -> 12 ^{2}S_{0.5}   /adf15/pec40][ar/pec40][ar_ic][ar15.dat 
3.99122     Ar       15+     ADF15      11512513 ^{0}S_{11.5} -> 12 ^{0}S_{0.5}  /adf15/pec40][ar/pec40][ar_cl][ar15.dat 
3.99122     Ar       15+     ADF15      11512513 ^{0}S_{11.5} -> 12 ^{0}S_{0.5}  /adf15/pec40][ar/pec40][ar_ca][ar15.dat 
4           Ar       16+     ADF15       ^{3}S_{1.0} ->  ^{1}S_{0.0}             /adf15/transport/transport_llu][ar16.dat
4           Ar       16+     ADF15       ^{3}P_{1.0} ->  ^{1}S_{0.0}             /adf15/transport/transport_llu][ar16.dat

```