### PR TITLE
Issue539 fit2d

### DIFF
--- a/tofu/spectro/_fit12d.py
+++ b/tofu/spectro/_fit12d.py
@@ -588,6 +588,9 @@ def multigausfit2d_from_dlines(
     message = ['' for ss in range(nspect)]
     errmsg = ['' for ss in range(nspect)]
 
+    indamp = np.zeros((dind['sizex'],), dtype=bool)
+    indamp[dinput['dind']['amp']['x'].T.ravel()] = True
+
     # Prepare msg
     if verbose in [1, 2]:
         col = np.char.array(['Spect', 'time (s)', 'cost',
@@ -669,9 +672,16 @@ def multigausfit2d_from_dlines(
             sol_x[ii, indx[ii, :]] = res.x
 
             # detect saturated values
+            # amp at 0 are ok
             saturated[ii, indx[ii, :]] = (
-                (res.x < bounds[0, indx[ii, :]] + deltab*1e-4)
-                | (res.x > bounds[1, indx[ii, :]] - deltab*1e-4)
+                res.x > bounds[1, indx[ii, :]] - deltab*1e-4
+            )
+            saturated[ii, indx[ii, :] & indamp] |= (
+                res.x[indamp[indx[ii, :]]] < 0.
+            )
+            saturated[ii, indx[ii, :] & (~indamp)] |= (
+                res.x[(~indamp)[indx[ii, :]]]
+                < bounds[0, indx[ii, :] & (~indamp)] + deltab*1e-4
             )
 
         except Exception as err:

--- a/tofu/spectro/_fit12d_dextract.py
+++ b/tofu/spectro/_fit12d_dextract.py
@@ -853,7 +853,9 @@ def fit2d_extract(
                     d3[k0][k1]['values'][~indphi, jj] = np.nan
 
     # update validity according to indphi
-    dfit2d['validity'][np.all(~indphi, axis=1)] = -3
+    dfit2d['validity'][
+        (dfit2d['validity'] == 0) & np.all(~indphi, axis=1)
+    ] = -3
 
     # ----------
     # func

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.0-231-ge4efc387'
+__version__ = '1.5.0-232-g5578af59'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.0-232-g5578af59'
+__version__ = '1.5.0-233-g1cdbea69'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.0-229-gc1b70e23'
+__version__ = '1.5.0-231-ge4efc387'


### PR DESCRIPTION
Main changes:
----------------
* Saturation of amp is explored
  => turns out it was mostly due amplitudes close to 0
  => But 0 amplitude is acceptable, should not raise a warning
  => Amp are now allowed to be close to 0, solves most problems
* More informative saturation messages:
  => now prints also the average number of bsplines for wich there was saturation