### PR TITLE
[#522] Closed polygons treated separately => no warning

### DIFF
--- a/tofu/geom/_core.py
+++ b/tofu/geom/_core.py
@@ -464,7 +464,14 @@ class Struct(utils.ToFuObject):
         if Poly.shape[0] != 2:
             Poly = Poly.T
 
+        # --------------------------------------
         # Elimininate any double identical point
+
+        # Treat closed polygons seperately (no warning)
+        if np.sum((Poly[:, 0] - Poly[:, -1])**2) < 1.e-12:
+            Poly = Poly[:, :-1]
+
+        # Treat other points
         ind = np.sum(np.diff(np.concatenate((Poly, Poly[:, 0:1]), axis=1),
                              axis=1) ** 2, axis=0) < 1.0e-12
         if np.any(ind):

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.10-alpha9-337-ga589ad1d'
+__version__ = '1.4.10-alpha9-344-g7d0c938a'


### PR DESCRIPTION
Motivations:
--------------
* see issue #522 

Main Changes:
----------------
* Closed polygons are a particular and common case, they are treated separately before raising a warning

Example:
----------
When loading from a svg no warning is raised anymore everytime a closed polygon is loaded
```
In [1]: import tofu as tf                                                                                                                                                              
/Home/DV226270/ToFu_All/tofu_git/tofu/tofu/imas2tofu/__init__.py:87: UserWarning: 
You do not seem to be using the latest IMAS version:
'module list' vs 'module av IMAS' suggests:
	- Current version: 3.30.0-4.8.4
	- Latest version : 3.32.1-4.9.1-R2019b
  warnings.warn(msg)

In [2]: conf = tf.geom.Config.from_svg('tofu/tests/tests01_geom/test_03_core_data/Inkscape.svg', Name='test', Exp='Test', z0=-150, res=10)                                             
The following structures were loaded:
	- Ves: vessel (65 pts, None)
	- PFC: limiter (5 pts, #0000ff)
	- PFC: pfcoil (5 pts, #ff0000)
from /Home/DV226270/ToFu_All/tofu_git/tofu/tofu/tests/tests01_geom/test_03_core_data/Inkscape.svg
```