### PR TITLE
[#518] Implement warning when Config.from_svg() has r0 too large

### DIFF
--- a/tofu/geom/_comp.py
+++ b/tofu/geom/_comp.py
@@ -225,6 +225,22 @@ def get_paths_from_svg(
             dpath[k0]['cls'] = 'PFC'
         dpath[k0]['color'] = color
 
+    # Check for negative r
+    lkneg = [k0 for k0, v0 in dpath.items() if np.any(v0['poly'][0, :] <= 0.)]
+    if len(lkneg) > 0.:
+        lstr = ['\t- {}'.format(k0) for k0 in lkneg]
+        msg = (
+            "With the chosen r0 ({}) some structure have negative r values\n"
+            + "This is impossible in a toroidal coordinate system\n"
+            + "  => the following structures are removed:\n"
+            + "\n".join(lstr)
+        )
+        if len(lkneg) == len(dpath):
+            raise Exception(msg)
+        else:
+            warnings.warn(msg)
+        dpath = {k0: dpath[k0] for k0 in dpath.keys() if k0 not in lkneg}
+
     # verb
     if verb is True:
         lVes = sorted([k0 for k0, v0 in dpath.items() if v0['cls'] == 'Ves'])

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.10-alpha9-337-ga589ad1d'
+__version__ = '1.4.10-alpha9-344-g7d0c938a'


### PR DESCRIPTION
Motivations:
--------------
* `Config.from_svg()` allows the user to set the origin `r0`
* But if `r0` is too large, some structures may have negative R, which is impossible in toroidal geometry

Main changes:
-----------------
* A warning is implemented so when it happens it explains that r0 is too large and displays the names of the Structures that are deleted due to this issue.

Issues:
-------
* Fixes, in devel, issue #518 

Example:
----------

Here 2 structures are deleteddue to this problem: `limiter` and `pfcoil`

```
In [1]: import tofu as tf                                                                                                                                                              
conf /Home/DV226270/ToFu_All/tofu_git/tofu/tofu/imas2tofu/__init__.py:87: UserWarning: 
You do not seem to be using the latest IMAS version:
'module list' vs 'module av IMAS' suggests:
	- Current version: 3.30.0-4.8.4
	- Latest version : 3.32.1-4.9.1-R2019b
  warnings.warn(msg)

In [2]: conf = tf.geom.Config.from_svg('tofu/tests/tests01_geom/test_03_core_data/Inkscape.svg', Name='test', Exp='Test', z0=-150, res=10, r0=50)                                      
/Home/DV226270/ToFu_All/tofu_git/tofu/tofu/geom/_comp.py:241: UserWarning: With the chosen r0 ({}) some structure have negative r values
This is impossible in a toroidal coordinate system
  => the following structures are removed:
	- limiter
	- pfcoil
  warnings.warn(msg)
The following structures were loaded:
	- Ves: vessel (65 pts, None)
from /Home/DV226270/ToFu_All/tofu_git/tofu/tofu/tests/tests01_geom/test_03_core_data/Inkscape.svg
/Home/DV226270/ToFu_All/tofu_git/tofu/tofu/geom/_core.py:481: UserWarning: Struct instance: double identical points in Poly
  => 1 points removed
  => Poly goes from 65 to 64 points
  warnings.warn(msg)
```