### PR TITLE
[#582] Added svg.path to setup.py, requirements.txt, meta.yaml

### DIFF
--- a/.github/workflows/python-package-pip-testing.yml
+++ b/.github/workflows/python-package-pip-testing.yml
@@ -28,6 +28,7 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
+        conda config --append channels conda-forge
         conda env update --file requirements.txt --name base
     - name: Lint with flake8
       run: |

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - pytest
     - pygments
     - requests
+    - svg.path
 
 test:
   requires:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ scipy
 # scikit-umfpack   # similar issue
 matplotlib
 requests
+svg.path
 
 ######## Requirements with Version Specifier ########
 Cython>=0.26

--- a/setup.py
+++ b/setup.py
@@ -313,6 +313,7 @@ setup(
         "matplotlib",
         "requests",
         "cython>=0.26",
+        "svg.path",
     ],
     python_requires=">=3.6",
 
@@ -322,7 +323,6 @@ setup(
     # $ pip install -e .[dev,test]
     extras_require={
         "dev": [
-            "svg.path",
             "check-manifest",
             "coverage",
             "pytest",

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.0-3-g96c1c10c'
+__version__ = '1.5.0-4-g1c28603c'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.15-133-g65788b3e'
+__version__ = '1.5.0-3-g96c1c10c'


### PR DESCRIPTION
Motivations:
--------------
* see issue #582 
* Adding svg.path as a compulsory dependency for users results from the following reasons:
    * to avoid crashing conda-forge
    * because importing a tokamak geometry from inkscape is one of the popular features of tofu
    * because svg.path seems available on ll platforms both from [Pypi](https://pypi.org/project/svg.path/) and [anaconda.org](https://anaconda.org/conda-forge/svg.path)

Main changes:
----------------
* Added svg.path to setup.py, requirements.txt, conda_recipe/meta.yaml
