### PR TITLE
[#621] Added some key signa from ids summary

### DIFF
--- a/tofu/imas2tofu/_def.py
+++ b/tofu/imas2tofu/_def.py
@@ -105,15 +105,15 @@ _dshort = {
         },
         'beta_tor_norm': {
             'str': 'global_quantities.beta_tor_norm.value',
-            'units': '',
+            'units': '-',
         },
         'beta_tor': {
             'str': 'global_quantities.beta_tor.value',
-            'units': '',
+            'units': '-',
         },
         'beta_pol': {
             'str': 'global_quantities.beta_pol.value',
-            'units': '',
+            'units': '-',
         },
         'energy_total': {
             'str': 'global_quantities.energy_total.value',
@@ -125,7 +125,7 @@ _dshort = {
         },
         'fusion_gain': {
             'str': 'global_quantities.fusion_gain.value',
-            'units': '',
+            'units': '-',
         },
         'tau_resistive': {
             'str': 'global_quantities.tau_resistive.value',
@@ -141,15 +141,15 @@ _dshort = {
         },
         'ng_fraction': {
             'str': 'global_quantities.greenwald_fraction.value',
-            'units': '',
+            'units': '-',
         },
         'q95': {
             'str': 'global_quantities.q_95.value',
-            'units': '',
+            'units': '-',
         },
         'li': {
             'str': 'global_quantities.li.value',
-            'units': '',
+            'units': '-',
         },
     },
 

--- a/tofu/imas2tofu/_def.py
+++ b/tofu/imas2tofu/_def.py
@@ -70,6 +70,89 @@ _dshort = {
                          'units': 's'},
         'events_names': {'str': 'event[].identifier'}},
 
+    'summary': {
+        'time': {
+            'str': 'time',
+            'units': 's',
+        },
+        'power_ic': {
+            'str': 'heating_current_drive.power_ic.value',
+            'units': 'W',
+        },
+        'power_lh': {
+            'str': 'heating_current_drive.power_lh.value',
+            'units': 'W',
+        },
+        'power_ec': {
+            'str': 'heating_current_drive.power_ec.value',
+            'units': 'W',
+        },
+        'power_nbi': {
+            'str': 'heating_current_drive.power_nbi.value',
+            'units': 'W',
+        },
+        'ip': {
+            'str': 'global_quantities.ip.value',
+            'units': 'A',
+        },
+        'v_loop': {
+            'str': 'global_quantities.v_loop.value',
+            'units': 'V',
+        },
+        'fusion_power': {
+            'str': 'fusion.power.value',
+            'units': 'W',
+        },
+        'beta_tor_norm': {
+            'str': 'global_quantities.beta_tor_norm.value',
+            'units': '',
+        },
+        'beta_tor': {
+            'str': 'global_quantities.beta_tor.value',
+            'units': '',
+        },
+        'beta_pol': {
+            'str': 'global_quantities.beta_pol.value',
+            'units': '',
+        },
+        'energy_total': {
+            'str': 'global_quantities.energy_total.value',
+            'units': 'J',
+        },
+        'volume': {
+            'str': 'global_quantities.volume.value',
+            'units': 'm^3',
+        },
+        'fusion_gain': {
+            'str': 'global_quantities.fusion_gain.value',
+            'units': '',
+        },
+        'tau_resistive': {
+            'str': 'global_quantities.tau_resistive.value',
+            'units': 's',
+        },
+        'tau_energy': {
+            'str': 'global_quantities.tau_energy.value',
+            'units': 's',
+        },
+        'fusion_fluence': {
+            'str': 'global_quantities.fusion_fluence.value',
+            'units': 'J',
+        },
+        'ng_fraction': {
+            'str': 'global_quantities.greenwald_fraction.value',
+            'units': '',
+        },
+        'q95': {
+            'str': 'global_quantities.q_95.value',
+            'units': '',
+        },
+        'li': {
+            'str': 'global_quantities.li.value',
+            'units': '',
+        },
+    },
+
     'equilibrium': {
         't': {'str': 'time', 'units': 's'},
         'ip': {'str': 'time_slice[time].global_quantities.ip',

--- a/tofu/imas2tofu/_def.py
+++ b/tofu/imas2tofu/_def.py
@@ -71,7 +71,7 @@ _dshort = {
         'events_names': {'str': 'event[].identifier'}},
 
     'summary': {
-        'time': {
+        't': {
             'str': 'time',
             'units': 's',
         },

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.0-206-g7abd03fd'
+__version__ = '1.5.0-227-g4d9d6667'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.0-227-g4d9d6667'
+__version__ = '1.5.0-228-ga8a79b62'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.0-228-ga8a79b62'
+__version__ = '1.5.0-229-gc1b70e23'


### PR DESCRIPTION
Main changes:
----------------
* Added ids summary to tofu-known ids's from IMAs, with many key signals

Issues:
-------
* Fixes, in devel, issue #621 

Examples:
-----------

```
In [1]: import tofu as tf

In [2]: multi = tf.imas2tofu.MultiIDSLoader(shot=56681, ids=['summary'], ids_base=False)
Getting ids  [occ]  database  user         version  shot   run  refshot  refrun
-----------  -----  --------  -----------  -------  -----  ---  -------  ------
summary      [0]    west      imas_public  3        56681  0    -1       -1    

In [3]: tf.imas2tofu.MultiIDSLoader.get_shortcutsc('summary')
ids      shortcut        units  long version                              
-------  --------------  -----  ------------------------------------------
summary  beta_pol        -      global_quantities.beta_pol.value          
summary  beta_tor        -      global_quantities.beta_tor.value          
summary  beta_tor_norm   -      global_quantities.beta_tor_norm.value     
summary  energy_total    J      global_quantities.energy_total.value      
summary  fusion_fluence  J      global_quantities.fusion_fluence.value    
summary  fusion_gain     -      global_quantities.fusion_gain.value       
summary  fusion_power    W      fusion.power.value                        
summary  ip              A      global_quantities.ip.value                
summary  li              -      global_quantities.li.value                
summary  ng_fraction     -      global_quantities.greenwald_fraction.value
summary  power_ec        W      heating_current_drive.power_ec.value      
summary  power_ic        W      heating_current_drive.power_ic.value      
summary  power_lh        W      heating_current_drive.power_lh.value      
summary  power_nbi       W      heating_current_drive.power_nbi.value     
summary  q95             -      global_quantities.q_95.value              
summary  tau_energy      s      global_quantities.tau_energy.value        
summary  tau_resistive   s      global_quantities.tau_resistive.value     
summary  time            s      time                                      
summary  v_loop          V      global_quantities.v_loop.value            
summary  volume          m^3    global_quantities.volume.value            

In [4]: dout = multi.get_data(dsig='summary')
/Home/DV226270/ToFu_All/tofu_git/tofu/tofu/imas2tofu/_comp.py:756: UserWarning: The following data could not be retrieved:
	- summary:
		beta_pol data      :  empty data in summary.beta_pol
		li data            :  empty data in summary.li
		power_nbi data     :  empty data in summary.power_nbi
		tau_resistive data :  empty data in summary.tau_resistive
		energy_total data  :  empty data in summary.energy_total
		fusion_fluence data:  empty data in summary.fusion_fluence
		fusion_power data  :  empty data in summary.fusion_power
		power_ec data      :  empty data in summary.power_ec
		fusion_gain data   :  empty data in summary.fusion_gain
		beta_tor_norm data :  empty data in summary.beta_tor_norm
  warnings.warn(msg)

```