### PR TITLE
Issue 540 - Wavelength Interval

### DIFF
--- a/tofu/geom/_core_optics.py
+++ b/tofu/geom/_core_optics.py
@@ -1888,11 +1888,10 @@ class CrystalBragg(utils.ToFuObject):
         bragg, phi, lamb = bragg[..., 0], phi[..., 0], lamb[..., 0]
 
         # Check lambda interval into lamb array
-        c0= (
+        c0 = (
             np.min(lamb) < lambda_interval_min
             and np.max(lamb) > lambda_interval_max
         )
-        test_lambda_interv = None
         if c0:
             test_lambda_interv = True
         else:
@@ -2085,7 +2084,7 @@ class CrystalBragg(utils.ToFuObject):
         ddist = np.linspace(dist_min, dist_max, int(ndist))
         di = np.linspace(di_min, di_max, int(ndi))
         error_lambda = np.full((di.size, ddist.size), np.nan)
-        test_lamb_interv = np.full((di.size, ddist.size), np.nan, dtype='bool')
+        test_lamb_interv = np.zeros((di.size, ddist.size), dtype='bool')
         end = '\r'
         for ii in range(ddist.size):
             for jj in range(di.size):
@@ -2118,24 +2117,17 @@ class CrystalBragg(utils.ToFuObject):
                 )
 
                 # Integrate error
-                error_lambda[jj, ii] = np.nanmean(
-                    self.calc_johannerror(
-                        xi=xi, xj=xj,
-                        det=det,
-                        err=err,
-                        lambda_interval_min=lambda_interval_min,
-                        lambda_interval_max=lambda_interval_max,
-                        plot=False,
-                    )[0],
-                )
-                test_lamb_interv[jj, ii] = self.calc_johannerror(
+                (
+                    error_lambda_temp, test_lamb_interv[jj, ii],
+                ) = self.calc_johannerror(
                     xi=xi, xj=xj,
                     det=det,
                     err=err,
                     lambda_interval_min=lambda_interval_min,
                     lambda_interval_max=lambda_interval_max,
                     plot=False,
-                )[4]
+                )[::4]
+                error_lambda[jj, ii] = np.nanmean(error_lambda_temp)
 
         if 'rel' in err:
             units = '%'

--- a/tofu/geom/_core_optics.py
+++ b/tofu/geom/_core_optics.py
@@ -1871,6 +1871,10 @@ class CrystalBragg(utils.ToFuObject):
         # Check xi, xj once before to avoid doing it twice
         if err is None:
             err = 'abs'
+        if lambda_interval_min is None:
+            lambda_interval_min = 3.93e-10
+        if lambda_interval_max is None:
+            lambda_interval_max = 4.00e-10
 
         xi, xj, (xii, xjj) = _comp_optics._checkformat_xixj(xi, xj)
 
@@ -2028,7 +2032,6 @@ class CrystalBragg(utils.ToFuObject):
             lambda_interval_min = 3.93e-10
         if lambda_interval_max is None:
             lambda_interval_max = 4.00e-10
-
 
         l0 = [dist_min, dist_max, ndist, di_min, di_max, ndi]
         c0 = any([l00 is not None for l00 in l0])

--- a/tofu/geom/_core_optics.py
+++ b/tofu/geom/_core_optics.py
@@ -1839,6 +1839,8 @@ class CrystalBragg(utils.ToFuObject):
         xi=None, xj=None, err=None,
         det=None, n=None,
         lpsi=None, ldtheta=None,
+        lambda_interval_min=None,
+        lambda_interval_max=None,
         use_non_parallelism=None,
         plot=True, fs=None, cmap=None,
         vmin=None, vmax=None, tit=None, wintit=None,
@@ -1861,6 +1863,9 @@ class CrystalBragg(utils.ToFuObject):
             - crystal's summit
         Then, computing error on bragg and phi angles on each pixels by
         computing lambda and phi from the crystal's outline
