### PR TITLE
Issue537 crystal splitting

### DIFF
--- a/tofu/geom/_check_optics.py
+++ b/tofu/geom/_check_optics.py
@@ -116,7 +116,7 @@ def _check_dict_unitvector(dd=None, dd_name=None):
                     - {0}['e1'] must be perpendicular to {0}['e2']
 
                 Provided:
-                    {}
+                    {1}
                 """.format(dd_name, dd['e2'])
             )
             raise Exception(msg)

--- a/tofu/tests/tests01_geom/test_04_core_optics.py
+++ b/tofu/tests/tests01_geom/test_04_core_optics.py
@@ -377,7 +377,13 @@ class Test01_Crystal(object):
             )
         plt.close('all')
 
-    def test15_saveload(self, verb=False):
+    def test15_split(self):
+        for ii, (k0, obj) in enumerate(self.dobj.items()):
+            direction = None if ii == 0 else ('e1' if ii % 2 == 0 else 'e2')
+            nb = None if ii == 0 else (2 if ii % 2 == 0 else 3)
+            lcryst = obj.split(direction=direction, nb=nb)
+
+    def test16_saveload(self, verb=False):
         for k0, obj in self.dobj.items():
             obj.strip(-1)
             pfe = obj.save(verb=verb, return_pfe=True)

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.11-446-g0f058096'
+__version__ = '1.4.11-447-g293e66cf'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.11-443-gb29c1690'
+__version__ = '1.4.11-446-g0f058096'


### PR DESCRIPTION
Motivations:
--------------
* see issue #537 

Main changes:
-----------------
* The `Crystal.split()` method is implemented
* It takes 2 kwdargs: 
   - `'direction'`: specify the splitting direction (`'e1'` or `'e2'`)
   - `'nb'`: specify in how many equal parts the crystal must be splitted
* It returns a list of new Crystal instances

Issues:
-------
* Fixes, in devel, issue #537 

Example:
----------

```
In [1]: import tofu as tf                                                                                                                           
/Home/DV226270/ToFu_All/tofu_git/tofu/tofu/imas2tofu/__init__.py:87: UserWarning: 
You do not seem to be using the latest IMAS version:
'module list' vs 'module av IMAS' suggests:
	- Current version: 3.30.0-4.8.4
	- Latest version : 3.32.1-4.9.1-R2019b
  warnings.warn(msg)

In [2]: cryst = tf.load('inputs_temp/TFG_CrystalBragg_ExpWEST_DgXICS_ArXVII_sh00000_Vers1.4.9-315-gc93fa7a3.npz')                                   
Loaded from:
    /Home/DV226270/ToFu_All/tofu_git/tofu/inputs_temp/TFG_CrystalBragg_ExpWEST_DgXICS_ArXVII_sh00000_Vers1.4.9-315-gc93fa7a3.npz

In [3]: lcryst = cryst.split()                                                                                                                      

In [4]: dax = cryst.plot()                                                                                                                          

In [5]: dax = lcryst[0].plot(color='b', dax=dax)                                                                                                    

In [6]: dax = lcryst[1].plot(color='r', dax=dax) 
```

![image](https://user-images.githubusercontent.com/5929562/126688794-fbae3555-4c57-4890-b37b-8859c80788f1.png)