### PR TITLE
Figure interactivity lost

### DIFF
--- a/tofu/_plot.py
+++ b/tofu/_plot.py
@@ -74,7 +74,7 @@ def _plot_shotoverview_init(ns=1, sharet=True, sharey=True, shareRZ=True,
     # Make figure and axes
     fig = plt.figure(figsize=fs)
     if wintit is not None:
-        fig.canvas.set_window_title(wintit)
+        fig.canvas.manager.set_window_title(wintit)
     axarr = GridSpec(ns, 3, **dmargin)
 
     laxt = [None for ii in range(0,ns)]

--- a/tofu/data/_DataCollection_plot.py
+++ b/tofu/data/_DataCollection_plot.py
@@ -172,7 +172,7 @@ def _get_fig_dax_mpl(dcases=None, axgrid=None,
     fs = utils.get_figuresize(fs)
     fig = plt.figure(facecolor=bckcolor, figsize=fs)
     if wintit is not False:
-        fig.canvas.set_window_title(wintit)
+        fig.canvas.manager.set_window_title(wintit)
 
     # -----------------
     # Check all cases
@@ -667,7 +667,7 @@ def _ax_axvline(
             tit = ''
 
         fig = plt.figure(figsize=figsize)
-        fig.canvas.set_window_title(wintit)
+        fig.canvas.manager.set_window_title(wintit)
         fig.suptitle(tit, size=12, fontweight='bold')
 
         gs = gridspec.GridSpec(1, 1, **dmargin)
@@ -829,7 +829,7 @@ def _ax_dominance_map(
             dtit = {}
 
         fig = plt.figure(figsize=figsize)
-        fig.canvas.set_window_title(wintit)
+        fig.canvas.manager.set_window_title(wintit)
         fig.suptitle(tit, size=12, fontweight='bold')
 
         if len(proj) == 1:

--- a/tofu/data/_plot.py
+++ b/tofu/data/_plot.py
@@ -265,7 +265,7 @@ def _init_DataCam12D(fs=None, dmargin=None,
         dmargin = _def.dmargin1D
     fig = plt.figure(facecolor=axCol,figsize=fs)
     if wintit != False:
-        fig.canvas.set_window_title(wintit)
+        fig.canvas.manager.set_window_title(wintit)
 
     # Axes
     gs1 = gridspec.GridSpec(6, 5, **dmargin)
@@ -926,7 +926,7 @@ def _init_DataCam12D_spectral(fs=None, dmargin=None,
                        wspace=0.4, hspace=2.)
     fig = plt.figure(facecolor=axCol,figsize=fs)
     if wintit != False:
-        fig.canvas.set_window_title(wintit)
+        fig.canvas.manager.set_window_title(wintit)
 
     # -------------
     # Axes grid
@@ -1773,7 +1773,7 @@ def _init_DataCam12D_combine(fs=None, dmargin=None,
         dmargin = _def.dmargin_combine
     fig = plt.figure(facecolor=axCol,figsize=fs)
     if wintit != False:
-        fig.canvas.set_window_title(wintit)
+        fig.canvas.manager.set_window_title(wintit)
 
     # Axes
     gs1 = gridspec.GridSpec(nDat+1, 5, **dmargin)
@@ -2434,7 +2434,7 @@ def _init_Data1D_spectrogram(fs=None, dmargin=None, nD=1,
         dmargin = _def.dmargin1D
     fig = plt.figure(facecolor=axCol,figsize=fs)
     if wintit != False:
-        fig.canvas.set_window_title(wintit)
+        fig.canvas.manager.set_window_title(wintit)
 
     gs1 = gridspec.GridSpec(6, 5, **dmargin)
     laxt = [fig.add_subplot(gs1[:2,:2], fc='w')]
@@ -3089,7 +3089,7 @@ def _init_Data_svd(fs=None, dmargin=None, nD=1,
         dmargin = _def.dmargin1D
     fig = plt.figure(facecolor=axCol,figsize=fs)
     if wintit != False:
-        fig.canvas.set_window_title(wintit)
+        fig.canvas.manager.set_window_title(wintit)
 
     # Axes array
     gs1 = gridspec.GridSpec(4, 5, **dmargin)

--- a/tofu/geom/_plot.py
+++ b/tofu/geom/_plot.py
@@ -1409,7 +1409,7 @@ def _Cam12D_plot_touch_init(fs=None, dmargin=None, fontsize=8,
         fs = (8.27,11.69)
     fig = plt.figure(facecolor=axCol,figsize=fs)
     if wintit != False:
-        fig.canvas.set_window_title(wintit)
+        fig.canvas.manager.set_window_title(wintit)
     if dmargin is None:
         dmargin = {'left':0.03, 'right':0.99,
                    'bottom':0.05, 'top':0.92,

--- a/tofu/spectro/_plot.py
+++ b/tofu/spectro/_plot.py
@@ -235,7 +235,7 @@ def CrystalBragg_plot_data_vs_lambphi(
     if tit is not False:
         fig.suptitle(tit, size=14, weight='bold')
     if wintit is not False:
-        fig.canvas.set_window_title(wintit)
+        fig.canvas.manager.set_window_title(wintit)
     return [ax0, ax1]
 
 
@@ -502,7 +502,7 @@ def plot_fit1d(
         if titi is not False:
             fig.suptitle(titi, size=14, weight='bold')
         if wintit is not False:
-            fig.canvas.set_window_title(wintit)
+            fig.canvas.manager.set_window_title(wintit)
     if xlim is not False:
         ax.set_xlim(xlim)
     return ax
@@ -607,7 +607,7 @@ def CrystalBragg_plot_data_fit2d(xi, xj, data, lamb, phi, indok=None,
         if tit is not False:
             fig.suptitle(tit)
         if wintit is not False:
-            fig.canvas.set_window_title(wintit)
+            fig.canvas.manager.set_window_title(wintit)
 
         if naxv == 1:
             dax['fit1d'] = fig.add_subplot(gs[9:11, 6:9], sharex=ax2)

--- a/tofu/utils.py
+++ b/tofu/utils.py
@@ -4012,8 +4012,8 @@ class KeyHandler_mpl(object):
 
         # Check axes is relevant and toolbar not active
         c_activeax = 'fix' not in self.dax[event.inaxes].keys()
-        c_toolbar = self.can.manager.toolbar._active in [None,False]
-        if not all([c_activeax,c_toolbar]):
+        c_toolbar = not self.can.manager.toolbar.mode
+        if not all([c_activeax, c_toolbar]):
             return
 
         # Set self.dcur
@@ -4072,8 +4072,8 @@ class KeyHandler_mpl(object):
     def mouserelease(self, event):
         msg = "Make sure you release the mouse button on an axes !"
         msg += "\n Otherwise the background plot cannot be properly updated !"
-        c0 = self.can.manager.toolbar._active == 'PAN'
-        c1 = self.can.manager.toolbar._active == 'ZOOM'
+        c0 = 'pan' in self.can.manager.toolbar.mode.lower()
+        c1 = 'zoom' in self.can.manager.toolbar.mode.lower()
 
         if c0 or c1:
             ax = self.curax_panzoom
@@ -4088,7 +4088,7 @@ class KeyHandler_mpl(object):
 
         lkey = event.key.split('+')
 
-        c0 = self.can.manager.toolbar._active is not None
+        c0 = self.can.manager.toolbar.mode != ''
         c1 = len(lkey) not in [1,2]
         c2 = [ss not in self.dkeys.keys() for ss in lkey]
         if c0 or c1 or any(c2):

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.0-56-gae514c16'
+__version__ = '1.5.0-58-g0d31268b'


### PR DESCRIPTION
Motivations:
--------------
* see Issue #593 
* As suggested by [this post](https://stackoverflow.com/questions/20711148/ignore-matplotlib-cursor-widget-when-toolbar-widget-selected), The interactivity was lost due to the private attribute `toolbar._active` being suppressed since [this commit](https://github.com/matplotlib/matplotlib/commit/2d41a724aa711decceba1a1df3fa167c585fbdaa) in matploltib
* The private attribute was replaced by a public one `toolbar.mode` 

Main changes:
----------------
* tofu updated to use the public attribute `toolbar.mode` ony
* Used this opportunity to fix all warnings regarding `canvas.set_window_title()` (deprecated and replaced by `canvas.manager.set_window_title()`)
* Interactivity recovered

Issues:
-------
* Fixes, in devel, issue #593 
* Known issue: noticed a new deprecationb warning regarding zoom release events, opening a dedicated issue #595 