+        Provide lambda_interval_min/max to ensure the given wavelength interval
+        is detected over the whole surface area.
+        A True/False boolean is then returned.
         """
 
         # Check xi, xj once before to avoid doing it twice
@@ -1881,6 +1886,17 @@ class CrystalBragg(utils.ToFuObject):
 
         # Only one summit was selected
         bragg, phi, lamb = bragg[..., 0], phi[..., 0], lamb[..., 0]
+
+        # Check lambda interval into lamb array
+        c0= (
+            np.min(lamb) < lambda_interval_min
+            and np.max(lamb) > lambda_interval_max
+        )
+        test_lambda_interv = None
+        if c0:
+            test_lambda_interv = True
+        else:
+            test_lambda_interv = False
 
         # Get err from multiple ldtheta, lpsi
         if lpsi is None:
@@ -1928,7 +1944,10 @@ class CrystalBragg(utils.ToFuObject):
                 cmap=cmap, vmin=vmin, vmax=vmax,
                 fs=fs, tit=tit, wintit=wintit,
                 )
-        return err_lamb, err_phi, err_lamb_units, err_phi_units
+        return (
+            err_lamb, err_phi, err_lamb_units, err_phi_units,
+            test_lambda_interv,
+        )
 
     def plot_focal_error_summed(
         self,
@@ -1941,8 +1960,11 @@ class CrystalBragg(utils.ToFuObject):
         use_non_parallelism=None,
         tangent_to_rowland=None, n=None,
         plot=None,
+        pts=None,
         det_ref=None, plot_dets=None, nsort=None,
         dcryst=None,
+        lambda_interval_min=None,
+        lambda_interval_max=None,
         contour=None,
         fs=None,
         ax=None,
@@ -1974,18 +1996,21 @@ class CrystalBragg(utils.ToFuObject):
             detector
             dict(np.load('det37_CTVD_incC4_New.npz', allow_pickle=True))
         - nsort : float
-
+            Number of best detector's position to plot
+        - lambda_interv_min/max : float
+            To ensure the given wavelength interval is detected over the whole
+            surface area. A True/False boolean is then returned.
         """
 
         # Check / format inputs
         if dist_min is None:
-            dist_min = -0.08
+            dist_min = -0.15
         if dist_max is None:
-            dist_max = 0.01
+            dist_max = 0.15
         if di_min is None:
-            di_min = -0.41
+            di_min = -0.40
         if di_max is None:
-            di_max = -0.05
+            di_max = 0.40
         if ndist is None:
             ndist = 21
         if ndi is None:
@@ -1996,8 +2021,15 @@ class CrystalBragg(utils.ToFuObject):
             plot = True
         if plot_dets is None:
             plot_dets = det_ref is not None
+        if nsort is None:
+            nsort = 5
         if return_ax is None:
             return_ax = True
+        if lambda_interval_min is None:
+            lambda_interval_min = 3.93e-10
+        if lambda_interval_max is None:
+            lambda_interval_max = 4.00e-10
+
 
         l0 = [dist_min, dist_max, ndist, di_min, di_max, ndi]
         c0 = any([l00 is not None for l00 in l0])
@@ -2053,6 +2085,7 @@ class CrystalBragg(utils.ToFuObject):
         ddist = np.linspace(dist_min, dist_max, int(ndist))
         di = np.linspace(di_min, di_max, int(ndi))
         error_lambda = np.full((di.size, ddist.size), np.nan)
+        test_lamb_interv = np.full((di.size, ddist.size), np.nan, dtype='bool')
         end = '\r'
         for ii in range(ddist.size):
             for jj in range(di.size):
@@ -2090,9 +2123,19 @@ class CrystalBragg(utils.ToFuObject):
                         xi=xi, xj=xj,
                         det=det,
                         err=err,
+                        lambda_interval_min=lambda_interval_min,
+                        lambda_interval_max=lambda_interval_max,
                         plot=False,
                     )[0],
                 )
+                test_lamb_interv[jj, ii] = self.calc_johannerror(
+                    xi=xi, xj=xj,
+                    det=det,
+                    err=err,
+                    lambda_interval_min=lambda_interval_min,
+                    lambda_interval_max=lambda_interval_max,
+                    plot=False,
+                )[4]
 
         if 'rel' in err:
             units = '%'
@@ -2113,6 +2156,8 @@ class CrystalBragg(utils.ToFuObject):
                 plot_dets=plot_dets, nsort=nsort,
                 tangent_to_rowland=tangent_to_rowland,
                 use_non_parallelism=use_non_parallelism,
+                pts=pts,
+                test_lamb_interv=test_lamb_interv,
                 contour=contour,
                 fs=fs,
                 ax=ax,
@@ -2121,9 +2166,9 @@ class CrystalBragg(utils.ToFuObject):
                 vmax=vmax,
             )
         if return_ax:
-            return error_lambda, ddist, di, ax
+            return error_lambda, ddist, di, test_lamb_interv, ax
         else:
