### PR TITLE
[#567] Removed python 3.6, added 3.9 to testing matrix

### DIFF
--- a/.github/workflows/complete-matrix.yml
+++ b/.github/workflows/complete-matrix.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.7', '3.8', '3.9']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.4.15-133-g65788b3e'
+__version__ = '1.5.0-3-g96c1c10c'


### PR DESCRIPTION
Motivations:
--------------
* Python 3.10 was recently released
* We cannot test everything, but a number of 3 python versions seems reasonable
* Up to now we were testing 3.6, 3.7 and 3.8
* It is  bit early to test 3.10, since many libraries do not use it yet
* However it seems reasonable that we should test at least python 3.9
* see issue #567 

Main changes:
----------------
* Testing matrix no w tests against 3.7, 3.8 and 3.9
