### PR TITLE
Issue513 aug config not loading

### DIFF
--- a/tofu/geom/_core.py
+++ b/tofu/geom/_core.py
@@ -1969,7 +1969,7 @@ class Struct(utils.ToFuObject):
             if pfe[-4:] == '.csv':
                 delimiter = ', '
             else:
-                delimiter = ' '
+                delimiter = None
         if comments is None:
             comments = _COMMENT
 

--- a/tofu/geom/_def_config.py
+++ b/tofu/geom/_def_config.py
@@ -169,11 +169,11 @@ _DCONFIG = {
         'CoilPF': ['PF1', 'PF2', 'PF3', 'PF4', 'PF5', 'PF6'],
         'CoilCS': ['CS3U', 'CS2U', 'CS1U', 'CS1L', 'CS2L', 'CS3L'],
     },
-    'ITER-SOLEDGE3XV0': {
-        'Exp': _ExpITER,
-        'Ves': ['SOLEDGE3XV0'],
-        'PFC': ['SOLEDGE3XDivDomeV0', 'SOLEDGE3XDivSupportV0']
-    },
+    # 'ITER-SOLEDGE3XV0': {
+        # 'Exp': _ExpITER,
+        # 'Ves': ['SOLEDGE3XV0'],
+        # 'PFC': ['SOLEDGE3XDivDomeV0', 'SOLEDGE3XDivSupportV0']
+    # },
 
     # AUG
     'AUG-V1': {
@@ -240,7 +240,7 @@ _DCONFIG = {
 # the associated unique name it refers to
 _DCONFIG_SHORTCUTS = {
     'ITER': 'ITER-V2',
-    'ITER-SOLEDGE3X': 'ITER-SOLEDGE3XV0',
+    # 'ITER-SOLEDGE3X': 'ITER-SOLEDGE3XV0',
     'JET': 'JET-V0',
     'WEST': 'WEST-V4',
     'A1': 'WEST-V1',

--- a/tofu/geom/utils.py
+++ b/tofu/geom/utils.py
@@ -718,6 +718,7 @@ def _create_config_testcase_check_inputs(
     dconfig=None,
     dconfig_shortcuts=None,
     returnas=None,
+    strict=None,
 ):
     # config
     if config is None:
@@ -759,7 +760,15 @@ def _create_config_testcase_check_inputs(
         msg = ("Arg returnas must be either object or dict!\n"
                + "\t-Provided: {}".format(returnas))
         raise Exception(msg)
-    return config, path, dconfig, dconfig_shortcuts, returnas
+
+    # strict
+    if strict is None:
+        strict = False
+    if not isinstance(strict, bool):
+        msg = ("Arg strict must be a bool!\n"
+               + "\t-Provided: {}".format(strict))
+        raise Exception(msg)
+    return config, path, dconfig, dconfig_shortcuts, returnas, strict
 
 
 def _create_config_testcase(
@@ -768,6 +777,7 @@ def _create_config_testcase(
     dconfig=None,
     dconfig_shortcuts=None,
     returnas=None,
+    strict=None,
 ):
     """ Load the desired test case configuration
 
@@ -777,13 +787,17 @@ def _create_config_testcase(
 
     # -----------
     # Check input
-    (config, path, dconfig,
-     dconfig_shortcuts, returnas) = _create_config_testcase_check_inputs(
+    (
+        config, path, dconfig,
+        dconfig_shortcuts,
+        returnas, strict,
+    ) = _create_config_testcase_check_inputs(
         config=config,
         path=path,
         dconfig=dconfig,
         dconfig_shortcuts=dconfig_shortcuts,
         returnas=returnas,
+        strict=strict,
      )
 
     # --------------------------
@@ -819,39 +833,68 @@ def _create_config_testcase(
         ])
 
     Exp = dconfig[config]['Exp']
+    dfail = {}
     for cc in lcls:
         for ss in dconfig[config][cc]:
-            ff = [f for f in lf
-                  if all([s in f for s in [cc, Exp, ss]])]
+            k0 = '{}_{}'.format(cc, ss)
+            ff = [
+                f for f in lf
+                if all([s in f for s in [cc, Exp, ss]])
+            ]
             if len(ff) == 0:
-                msg = "No matching files\n"
-                msg += "  Folder: %s\n"%path
-                msg += "    Criteria: [%s, %s]\n"%(cc,ss)
-                msg += "    Matching: "+"\n              ".join(ff)
-                raise Exception(msg)
+                msg = (
+                    "No matching files in {} ".format(path)
+                    + "for ['{}', '{}']".format(cc, ss)
+                )
+                dfail[k0] = msg
+                continue
             elif len(ff) > 1:
                 # More demanding criterion
                 ssbis, Expbis = '_'+ss+'.txt', '_Exp'+Exp+'_'
                 ff = [fff for fff in ff if ssbis in fff and Expbis in fff]
-                if len(ff) != 1:
-                    msg = ("No / several matching files\n"
-                           + "  Folder: {}\n".format(path)
-                           + "    Criteria: [{}, {}]\n".format(cc, ss)
-                           + "    Matching: "+"\n              ".join(ff))
-                    raise Exception(msg)
+                if len(ff) == 0:
+                    msg = (
+                        "No matching files in {} ".format(path)
+                        + "for ['{}', '{}', '{}']".format(cc, ssbis, Expbis)
+                    )
+                    dfail[k0] = msg
+                    continue
+                elif len(ff) > 1:
+                    msg = (
+                        "Many ({}) matching files in {} ".format(len(ff), path)
+                        + "for ['{}', '{}', '{}']".format(cc, ssbis, Expbis)
+                    )
+                    dfail[k0] = msg
+                    continue
 
             pfe = os.path.join(path, ff[0])
             try:
-                obj = eval('_core.'+cc).from_txt(pfe, Name=ss, Type='Tor',
-                                                 Exp=dconfig[config]['Exp'],
-                                                 returnas=returnas)
+                obj = eval('_core.'+cc).from_txt(
+                    pfe, Name=ss, Type='Tor',
+                    Exp=dconfig[config]['Exp'],
+                    returnas=returnas,
+                )
                 if returnas not in ['object', object]:
-                    obj = ((ss, {'Poly': obj[0],
-                                 'pos': obj[1], 'extent': obj[2]}),)
+                    obj = ((
+                        ss, {'Poly': obj[0], 'pos': obj[1], 'extent': obj[2]}
+                    ),)
                 lS.append(obj)
             except Exception as err:
-                msg = "Could not be loaded: {}".format(ff[0])
-                warnings.warn(msg)
+                msg = "Error loading: {}".format(str(err))
+                dfail[k0] = msg
+                continue
+
+    if len(dfail) > 0:
+        lstr = ['\t- {}: {}'.format(k0, v0) for k0, v0 in dfail.items()]
+        msg = (
+            "The following structures could not be loaded:\n"
+            + "\n".join(lstr)
+        )
+        if strict is True or len(lS) == 0:
+            raise Exception(msg)
+        else:
+            warnings.warn(msg)
+
     if returnas == 'dict':
         conf = dict([tt for tt in lS])
     else:
@@ -859,11 +902,14 @@ def _create_config_testcase(
     return conf
 
 
-def create_config(case=None, Exp='Dummy', Type='Tor',
-                  Lim=None, Bump_posextent=[np.pi/4., np.pi/4],
-                  R=None, r=None, elong=None, Dshape=None,
-                  divlow=None, divup=None, nP=None,
-                  returnas=None, SavePath='./', path=_path_testcases):
+def create_config(
+    case=None, Exp='Dummy', Type='Tor',
+    Lim=None, Bump_posextent=[np.pi/4., np.pi/4],
+    R=None, r=None, elong=None, Dshape=None,
+    divlow=None, divup=None, nP=None,
+    returnas=None, strict=None,
+    SavePath='./', path=_path_testcases,
+):
     """ Create easily a tofu.geom.Config object
 
     In tofu, a Config (short for geometrical configuration) refers to the 3D
@@ -932,8 +978,12 @@ def create_config(case=None, Exp='Dummy', Type='Tor',
 
     # Get config, either from known case or geometrical parameterization
     if case is not None:
-        conf = _create_config_testcase(config=case,
-                                       returnas=returnas, path=path)
+        conf = _create_config_testcase(
+            config=case,
+            path=path,
+            returnas=returnas,
+            strict=strict,
+        )
     else:
         poly, pbump, pbaffle = _compute_VesPoly(R=R, r=r,
                                                 elong=elong, Dshape=Dshape,

--- a/tofu/tests/tests01_geom/test_03_core.py
+++ b/tofu/tests/tests01_geom/test_03_core.py
@@ -740,7 +740,12 @@ class Test02_Config(object):
         except Exception as err:
             pass
 
-    def test15_saveload(self, verb=False):
+    def test15_load_config(self):
+        lc = sorted(tfg.utils._get_listconfig(returnas=dict).keys())
+        for cc in lc:
+            conf = tf.load_config(cc)
+
+    def test16_saveload(self, verb=False):
         for typ in self.dobj.keys():
             self.dobj[typ].strip(-1)
             pfe = self.dobj[typ].save(verb=verb, return_pfe=True)

--- a/tofu/tests/tests01_geom/test_03_core.py
+++ b/tofu/tests/tests01_geom/test_03_core.py
@@ -743,7 +743,7 @@ class Test02_Config(object):
     def test15_load_config(self):
         lc = sorted(tfg.utils._get_listconfig(returnas=dict).keys())
         for cc in lc:
-            conf = tf.load_config(cc)
+            conf = tf.load_config(cc, strict=True)
 
     def test16_saveload(self, verb=False):
         for typ in self.dobj.keys():

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.10-alpha9-332-g05255faa'
+__version__ = '1.4.10-alpha9-333-g3912ac61'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.10-alpha9-330-gf0697ffb'
+__version__ = '1.4.10-alpha9-331-g9f602e49'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.10-alpha9-333-g3912ac61'
+__version__ = '1.4.10-alpha9-334-g40a45120'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.10-alpha9-280-g3fdd0810'
+__version__ = '1.4.10-alpha9-330-gf0697ffb'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.10-alpha9-331-g9f602e49'
+__version__ = '1.4.10-alpha9-332-g05255faa'


### PR DESCRIPTION
Motivations:
--------------
*  As reported by @lasofivec , the AUG config was not loading properly in the tutorials
* It was due to a too constraining `delimiter `in `numpy.loadtxt()` AUG files had 2 white spaces as separators)

Main changes:
----------------
* The delimiter is set to `None`, which solves the issue
* But since this error was not caught by unit tests previously, a new dedicated unit test has been implemented to catch it if it shows up again
* It relies on the introduction of a new keyword argument `tf.load_config('AUG', strict=True)` that forces forces an `Exception `(instead of a simple `warning`) to be raised if a `Structure` cannot be loaded properly
* The associated error message was refactored to be more informative and more compact (for readability)
* Thanks to the new unit test, another hidden bug was identified: an old useless config was still considered as valid except that the corresponding files had been deleted. This config is now removed.

Issues:
--------
* Fixes, in devel, issue #513 

Example:
----------

The following works fine now
```
In [1]: import tofu as tf                                                                                                                                                              
/Home/DV226270/ToFu_All/tofu_git/tofu/tofu/imas2tofu/__init__.py:87: UserWarning: 
You do not seem to be using the latest IMAS version:
'module list' vs 'module av IMAS' suggests:
	- Current version: 3.30.0-4.8.4
	- Latest version : 3.32.1-4.9.1-R2019b
  warnings.warn(msg)

In [2]: conf = tf.load_config('AUG')   
```   