-            return error_lambda, ddist, di
+            return error_lambda, ddist, di, test_lamb_interv
 
     def _get_local_coordinates_of_det(
         self,

--- a/tofu/geom/_plot_optics.py
+++ b/tofu/geom/_plot_optics.py
@@ -1092,8 +1092,10 @@ def CrystalBragg_plot_focal_error_summed(
     det_ref=None,
     units=None,
     plot_dets=None, nsort=None,
-    use_non_parallelism=None,
     tangent_to_rowland=None,
+    use_non_parallelism=None,
+    pts=None,
+    test_lamb_interv=None,
     contour=None,
     fs=None,
     cmap=None,
@@ -1146,8 +1148,17 @@ def CrystalBragg_plot_focal_error_summed(
         linewstyles='-',
         linewidths=1.,
     )
+    ax.contour(
+        ddist,
+        di,
+        test_lamb_interv,
+        contour,
+        colors='yellow',
+        linewstyles='-',
+        linewidths=1.,
+    )
 
-    # computing detector with exact position of det_ref
+    # Computing detector with exact position of det_ref
     if det_ref:
         dpsi0bis = float(dpsi0)
         if tangent_to_rowland:
@@ -1164,7 +1175,6 @@ def CrystalBragg_plot_focal_error_summed(
             use_non_parallelism=use_non_parallelism,
             tangent_to_rowland=False,
         )
-
         detector_comp['outline'] = det_ref['outline']
         ax.plot(
             ddist0,
@@ -1190,17 +1200,18 @@ def CrystalBragg_plot_focal_error_summed(
 
         # plot dets geometry with CrystalBragg_plot()
         if det_ref is not None:
-            dax = CrystalBragg_plot(
-                cryst=cryst, dcryst=dcryst,
+            dax = cryst.plot(
                 det=det_ref,
+                pts=pts,
                 color='black',
-                )
-            dax = CrystalBragg_plot(
-                    cryst=cryst, dcryst=dcryst,
-                    det=detector_comp, color='blue',
-                    dax=dax,
-                    element='ocv',
-                )
+            )
+            dax = cryst.plot(
+                det=detector_comp,
+                pts=pts,
+                color='blue',
+                element='ocv',
+                dax=dax,
+            )
             msg = (
                 "Parameters of reference detector:\n"
                 + "Center position in (x, y, z): ({})\n".format(
@@ -1222,11 +1233,12 @@ def CrystalBragg_plot_focal_error_summed(
                     tangent_to_rowland=tangent_to_rowland,
                 )
                 det[ii]['outline'] = det_ref['outline']
-                dax = CrystalBragg_plot(
-                    cryst=cryst, dcryst=dcryst,
-                    det=det[ii], color='red',
-                    dax=dax,
+                dax = cryst.plot(
+                    det=det[ii],
+                    pts=pts,
+                    color='red',
                     element='oc',
+                    dax=dax,
                 )
                 print(
                     "det: {}\n".format(det[ii])

--- a/tofu/tests/tests01_geom/test_04_core_optics.py
+++ b/tofu/tests/tests01_geom/test_04_core_optics.py
@@ -312,7 +312,7 @@ class Test01_Crystal(object):
     def test11_calc_johann_error(self):
         for k0, obj in self.dobj.items():
             det = obj.get_detector_approx()
-            err_lamb, err_phi, _, _ = obj.calc_johannerror(
+            err_lamb, err_phi, _, _, _ = obj.calc_johannerror(
                 xi=self.xi,
                 xj=self.xj,
                 det=det,


### PR DESCRIPTION
Motivation:
-------------
* see Issue #540 

Main changes:
----------------
* The user can determine a wavelength interval of validity thanks to new entry agruments into `cryst.plot_focal_error_summed()`.
* This condition is fullfilled into cryst.calc_johannerror() and the domain of validity is plotted as the same time of the method.
* Added possibility to plot ray-tracing in order to visualize non focalization.

Issues:
-------
* Fixes, in devel, Issue #540 

Example:
---------
```
In [1]: import tofu as tf                                                                                                                                                                                       

In [2]: import inputs_temp.XICS_allshots_C34 as xics                                                                                                                                                            

In [3]: cryst = tf.load('inputs_temp/TFG_CrystalBragg_ExpWEST_DgXICS_ArXVII_sh00000_Vers1.4.9-315-gc93fa7a3.npz')                                                                                               
Loaded from:
    /Home/AD265925/project_git/tofu/inputs_temp/TFG_CrystalBragg_ExpWEST_DgXICS_ArXVII_sh00000_Vers1.4.9-315-gc93fa7a3.npz

In [4]: det = dict(np.load('inputs_temp/det37_CTVD_incC4_New.npz', allow_pickle=True))                                                                                                                          

In [5]: xi, xj = xics._XI, xics._XJ                                                                                                                                                                             

In [6]: dax = cryst.plot_focal_error_summed(xi=xi[::10], xj=xj[::10], err='rel', plot_dets=True, det_ref=det, pts=pts)
```

![image](https://user-images.githubusercontent.com/81628304/127141759-598ff103-e381-456e-bf33-ae8af6bc8709.png)
![image](https://user-images.githubusercontent.com/81628304/127141784-8e960e80-a404-425e-b8f3-22b1f102e40c.png)
