### PR TITLE
Issue629 non parallelism into rocking curves

### DIFF
--- a/tofu/geom/_core_optics.py
+++ b/tofu/geom/_core_optics.py
@@ -803,12 +803,16 @@ class CrystalBragg(utils.ToFuObject):
 
     def compute_rockingcurve(
         self, ih=None, ik=None, il=None, lamb=None,
-        plot_asf=None, plot_power_ratio=None,
+        use_non_parallelism=None,
+        plot_asf=None, plot_power_ratio=None, plot_relation=None,
         verb=None, returnas=None,
     ):
         return _rockingcurve.compute_rockingcurve(
             self, ih=ih, ik=ik, il=il, lamb=lamb,
-            plot_asf=plot_asf, plot_power_ratio=plot_power_ratio,
+            use_non_parallelism=use_non_parallelism,
+            plot_asf=plot_asf,
+            plot_power_ratio=plot_power_ratio,
+            plot_relation=plot_relation,
             verb=None, returnas=None,
         )
 

--- a/tofu/geom/_core_optics.py
+++ b/tofu/geom/_core_optics.py
@@ -808,9 +808,8 @@ class CrystalBragg(utils.ToFuObject):
         verb=None, returnas=None,
     ):
         return _rockingcurve.compute_rockingcurve(
-            self, ih=ih, ik=ik, il=il, lamb=lamb,
-            use_non_parallelism=use_non_parallelism,
-            na=na,
+            ih=ih, ik=ik, il=il, lamb=lamb,
+            use_non_parallelism=use_non_parallelism, na=na,
             plot_asf=plot_asf,
             plot_power_ratio=plot_power_ratio,
             plot_relation=plot_relation,

--- a/tofu/geom/_core_optics.py
+++ b/tofu/geom/_core_optics.py
@@ -803,13 +803,14 @@ class CrystalBragg(utils.ToFuObject):
 
     def compute_rockingcurve(
         self, ih=None, ik=None, il=None, lamb=None,
-        use_non_parallelism=None,
+        use_non_parallelism=None, na=None,
         plot_asf=None, plot_power_ratio=None, plot_relation=None,
         verb=None, returnas=None,
     ):
         return _rockingcurve.compute_rockingcurve(
             self, ih=ih, ik=ik, il=il, lamb=lamb,
             use_non_parallelism=use_non_parallelism,
+            na=na,
             plot_asf=plot_asf,
             plot_power_ratio=plot_power_ratio,
             plot_relation=plot_relation,

--- a/tofu/spectro/_rockingcurve.py
+++ b/tofu/spectro/_rockingcurve.py
@@ -26,14 +26,25 @@ from tofu.version import __version__
 
 def compute_rockingcurve(self,
     ih=None, ik=None, il=None, lamb=None,
-    use_non_parallelism=None,
+    use_non_parallelism=None, na=None,
     plot_asf=None, plot_power_ratio=None, plot_relation=None,
     verb=None, returnas=None,
 ):
-    """The code evaluates, for a given wavelength, the atomic plane distance d,
-    the Bragg angle, the complex structure factor, the integrated reflectivity
-    with the perfect and mosaic crystal models, the reflectivity curve with the
-    full dynamical model for parallel and perpendicular photon polarizations.
+    """The code evaluates, for a given wavelength and Miller indices set,
+    the atomic plane distance d, the Bragg angle and the complex structure
+    factor for alpha_Quartz crystals.
+    Then, the power ratio and their integrated reflectivity, for 3 differents
+    models (perfect, mosaic and dynamical) are computed to obtain
+    rocking curves, for parallel and perpendicular photon polarizations.
+
+    The possibility to add a non-parallelism between crystal's optical surface
+    and inter-atomic planes is now available. Rocking curve plots are updated
+    in order to show 3 cases: non-parallelism equal to zero and both limit
+    cases near to +/- the reference Bragg angle.
+    The relation between the value of this non-parallelism and 3 physical
+    quantities can also be plotted: the integrated reflectivity for the normal
+    component of polarization, the rocking curve widths and the symmetry
+    parameter b.
 
     The alpha-Quartz, symmetry group D(4,3), is assumed left-handed.
     It makes a difference for certain planes, for example between
@@ -51,6 +62,8 @@ def compute_rockingcurve(self,
         Wavelength of interest, in Angstroms (1e-10 m)
     use_non_parallelism:    str
         Introduce non-parallelism between dioptre and reflecting planes
+    na:    int
+        Number of non-parallelism angles steps, odd number preferred
     plot_asf:    str
         Plotting the atomic scattering factor thanks to data with respect to
         sin(theta)/lambda
@@ -70,6 +83,8 @@ def compute_rockingcurve(self,
 
     if use_non_parallelism is None:
         use_non_parallelism = False
+    if na is None:
+        na = 21
     if plot_asf is None:
         plot_asf = False
     if plot_power_ratio is None:
@@ -91,9 +106,10 @@ def compute_rockingcurve(self,
     # Classical electronical radius, in Angstroms
     re = 2.8208e-5
 
-    # Inter-atomic distances into hexagonal cell unit and associated volume TBC
-    a0 = 4.9130
-    c0 = 5.4045
+    # Inter-atomic distances into hexagonal cell unit and associated volume
+    # TBD with F.
+    a0 = 4.9134
+    c0 = 5.4051
     V = (a0**2.)*c0*np.sqrt(3.)/2.
 
     # Atomic number of Si and O atoms
@@ -105,7 +121,7 @@ def compute_rockingcurve(self,
     xsi = np.r_[-u, u, 0.]
     ysi = np.r_[-u, 0., u]
     zsi = np.r_[1./3., 0., 2./3.]
-    NSi = np.size(xsi)
+    Nsi = np.size(xsi)
 
     # Position of the six O atoms in the unit cell
     x = 0.4152
@@ -114,10 +130,10 @@ def compute_rockingcurve(self,
     xo = np.r_[x, y - x, -y, x - y, y, -x]
     yo = np.r_[y, -x, x - y, -y, x, y - x]
     zo = np.r_[z, z + 1./3., z + 2./3., -z, 2./3. - z, 1./3. - z]
-    NO = np.size(xo)
+    No = np.size(xo)
 
     # Bragg angle and atomic plane distance d for a given wavelength lamb and
-    # Miller index (h,k,l)
+    # Miller indices (h,k,l)
     d_num = np.sqrt(3.)*a0*c0
     d_den = np.sqrt(4.*(ih**2 + ik**2 + ih*ik)*(c0**2) + 3.*(il**2)*(a0**2))
     if d_den == 0.:
@@ -149,8 +165,9 @@ def compute_rockingcurve(self,
         )
         raise Exception(msg)
 
-    # Atomic scattering factors ["asf"] for Si(2+) and O(1-) as a function of
-    # sin(theta)/lambda ["sol_values"], taking into account molecular bounds
+    # Atomic scattering factors ("asf") for Si(2+) and O(1-) as a function of
+    # sin(theta)/lambda ("sol"), taking into account molecular bounds
+    # ("si") for Silicium and ("o") for Oxygen
     sol_si = np.r_[
         0., 0.1, 0.2, 0.25, 0.3, 0.35, 0.4, 0.5, 0.6,
         0.7, 0.8, 0.9, 1., 1.1, 1.2, 1.3, 1.4, 1.5,
@@ -168,11 +185,11 @@ def compute_rockingcurve(self,
     ]
 
 
-    # atomic absorption coefficient for Si and O as a function of lamb TBC
+    # atomic absorption coefficient for Si and O as a function of lamb
     mu_si = 1.38e-2*(lamb**2.79)*(Zsi**2.73)
     mu_si1 = 5.33e-4*(lamb**2.74)*(Zsi**3.03)
     if lamb > 6.74:
-        mu_si = mu_si + mu_si1
+        mu_si = mu_si1
     mu_o = 5.4e-3*(lamb**2.92)*(Zo**3.07)
     mu = 2.65e-8*(7.*mu_si + 8.*mu_o)/15.
 
@@ -180,7 +197,6 @@ def compute_rockingcurve(self,
     # ----------------------------------------------------------------
 
     # interpolation of atomic scattering factor ("f") in function of sol
-    # ("si") for Silicium and ("o") for Oxygen
     # ("_re") for Real part and ("_im") for Imaginary part
     fsi_re = scipy.interpolate.interp1d(sol_si, asf_si)
     dfsi_re = 0.1335*lamb - 0.006
@@ -239,33 +255,38 @@ def compute_rockingcurve(self,
     # ratio imaginary part and real part of the structure factor
     kk = F_im/F_re
 
-    # rek = Real(kk)
+    # rek : Real(kk)
     rek = (F_re_cos*F_im_cos + F_re_sin*F_im_sin)/(F_re**2.)
 
     # real part of psi_H
     psi_re = (re*(lamb**2)*F_re)/(np.pi*V)
 
-    # zero-order real part (averaged) TBC
+    # zero-order real part (averaged)
+    # TBC with F.
     psi0_dre = -re*(lamb**2)*(
-        NO*(Zo + dfo_re) + NSi*(Zsi + dfsi_re)
-        )/(np.pi*V)
+        No*(Zo + dfo_re) + Nsi*(Zsi + dfsi_re)
+    )/(np.pi*V)
+    """psi0_dre = -re*(lamb**2)*(
+        No*Zo*(1. + dfo_re) + Nsi*Zsi*(1. + dfsi_re)
+    )/(np.pi*V)"""
 
     # zero-order imaginary part (averaged)
-    psi0_im = -re*(lamb**2)*(NO*fo_im + NSi*fsi_im)/(np.pi*V)
+    psi0_im = -re*(lamb**2)*(No*fo_im + Nsi*fsi_im)/(np.pi*V)
+    """psi0_im = -re*(lamb**2)*(No*Zo*fo_im + Nsi*Zsi*fsi_im)/(np.pi*V)"""
 
     # Power ratio and their integrated reflectivity for 3 crystals models:
     # perfect (Darwin model), ideally mosaic thick and dynamical
-    # ------------------------------------------------------------------------
+    # --------------------------------------------------------------------
 
     (
-        alpha, bb, polar, g, y, y0, power_ratio, th, rr,
-        P_per, P_mos, P_dyn, det,
+        alpha, bb, polar, g, y, y0, power_ratio, th, rhg,
+        P_per, P_mos, P_dyn, P_dyn_norm, det, det_norm,
     ) = CrystBragg_comp_integrated_reflect(
         lamb=lamb, re=re, V=V, Zo=Zo, theta=theta, mu=mu,
         F_re=F_re, psi_re=psi_re, psi0_dre=psi0_dre, psi0_im=psi0_im,
         Fmod=Fmod, Fbmod=Fbmod, kk=kk, rek=rek,
         model=['perfect', 'mosaic', 'dynamical',],
-        use_non_parallelism=use_non_parallelism,
+        use_non_parallelism=use_non_parallelism, na=na,
     )
 
     # Plot atomic scattering factor
@@ -282,10 +303,11 @@ def compute_rockingcurve(self,
 
     if plot_power_ratio:
         CrystalBragg_plot_power_ratio(
-            ih=ih, ik=ik, il=il, lamb=lamb, theta=theta,
+            ih=ih, ik=ik, il=il, lamb=lamb,
+            theta=theta, theta_deg=theta_deg,
             th=th, power_ratio=power_ratio, y=y, y0=y0,
             bb=bb, polar=polar, alpha=alpha,
-            use_non_parallelism=use_non_parallelism,
+            use_non_parallelism=use_non_parallelism, na=na,
         )
 
     # Plot P_dyn vs glancing angle
@@ -293,8 +315,10 @@ def compute_rockingcurve(self,
 
     if plot_relation:
         CrystalBragg_plot_reflect_glancing(
-            ih=ih, ik=ik, il=il, lamb=lamb, theta=theta,
-            alpha=alpha, bb=bb, rr=rr, P_dyn=P_dyn, th=th, det=det,
+            ih=ih, ik=ik, il=il, lamb=lamb,
+            theta=theta, theta_deg=theta_deg,
+            alpha=alpha, bb=bb, th=th,
+            P_dyn=P_dyn_norm, det=det_norm,
         )
 
     # Print results
@@ -312,9 +336,11 @@ def compute_rockingcurve(self,
             'dynamical model': P_dyn,
         },
         'Ratio imag & real part of structure factor': kk,
-        'R_perp/R_par': rr[1]/rr[0],
+        'R_perp/R_par': rhg[1]/rhg[0],
         'RC width': det,
     }
+    if use_non_parallelism:
+        dout['Non-parallelism angles (deg)'] = alpha*(180/np.pi)
 
     if verb is True:
         dout['Inter-reticular distance (A)'] = np.round(d_atom, decimals=3)
@@ -323,7 +349,7 @@ def compute_rockingcurve(self,
         dout['Ratio imag & real part of structure factor'] = (
             np.round(kk, decimals=3,)
         )
-        dout['R_perp/R_par'] = np.round(rr[1]/rr[0], decimals=9)
+        dout['R_perp/R_par'] = np.round(rhg[1]/rhg[0], decimals=9)
         dout['RC width'] = np.round(det, decimals=6)
         dout['Integrated reflectivity']['perfect model'] = (
             np.round(P_per, decimals=9),
@@ -359,7 +385,7 @@ def CrystBragg_check_inputs_rockingcurve(
         lamb = 3.96
         msg = (
             "Args h, k, l and lamb were not explicitely specified\n"
-            "and have been put to default values:\n"
+            "and have been put to the following default values:\n"
             + "\t - h: first Miller index ({})\n".format(ih)
             + "\t - k: second Miller index ({})\n".format(ik)
             + "\t - l: third Miller index ({})\n".format(il)
@@ -401,37 +427,31 @@ def CrystBragg_comp_integrated_reflect(
     F_re=None, psi_re=None, psi0_dre=None, psi0_im=None,
     Fmod=None, Fbmod=None, kk=None, rek=None,
     model=[None, None, None],
-    use_non_parallelism=None,
+    use_non_parallelism=None, na=None,
 ):
 
-    # Parameter b
-    # -----------
+    # Symmetry parameter b
+    # ---------------------
 
     if use_non_parallelism == False:
         alpha = 0.
         bb = np.r_[-1.]
     else:
-        # to redo F's plots about (2,2,-3,1.85A)
-        alpha = np.linspace(-theta + 0.2294, theta - 0.2294, 5)
-        # max value of both ArXVII half crystals: 3 arcmin
-        # alpha = np.linspace(-0.05, 0.05, 5)*(np.pi/180)
+        alpha = np.linspace(-theta + 0.05, theta - 0.05, na)
+        #alpha = np.linspace(-0.05, 0.05, 5)*(np.pi/180)
         bb = np.sin(alpha + theta)/np.sin(alpha - theta)
 
     # Perfect (darwin) model
     # ----------------------
 
-    P_per = Zo*F_re*re*(lamb**2)*(
-        1. + abs(np.cos(2.*theta))
-    )/(
+    P_per = Zo*F_re*re*(lamb**2)*(1. + abs(np.cos(2.*theta)))/(
         6.*np.pi*V*np.sin(2.*theta)
     )
 
     # Ideally thick mosaic model
     # --------------------------
 
-    P_mos = (F_re**2)*(re**2)*(lamb**3)*(
-        1. + (np.cos(2.*theta))**2
-    )/(
+    P_mos = (F_re**2)*(re**2)*(lamb**3)*(1. + (np.cos(2.*theta))**2)/(
         4.*mu*(V**2)*np.sin(2.*theta)
     )
 
@@ -445,51 +465,47 @@ def CrystBragg_comp_integrated_reflect(
     g = np.full((polar.size, bb.size), np.nan)
     for i in range(polar.size):
         for j in range(bb.size):
-            g[i, j] = (
-                ((1. - bb[j])/2.)*psi0_im
-            )/(
+            g[i, j] = (((1. - bb[j])/2.)*psi0_im)/(
                 np.sqrt(abs(bb[j]))*polar[i]*psi_re
             )
-    y = np.linspace(-4., 4., 81)
-    dy = np.zeros(81) + 0.1
+    y = np.linspace(-10., 10., 201)
+    dy = np.zeros(201) + 0.1
     y0 = -psi0_dre/np.sin(2.*theta)
 
     al = np.full((polar.size, bb.size, y.size), 0.)
     power_ratio = np.full((al.shape), np.nan)
-    th = np.full((al.shape), np.nan)
-
     power_ratiob = np.full((bb.size, y.size), np.nan)
     rhy = np.full((bb.size), np.nan)
-    rr = np.full((polar.size, bb.size), np.nan)
-    P_dyn = np.full((bb.size), np.nan)
+    th = np.full((al.shape), np.nan)
+    conv_ygscale = np.full((polar.size, bb.size), np.nan)
+    rhg = np.full((polar.size, bb.size), np.nan)
 
     for i in range(polar.size):
         for j in range(bb.size):
             al[i, j, ...] = (y**2 + g[i, j]**2 + np.sqrt(
-                (y**2 - g[i, j]**2 + kk**2 - 1.)**2 + 4.*(g[i, j]*y - rek)**2
-                ))/np.sqrt((kk**2 - 1.)**2 + 4.*rek**2)
+                (y**2 - g[i, j]**2 + abs(kk)**2 - 1.)**2 + 4.*(
+                    g[i, j]*y - rek
+                )**2
+            ))/np.sqrt((abs(kk)**2 - 1.)**2 + 4.*(rek**2))
             # reflecting power or power ratio R_dyn
             power_ratio[i, j, ...] = (Fmod/Fbmod)*(
-                al[i, j, :] - np.sqrt((al[i, j, :]**2 - 1.))
+                al[i, j, :] - np.sqrt((al[i, j, :]**2) - 1.)
             )
+            # integration of the power ratio over dy
             power_ratiob[j, :] = power_ratio[i, j, ...]
+            rhy[j] = np.sum(dy*power_ratiob[j, :])
             # conversion formula from y-scale to glancing angle scale
             th[i, j, ...] = (
                 -y*polar[i]*psi_re*np.sqrt(abs(bb[j])) + psi0_dre*(
                     (1. - bb[j])/2.
                 )
             )/(bb[j]*np.sin(2.*theta))
-            # integration of the power ratio over dy
-            rhy[j] = np.sum(dy*power_ratiob[j, :])
-            # diffraction radiation
+            # integrated reflecting power in the glancing angle scale
             # r(i=0): normal component & r(i=1): parallel component
-            rr[i, ...] = (polar[i]*psi_re*rhy)/(
-                np.sqrt(abs(bb[j]))*np.sin(2.*theta)
+            conv_ygscale[i, ...] = (polar[i]*psi_re)/(
+                np.sqrt(abs(bb))*np.sin(2*theta)
             )
-    # Integrated reflectivity
-    P_dyn = np.full((bb.size), np.nan)
-    #fmax = P_dyn.copy()
-    det = P_dyn.copy()
+            rhg[i, ...] = conv_ygscale[i, :]*rhy
 
     def lin_interp(x, y, i, half):
         return x[i] + (x[i+1] - x[i])*((half - y[i])/(y[i+1] - y[i]))
@@ -504,8 +520,15 @@ def CrystBragg_comp_integrated_reflect(
             lin_interp(x, y, zero_cross_ind[1], half),
         ]
 
+    # Integrated reflectivity and rocking curve width
+    P_dyn = np.full((bb.size), np.nan)
+    det = P_dyn.copy()
+
     for j in range(bb.size):
-        P_dyn[j] = np.sum(rr[:, j])/2.
+        if use_non_parallelism:
+            P_dyn[j] = rhg[0, j]
+        else:
+            P_dyn[j] = np.sum(rhg[:, j])/2.
         if P_dyn[j] < 1e-7:
             msg = (
                 "Please check the equations for integrated reflectivity:\n"
@@ -514,22 +537,22 @@ def CrystBragg_comp_integrated_reflect(
             raise Exception(msg)
         hmx = half_max_x(th[0, j, :], power_ratio[0, j, :])
         det[j] = hmx[1] - hmx[0]
-        #fmax[j] = np.max(power_ratio[0, j, :] + power_ratio[1, j, :])
-        #det[j] = (2.*P_dyn[j])/fmax[j]
 
-    # Normalization from alpha=0 case
+    # Normalization for alpha=0 case
+    P_dyn_norm = np.full((P_dyn.size), np.nan)
+    det_norm = np.full((det.size), np.nan)
     if use_non_parallelism:
         nn = (det.size/2.)
         if (nn % 2) == 0:
             nn = int(nn - 1)
         else:
             nn = int(nn - 0.5)
-        det = det/det[nn]
-        P_dyn = P_dyn/P_dyn[nn]
+        det_norm = det/det[nn]
+        P_dyn_norm = P_dyn/P_dyn[nn]
 
     return (
-        alpha, bb, polar, g, y, y0, power_ratio, th, rr,
-        P_per, P_mos, P_dyn, det,
+        alpha, bb, polar, g, y, y0, power_ratio, th, rhg,
+        P_per, P_mos, P_dyn, P_dyn_norm, det, det_norm,
     )
 
 
@@ -562,10 +585,11 @@ def CrystalBragg_plot_atomic_scattering_factor(
 
 
 def CrystalBragg_plot_power_ratio(
-    ih=None, ik=None, il=None, lamb=None, theta=None,
+    ih=None, ik=None, il=None, lamb=None,
+    theta=None, theta_deg=None,
     th=None, power_ratio=None, y=None, y0=None,
     bb=None, polar=None, alpha=None,
-    use_non_parallelism=None,
+    use_non_parallelism=None, na=None,
 ):
 
     # Plot
@@ -576,38 +600,60 @@ def CrystalBragg_plot_power_ratio(
     ax = fig1.add_subplot(gs[0, 0])
     ax.set_title(
         'Qz, ' + f'({ih},{ik},{il})' + fr', $\lambda$={lamb} A' +
-        fr', Bragg angle={np.round(theta, decimals=3)} rad'
+        fr', Bragg angle={np.round(theta_deg, decimals=3)}$\deg$'
     )
     ax.set_xlabel(r'$\theta$-$\theta_{B}$ (rad)')
     ax.set_ylabel('P$_H$/P$_0$')
-    let = ['I', 'II', 'III', 'IV', 'V']
-    alpha_deg = alpha*(180/np.pi)
-    for j in range(bb.size):
-        ax.plot(
-            th[0, j, :],
-            power_ratio[0, j, :],
-            'k-',
-            #label='normal component'i,
-        )
-        ind = np.where(power_ratio[0, j, :] == np.amax(power_ratio[0, j, :]))
-        ax.text(
-            th[0, j, ind],
-            np.max(power_ratio[0, j, :] + 0.01),
-            '({})'.format(let[j]),
-        )
-        ax.plot(
-            th[1, j, :],
-            power_ratio[1, j, :],
-            'k:',
-            #label='parallel component',
-        )
+
+    if use_non_parallelism:
+        alpha_deg = alpha*(180/np.pi)
+        nalpha = alpha_deg.size
+        if (nalpha % 2) == 0:
+            nalpha = int(nalpha - 1)
+        else:
+            nalpha = int(nalpha - 0.5)
+        dd = np.r_[0, int(nalpha/2), nalpha]
+        let = {'I': dd[0], 'II': dd[1], 'III': dd[2]}
+    else:
+        alpha_deg = np.r_[alpha]*(180/np.pi)
+        dd = np.r_[0]
+        let = {'I': dd[0]}
+
+    for j in range(na):
+        if any(j == dd):
+            ind = np.where(
+                power_ratio[0, j, :] == np.amax(power_ratio[0, j, :])
+            )
+            keylist = list(let.keys())
+            valuelist = list(let.values())
+            valuedd = valuelist.index(j)
+            keydd = keylist[valuedd]
+            ax.text(
+                th[0, j, ind],
+                np.max(power_ratio[0, j, :] + 0.005),
+                '({})'.format(keydd),
+            )
+            ax.plot(
+                th[0, j, :],
+                power_ratio[0, j, :],
+                'k-',
+                label=r'normal, ({}): $\alpha$=({})deg'.format(
+                    keydd, np.round(alpha_deg[j], 1)
+                ),
+            )
+            ax.plot(
+                th[1, j, :],
+                power_ratio[1, j, :],
+                'k:',
+                label=r'parallel',
+            )
     #ax.axvline(y0, linetsyle=":", label='pattern center')
     ax.legend()
 
 
 def CrystalBragg_plot_reflect_glancing(
-    ih=None, ik=None, il=None, lamb=None, theta=None,
-    alpha=None, bb=None, rr=None, P_dyn=None, th=None, det=None,
+    ih=None, ik=None, il=None, lamb=None, theta=None, theta_deg=None,
+    alpha=None, bb=None, rhg=None, P_dyn=None, th=None, det=None,
 ):
 
     # Plot
@@ -618,29 +664,33 @@ def CrystalBragg_plot_reflect_glancing(
     ax = fig2.add_subplot(gs[0, 0])
     ax.set_title(
         'Qz, ' + f'({ih},{ik},{il})' + fr', $\lambda$={lamb} A' +
-        fr', Bragg angle={np.round(theta, decimals=3)} rad'
+        fr', Bragg angle={np.round(theta_deg, decimals=3)}deg'
     )
     ax.set_xlabel(r'$\alpha$ (deg)')
-    ax.set_xlim(-60., 60.)
+    ax.set_xlim(-theta_deg - 10., theta_deg + 10.)
+    ax.set_ylim(0., 5.)
 
     alpha_deg = alpha*(180/np.pi)
     f = scipy.interpolate.interp1d(alpha_deg, abs(bb), kind='cubic')
     alpha_deg_bis = np.linspace(-alpha_deg, alpha_deg, 20)
     bb_bis = f(alpha_deg_bis)
     ax.plot(
-        alpha_deg, det,
+        alpha_deg,
+        det,
         'k--',
-        label=r'$\Delta\theta$ [x1e-5] (normalized)',
+        label=r'RC width $\Delta\theta$ (normalized)',
     )
     ax.plot(
-        alpha_deg, rr[0, :]*(1e5),
+        alpha_deg,
+        P_dyn,
         'k-',
         label='P$_{dyn}$ (normal comp.) (normalized)',
     )
     ax.plot(
-        alpha_deg_bis[:, 0], bb_bis[:, 0],
+        alpha_deg_bis[:, 0],
+        bb_bis[:, 0],
         'k-.',
-        label='b',
+        label='|b|',
     )
     ax.legend()
 

--- a/tofu/spectro/_rockingcurve.py
+++ b/tofu/spectro/_rockingcurve.py
@@ -9,6 +9,7 @@ import copy
 # Common
 import numpy as np
 import scipy.interpolate
+from scipy.interpolate import InterpolatedUnivariateSpline
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 from matplotlib.axes._axes import Axes
@@ -287,7 +288,7 @@ def compute_rockingcurve(
             lamb=lamb, re=re, V=V, Zo=Zo, theta=theta, mu=mu,
             F_re=F_re, psi_re=psi_re, psi0_dre=psi0_dre, psi0_im=psi0_im,
             Fmod=Fmod, Fbmod=Fbmod, kk=kk, rek=rek,
-            model=['perfect', 'mosaic', 'dynamical',],
+            model=['perfect', 'mosaic', 'dynamical'],
             use_non_parallelism=use_non_parallelism, na=na,
         )
     else:
@@ -298,7 +299,7 @@ def compute_rockingcurve(
             lamb=lamb, re=re, V=V, Zo=Zo, theta=theta, mu=mu,
             F_re=F_re, psi_re=psi_re, psi0_dre=psi0_dre, psi0_im=psi0_im,
             Fmod=Fmod, Fbmod=Fbmod, kk=kk, rek=rek,
-            model=['perfect', 'mosaic', 'dynamical',],
+            model=['perfect', 'mosaic', 'dynamical'],
             use_non_parallelism=use_non_parallelism, na=na,
         )
 
@@ -451,12 +452,12 @@ def CrystBragg_comp_integrated_reflect(
     # Symmetry parameter b
     # ---------------------
 
-    if use_non_parallelism == False:
+    if not use_non_parallelism:
         alpha = np.r_[0.]
         bb = np.r_[-1.]
     else:
         alpha = np.linspace(-theta + 0.01, theta - 0.01, na)
-        #alpha = np.linspace(-0.05, 0.05, 5)*(np.pi/180)
+        # alpha = np.linspace(-0.05, 0.05, 5)*(np.pi/180)
         bb = np.sin(alpha + theta)/np.sin(alpha - theta)
 
     # Perfect (darwin) model
@@ -676,7 +677,7 @@ def CrystalBragg_plot_power_ratio(
                 'k:',
                 label=r'parallel',
             )
-    #ax.axvline(y0, linetsyle=":", label='pattern centeri in y-scale')
+    # ax.axvline(y0, linetsyle=":", label='pattern centeri in y-scale')
     ax.legend()
 
 

--- a/tofu/spectro/_rockingcurve.py
+++ b/tofu/spectro/_rockingcurve.py
@@ -12,7 +12,6 @@ import scipy.interpolate
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 from matplotlib.axes._axes import Axes
-from mpl_toolkits.mplot3d import Axes3D
 
 # tofu
 from tofu.version import __version__
@@ -27,7 +26,8 @@ from tofu.version import __version__
 
 def compute_rockingcurve(self,
     ih=None, ik=None, il=None, lamb=None,
-    plot_asf=None, plot_power_ratio=None,
+    use_non_parallelism=None,
+    plot_asf=None, plot_power_ratio=None, plot_relation=None,
     verb=None, returnas=None,
 ):
     """The code evaluates, for a given wavelength, the atomic plane distance d,
@@ -49,11 +49,16 @@ def compute_rockingcurve(self,
         Miller indices of crystal used
     lamb:    float
         Wavelength of interest, in Angstroms (1e-10 m)
+    use_non_parallelism:    str
+        Introduce non-parallelism between dioptre and reflecting planes
     plot_asf:    str
         Plotting the atomic scattering factor thanks to data with respect to
         sin(theta)/lambda
     plot_power_ratio:    str
         Plot the power ratio with respect to the glancing angle
+    plot_relation:    str
+        Plot relations between the integrated reflectivity, the intrinsic
+        width and the parameter b vs the glancing angle
     verb:    str
         True or False to print the content of the results dictionnary 'dout'
     returnas:    str
@@ -63,10 +68,14 @@ def compute_rockingcurve(self,
     # Check inputs
     # ------------
 
+    if use_non_parallelism is None:
+        use_non_parallelism = False
     if plot_asf is None:
         plot_asf = False
     if plot_power_ratio is None:
         plot_power_ratio = True
+    if plot_relation is None and use_non_parallelism is not False:
+        plot_relation = True
     if verb is None:
         verb = True
     if returnas is None:
@@ -80,39 +89,37 @@ def compute_rockingcurve(self,
     # ---------------------------------------
 
     # Classical electronical radius, in Angstroms
-    re = 2.82084508e-5
+    re = 2.8208e-5
 
-    # From Ralph W.G. Wyckoff, "Crystal Structures" (1948)
-    # https://babel.hathitrust.org/cgi/pt?id=mdp.39015081138136&view=1up&seq=259&skin=2021
-    # Inter-atomic distances into hexagonal cell unit (page 239 & 242) and
-    # calculation of the associated volume
-    # TBC with Francesca
+    # Inter-atomic distances into hexagonal cell unit and associated volume TBC
     a0 = 4.9130
     c0 = 5.4045
-    V = a0**2.*c0*np.sqrt(3.)/2.
+    V = (a0**2.)*c0*np.sqrt(3.)/2.
 
     # Atomic number of Si and O atoms
     Zsi = 14.
     Zo = 8.
 
-    # Position of the three Si atoms in the unit cell (page 242 Wyckoff)
+    # Position of the three Si atoms in the unit cell
     u = 0.4705
     xsi = np.r_[-u, u, 0.]
     ysi = np.r_[-u, 0., u]
     zsi = np.r_[1./3., 0., 2./3.]
+    NSi = np.size(xsi)
 
-    # Position of the six O atoms in the unit cell (page 242 Wyckoff)
+    # Position of the six O atoms in the unit cell
     x = 0.4152
     y = 0.2678
     z = 0.1184
-    xo = np.r_[x, y-x, -y, x-y, y, -x]
-    yo = np.r_[y, -x, x-y, -y, x, y-x]
-    zo = np.r_[z, z+1./3., z+2./3., -z, 2./3.-z, 1./3.-z]
+    xo = np.r_[x, y - x, -y, x - y, y, -x]
+    yo = np.r_[y, -x, x - y, -y, x, y - x]
+    zo = np.r_[z, z + 1./3., z + 2./3., -z, 2./3. - z, 1./3. - z]
+    NO = np.size(xo)
 
     # Bragg angle and atomic plane distance d for a given wavelength lamb and
     # Miller index (h,k,l)
     d_num = np.sqrt(3.)*a0*c0
-    d_den = np.sqrt(4.*(ih**2 + ik**2 + ih*ik)*c0**2 + 3.*il**2*a0**2)
+    d_den = np.sqrt(4.*(ih**2 + ik**2 + ih*ik)*(c0**2) + 3.*(il**2)*(a0**2))
     if d_den == 0.:
         msg = (
             "Something went wrong in the calculation of d, equal to 0!\n"
@@ -132,7 +139,7 @@ def compute_rockingcurve(self,
     sol = 1./(2.*d_atom)
     sin_theta = lamb/(2.*d_atom)
     theta = np.arcsin(sin_theta)
-    theta_deg = theta*180./np.pi
+    theta_deg = theta*(180./np.pi)
     lc = [theta_deg < 10., theta_deg > 89.]
     if any(lc):
         msg = (
@@ -143,10 +150,7 @@ def compute_rockingcurve(self,
         raise Exception(msg)
 
     # Atomic scattering factors ["asf"] for Si(2+) and O(1-) as a function of
-    # sol = sin(theta)/lambda ["sol_values"], taking into account molecular
-    # bounds
-    # From Henry & Lonsdale, "International tables for Crystallography" (1969)
-    # Vol.III p202 or Vol.IV page 73 for O(1-), Vol.III p202 ? for Si(2+)
+    # sin(theta)/lambda ["sol_values"], taking into account molecular bounds
     sol_si = np.r_[
         0., 0.1, 0.2, 0.25, 0.3, 0.35, 0.4, 0.5, 0.6,
         0.7, 0.8, 0.9, 1., 1.1, 1.2, 1.3, 1.4, 1.5,
@@ -164,15 +168,12 @@ def compute_rockingcurve(self,
     ]
 
 
-    # atomic absorption coefficient for Si and O as a function of lamb
-    # focus on the photoelectric effect, mu=cte*(lamb*Z)**3 with
-    # Z the atomic number
-    # TBF : I still didn't find where to pick up the cte values and the powers
-    mu_si = 1.38e-2*lamb**2.79*Zsi**2.73
-    mu_si1 = 5.33e-4*lamb**2.74*Zsi**3.03
+    # atomic absorption coefficient for Si and O as a function of lamb TBC
+    mu_si = 1.38e-2*(lamb**2.79)*(Zsi**2.73)
+    mu_si1 = 5.33e-4*(lamb**2.74)*(Zsi**3.03)
     if lamb > 6.74:
-        mu_si = mu_si1
-    mu_o = 5.4e-3*lamb**2.92*Zo**3.07
+        mu_si = mu_si + mu_si1
+    mu_o = 5.4e-3*(lamb**2.92)*(Zo**3.07)
     mu = 2.65e-8*(7.*mu_si + 8.*mu_o)/15.
 
     # Calculation of the structure factor for the alpha-quartz crystal
@@ -181,41 +182,41 @@ def compute_rockingcurve(self,
     # interpolation of atomic scattering factor ("f") in function of sol
     # ("si") for Silicium and ("o") for Oxygen
     # ("_re") for Real part and ("_im") for Imaginary part
-    fsi_re = scipy.interpolate.interp1d(sol_si, asf_si)    # fsire
-    dfsi_re = 0.1335*lamb - 0.006    # dfsire
-    fsi_re = fsi_re(sol) + dfsi_re    # fsire
-    fsi_im = 5.936e-4*Zsi*(mu_si/lamb)    # fsiim, =cte*(Z*mu)/lamb
+    fsi_re = scipy.interpolate.interp1d(sol_si, asf_si)
+    dfsi_re = 0.1335*lamb - 0.006
+    fsi_re = fsi_re(sol) + dfsi_re
+    fsi_im = 5.936e-4*Zsi*(mu_si/lamb)
 
-    fo_re = scipy.interpolate.interp1d(sol_o, asf_o)    # fore
-    dfo_re = 0.1335*lamb - 0.206    # dfore
-    fo_re = fo_re(sol) + dfo_re    # fore
-    fo_im = 5.936e-4*Zo*(mu_o/lamb)    # foim TBF: find where to find the cte
+    fo_re = scipy.interpolate.interp1d(sol_o, asf_o)
+    dfo_re = 0.1335*lamb - 0.206
+    fo_re = fo_re(sol) + dfo_re
+    fo_im = 5.936e-4*Zo*(mu_o/lamb)
 
     # structure factor ("F") for (hkl) reflection
     phasesi = np.full((xsi.size), np.nan)
     phaseo = np.full((xo.size), np.nan)
     for i in range(xsi.size):
-        phasesi[i] = ih*xsi[i] + ik*ysi[i] + il*zsi[i]    # arsi
+        phasesi[i] = ih*xsi[i] + ik*ysi[i] + il*zsi[i]
     for j in range(xo.size):
-        phaseo[j] = ih*xo[j] + ik*yo[j] + il*zo[j]    # aro
+        phaseo[j] = ih*xo[j] + ik*yo[j] + il*zo[j]
 
-    Fsi_re1 = np.sum(fsi_re*np.cos(2*np.pi*phasesi))    # resip
-    Fsi_re2 = np.sum(fsi_re*np.sin(2*np.pi*phasesi))    # aimsip
-    Fsi_im1 = np.sum(fsi_im*np.cos(2*np.pi*phasesi))    # resis
-    Fsi_im2 = np.sum(fsi_im*np.sin(2*np.pi*phasesi))    # aimsis
+    Fsi_re1 = np.sum(fsi_re*np.cos(2*np.pi*phasesi))
+    Fsi_re2 = np.sum(fsi_re*np.sin(2*np.pi*phasesi))
+    Fsi_im1 = np.sum(fsi_im*np.cos(2*np.pi*phasesi))
+    Fsi_im2 = np.sum(fsi_im*np.sin(2*np.pi*phasesi))
 
-    Fo_re1 = np.sum(fo_re*np.cos(2*np.pi*phaseo))    # reop
-    Fo_re2 = np.sum(fo_re*np.sin(2*np.pi*phaseo))    # aimop
-    Fo_im1 = np.sum(fo_im*np.cos(2*np.pi*phaseo))    # reos
-    Fo_im2 = np.sum(fo_im*np.sin(2*np.pi*phaseo))    # aimos
+    Fo_re1 = np.sum(fo_re*np.cos(2*np.pi*phaseo))
+    Fo_re2 = np.sum(fo_re*np.sin(2*np.pi*phaseo))
+    Fo_im1 = np.sum(fo_im*np.cos(2*np.pi*phaseo))
+    Fo_im2 = np.sum(fo_im*np.sin(2*np.pi*phaseo))
 
-    F_re_cos = Fsi_re1 + Fo_re1    # fpre
-    F_re_sin = Fsi_re2 + Fo_re2    # fpim
-    F_im_cos = Fsi_im1 + Fo_im1    # fsre
-    F_im_sin = Fsi_im2 + Fo_im2    # fsim
+    F_re_cos = Fsi_re1 + Fo_re1
+    F_re_sin = Fsi_re2 + Fo_re2
+    F_im_cos = Fsi_im1 + Fo_im1
+    F_im_sin = Fsi_im2 + Fo_im2
 
-    F_re = np.sqrt(F_re_cos**2 + F_re_sin**2)    # fpmod
-    F_im = np.sqrt(F_im_cos**2 + F_im_sin**2)    # fsmod
+    F_re = np.sqrt(F_re_cos**2 + F_re_sin**2)
+    F_im = np.sqrt(F_im_cos**2 + F_im_sin**2)
 
     # Calculation of Fourier coefficients of polarization
     # ---------------------------------------------------
@@ -223,12 +224,12 @@ def compute_rockingcurve(self,
     # expression of the Fourier coef. psi_H
     Fmod = np.sqrt(
         F_re**2 + F_im**2 - 2.*(F_re_cos*F_re_sin - F_im_cos*F_im_sin)
-    )    # fmod
+    )
 
     # psi_-H equivalent to (-ih, -ik, -il)
     Fbmod = np.sqrt(
         F_re**2 + F_im**2 - 2.*(F_im_cos*F_im_sin - F_re_cos*F_re_sin)
-    )    # fbmod
+    )
 
     if Fmod == 0.:
         Fmod == 1e-30
@@ -242,27 +243,29 @@ def compute_rockingcurve(self,
     rek = (F_re_cos*F_im_cos + F_re_sin*F_im_sin)/(F_re**2.)
 
     # real part of psi_H
-    psi_re = (re*(lamb**2)*F_re)/(np.pi*V)    # psihp
+    psi_re = (re*(lamb**2)*F_re)/(np.pi*V)
 
-    # zero-order real part (averaged) TBF
+    # zero-order real part (averaged) TBC
     psi0_dre = -re*(lamb**2)*(
-        6.*(Zo + dfo_re) + 3.*(Zsi + dfsi_re)
-        )/(np.pi*V)   # psiop
+        NO*(Zo + dfo_re) + NSi*(Zsi + dfsi_re)
+        )/(np.pi*V)
 
     # zero-order imaginary part (averaged)
-    psi0_im = -re*(lamb**2)*(6.*fo_im + 3.*fsi_im)/(np.pi*V)    # psios
+    psi0_im = -re*(lamb**2)*(NO*fo_im + NSi*fsi_im)/(np.pi*V)
 
     # Power ratio and their integrated reflectivity for 3 crystals models:
-    # perfect (Darwin model), ideally mosaic thick crystal and dynamical model
+    # perfect (Darwin model), ideally mosaic thick and dynamical
     # ------------------------------------------------------------------------
 
     (
-        P_per, P_mos, P_dyn, power_ratio, th, rr, det, ymax,
+        alpha, bb, polar, g, y, y0, power_ratio, th, rr,
+        P_per, P_mos, P_dyn, det,
     ) = CrystBragg_comp_integrated_reflect(
         lamb=lamb, re=re, V=V, Zo=Zo, theta=theta, mu=mu,
         F_re=F_re, psi_re=psi_re, psi0_dre=psi0_dre, psi0_im=psi0_im,
         Fmod=Fmod, Fbmod=Fbmod, kk=kk, rek=rek,
         model=['perfect', 'mosaic', 'dynamical',],
+        use_non_parallelism=use_non_parallelism,
     )
 
     # Plot atomic scattering factor
@@ -280,7 +283,18 @@ def compute_rockingcurve(self,
     if plot_power_ratio:
         CrystalBragg_plot_power_ratio(
             ih=ih, ik=ik, il=il, lamb=lamb, theta=theta,
-            th=th, power_ratio=power_ratio,
+            th=th, power_ratio=power_ratio, y=y, y0=y0,
+            bb=bb, polar=polar, alpha=alpha,
+            use_non_parallelism=use_non_parallelism,
+        )
+
+    # Plot P_dyn vs glancing angle
+    # ----------------------------
+
+    if plot_relation:
+        CrystalBragg_plot_reflect_glancing(
+            ih=ih, ik=ik, il=il, lamb=lamb, theta=theta,
+            alpha=alpha, bb=bb, rr=rr, P_dyn=P_dyn, th=th, det=det,
         )
 
     # Print results
@@ -298,12 +312,12 @@ def compute_rockingcurve(self,
             'dynamical model': P_dyn,
         },
         'Ratio imag & real part of structure factor': kk,
-        'Intensity maximum theoretical (normal & parallel compo)': ymax,
         'R_perp/R_par': rr[1]/rr[0],
         'RC width': det,
     }
 
     if verb is True:
+        dout['Inter-reticular distance (A)'] = np.round(d_atom, decimals=3)
         dout['Volume of the unit cell (A^3)'] = np.round(V, decimals=3)
         dout['Bragg angle of reference (rad)'] = np.round(theta, decimals=3)
         dout['Ratio imag & real part of structure factor'] = (
@@ -335,6 +349,7 @@ def CrystBragg_check_inputs_rockingcurve(
     ih=None, ik=None, il=None, lamb=None,
 ):
 
+    # All args are None
     dd = {'ih': ih, 'ik': ik, 'il': il, 'lamb': lamb}
     lc = [v0 is None for k0, v0 in dd.items()]
     if all(lc):
@@ -352,6 +367,7 @@ def CrystBragg_check_inputs_rockingcurve(
         )
         warnings.warn(msg)
 
+    # Some args are bot but not all
     dd2 = {'ih': ih, 'ik': ik, 'il': il, 'lamb': lamb}
     lc2 = [v0 is None for k0, v0 in dd2.items()]
     if any(lc2):
@@ -364,6 +380,7 @@ def CrystBragg_check_inputs_rockingcurve(
         )
         raise Exception(msg)
 
+    # Some args are string values
     cdt = [type(v0) == str for k0, v0 in dd.items()]
     if any(cdt) or all(cdt):
         msg = (
@@ -383,21 +400,39 @@ def CrystBragg_comp_integrated_reflect(
     lamb=None, re=None, V=None, Zo=None, theta=None, mu=None,
     F_re=None, psi_re=None, psi0_dre=None, psi0_im=None,
     Fmod=None, Fbmod=None, kk=None, rek=None,
-    model=[None, None, None]
+    model=[None, None, None],
+    use_non_parallelism=None,
 ):
+
+    # Parameter b
+    # -----------
+
+    if use_non_parallelism == False:
+        alpha = 0.
+        bb = np.r_[-1.]
+    else:
+        # to redo F's plots about (2,2,-3,1.85A)
+        alpha = np.linspace(-theta + 0.2294, theta - 0.2294, 5)
+        # max value of both ArXVII half crystals: 3 arcmin
+        # alpha = np.linspace(-0.05, 0.05, 5)*(np.pi/180)
+        bb = np.sin(alpha + theta)/np.sin(alpha - theta)
 
     # Perfect (darwin) model
     # ----------------------
 
-    P_per = Zo*F_re*re*lamb**2*(1. + abs(np.cos(2.*theta)))/(
+    P_per = Zo*F_re*re*(lamb**2)*(
+        1. + abs(np.cos(2.*theta))
+    )/(
         6.*np.pi*V*np.sin(2.*theta)
     )
 
     # Ideally thick mosaic model
     # --------------------------
 
-    P_mos = F_re**2*re**2*lamb**3*(1. + (np.cos(2.*theta))**2)/(
-        4.*mu*V**2*np.sin(2.*theta)
+    P_mos = (F_re**2)*(re**2)*(lamb**3)*(
+        1. + (np.cos(2.*theta))**2
+    )/(
+        4.*mu*(V**2)*np.sin(2.*theta)
     )
 
     # Dynamical model
@@ -407,44 +442,95 @@ def CrystBragg_comp_integrated_reflect(
     polar = np.r_[1., abs(np.cos(2.*theta))]
 
     # variables of simplification y, dy, g, L
-    g = psi0_im/(polar*psi_re)
-    y = np.linspace(-10., 10., 501)    # ay
-    ymax = kk/g
-    dy = np.zeros(501) + 0.1    # day
-    al = np.full((2, 501), 0.)
+    g = np.full((polar.size, bb.size), np.nan)
+    for i in range(polar.size):
+        for j in range(bb.size):
+            g[i, j] = (
+                ((1. - bb[j])/2.)*psi0_im
+            )/(
+                np.sqrt(abs(bb[j]))*polar[i]*psi_re
+            )
+    y = np.linspace(-4., 4., 81)
+    dy = np.zeros(81) + 0.1
+    y0 = -psi0_dre/np.sin(2.*theta)
 
-    power_ratio = np.full((al.shape), np.nan)    # phpo
-    th = np.full((al.shape), np.nan)    # phpo
-    rr = np.full((polar.shape), np.nan)
-    for i in range(al[:, 0].size):
-        al[i, ...] = (y**2 + g[i]**2 + np.sqrt(
-            (y**2 - g[i]**2 + kk**2 - 1.)**2 + 4.*(g[i]*y - rek)**2
-            ))/np.sqrt((kk**2 - 1.)**2 + 4.*rek**2)
-        # reflecting power or power ratio R_dyn
-        power_ratio[i, ...] = (Fmod/Fbmod)*(
-            al[i, :] - np.sqrt((al[i, :]**2 - 1.))
-        )
-        power_ratiob = power_ratio[i, ...]
-        # intensity scale on the glancing angle (y=kk/g)
-        th[i, ...] = (y*polar[i]*psi_re - psi0_dre)/np.sin(2.*theta)
-        # integration of the power ratio over dy
-        rhy = np.sum(dy*power_ratiob)
-        # diffraction radiation
-        # r(i=0): normal component & r(i=1): parallel component
-        rr[i, ...] = (polar[i]*psi_re*rhy)/np.sin(2.*theta)
+    al = np.full((polar.size, bb.size, y.size), 0.)
+    power_ratio = np.full((al.shape), np.nan)
+    th = np.full((al.shape), np.nan)
+
+    power_ratiob = np.full((bb.size, y.size), np.nan)
+    rhy = np.full((bb.size), np.nan)
+    rr = np.full((polar.size, bb.size), np.nan)
+    P_dyn = np.full((bb.size), np.nan)
+
+    for i in range(polar.size):
+        for j in range(bb.size):
+            al[i, j, ...] = (y**2 + g[i, j]**2 + np.sqrt(
+                (y**2 - g[i, j]**2 + kk**2 - 1.)**2 + 4.*(g[i, j]*y - rek)**2
+                ))/np.sqrt((kk**2 - 1.)**2 + 4.*rek**2)
+            # reflecting power or power ratio R_dyn
+            power_ratio[i, j, ...] = (Fmod/Fbmod)*(
+                al[i, j, :] - np.sqrt((al[i, j, :]**2 - 1.))
+            )
+            power_ratiob[j, :] = power_ratio[i, j, ...]
+            # conversion formula from y-scale to glancing angle scale
+            th[i, j, ...] = (
+                -y*polar[i]*psi_re*np.sqrt(abs(bb[j])) + psi0_dre*(
+                    (1. - bb[j])/2.
+                )
+            )/(bb[j]*np.sin(2.*theta))
+            # integration of the power ratio over dy
+            rhy[j] = np.sum(dy*power_ratiob[j, :])
+            # diffraction radiation
+            # r(i=0): normal component & r(i=1): parallel component
+            rr[i, ...] = (polar[i]*psi_re*rhy)/(
+                np.sqrt(abs(bb[j]))*np.sin(2.*theta)
+            )
     # Integrated reflectivity
-    P_dyn = np.sum(rr)/2.
-    if P_dyn < 1e-7:
-        msg = (
-            "Please check the equations for integrated reflectivity:\n"
-            "the value of P_dyn ({}) is less than 1e-7.\n".format(P_dyn)
-        )
-        raise Exception(msg)
+    P_dyn = np.full((bb.size), np.nan)
+    #fmax = P_dyn.copy()
+    det = P_dyn.copy()
 
-    fmax = np.max(power_ratio[0] + power_ratio[1])
-    det = (2.*P_dyn)/fmax
+    def lin_interp(x, y, i, half):
+        return x[i] + (x[i+1] - x[i])*((half - y[i])/(y[i+1] - y[i]))
 
-    return (P_per, P_mos, P_dyn, power_ratio, th, rr, det, ymax,)
+    def half_max_x(x, y):
+        half = np.max(y)/2.
+        signs = np.sign(np.add(y, -half))
+        zero_cross = (signs[0:-2] != signs[1:-1])
+        zero_cross_ind = np.where(zero_cross)[0]
+        return [
+            lin_interp(x, y, zero_cross_ind[0], half),
+            lin_interp(x, y, zero_cross_ind[1], half),
+        ]
+
+    for j in range(bb.size):
+        P_dyn[j] = np.sum(rr[:, j])/2.
+        if P_dyn[j] < 1e-7:
+            msg = (
+                "Please check the equations for integrated reflectivity:\n"
+                "the value of P_dyn ({}) is less than 1e-7.\n".format(P_dyn[j])
+            )
+            raise Exception(msg)
+        hmx = half_max_x(th[0, j, :], power_ratio[0, j, :])
+        det[j] = hmx[1] - hmx[0]
+        #fmax[j] = np.max(power_ratio[0, j, :] + power_ratio[1, j, :])
+        #det[j] = (2.*P_dyn[j])/fmax[j]
+
+    # Normalization from alpha=0 case
+    if use_non_parallelism:
+        nn = (det.size/2.)
+        if (nn % 2) == 0:
+            nn = int(nn - 1)
+        else:
+            nn = int(nn - 0.5)
+        det = det/det[nn]
+        P_dyn = P_dyn/P_dyn[nn]
+
+    return (
+        alpha, bb, polar, g, y, y0, power_ratio, th, rr,
+        P_per, P_mos, P_dyn, det,
+    )
 
 
 def CrystalBragg_plot_atomic_scattering_factor(
@@ -477,7 +563,9 @@ def CrystalBragg_plot_atomic_scattering_factor(
 
 def CrystalBragg_plot_power_ratio(
     ih=None, ik=None, il=None, lamb=None, theta=None,
-    th=None, power_ratio=None,
+    th=None, power_ratio=None, y=None, y0=None,
+    bb=None, polar=None, alpha=None,
+    use_non_parallelism=None,
 ):
 
     # Plot
@@ -492,7 +580,67 @@ def CrystalBragg_plot_power_ratio(
     )
     ax.set_xlabel(r'$\theta$-$\theta_{B}$ (rad)')
     ax.set_ylabel('P$_H$/P$_0$')
-    ax.plot(th[0, :], power_ratio[0, :], label='normal component')
-    ax.plot(th[1, :], power_ratio[1, :], label='parallel component')
+    let = ['I', 'II', 'III', 'IV', 'V']
+    alpha_deg = alpha*(180/np.pi)
+    for j in range(bb.size):
+        ax.plot(
+            th[0, j, :],
+            power_ratio[0, j, :],
+            'k-',
+            #label='normal component'i,
+        )
+        ind = np.where(power_ratio[0, j, :] == np.amax(power_ratio[0, j, :]))
+        ax.text(
+            th[0, j, ind],
+            np.max(power_ratio[0, j, :] + 0.01),
+            '({})'.format(let[j]),
+        )
+        ax.plot(
+            th[1, j, :],
+            power_ratio[1, j, :],
+            'k:',
+            #label='parallel component',
+        )
+    #ax.axvline(y0, linetsyle=":", label='pattern center')
+    ax.legend()
+
+
+def CrystalBragg_plot_reflect_glancing(
+    ih=None, ik=None, il=None, lamb=None, theta=None,
+    alpha=None, bb=None, rr=None, P_dyn=None, th=None, det=None,
+):
+
+    # Plot
+    # ----
+
+    fig2 = plt.figure(figsize=(8, 6))
+    gs = gridspec.GridSpec(1, 1)
+    ax = fig2.add_subplot(gs[0, 0])
+    ax.set_title(
+        'Qz, ' + f'({ih},{ik},{il})' + fr', $\lambda$={lamb} A' +
+        fr', Bragg angle={np.round(theta, decimals=3)} rad'
+    )
+    ax.set_xlabel(r'$\alpha$ (deg)')
+    ax.set_xlim(-60., 60.)
+
+    alpha_deg = alpha*(180/np.pi)
+    f = scipy.interpolate.interp1d(alpha_deg, abs(bb), kind='cubic')
+    alpha_deg_bis = np.linspace(-alpha_deg, alpha_deg, 20)
+    bb_bis = f(alpha_deg_bis)
+    ax.plot(
+        alpha_deg, det,
+        'k--',
+        label=r'$\Delta\theta$ [x1e-5] (normalized)',
+    )
+    ax.plot(
+        alpha_deg, rr[0, :]*(1e5),
+        'k-',
+        label='P$_{dyn}$ (normal comp.) (normalized)',
+    )
+    ax.plot(
+        alpha_deg_bis[:, 0], bb_bis[:, 0],
+        'k-.',
+        label='b',
+    )
     ax.legend()
 


### PR DESCRIPTION
Motivations:
---------------
* Integer an asymmetry property called non-parallelism between crystal's optical surface and inter-atomic planes into the rocking curve computations.
* Study the effect of the well-known non-parallelism specific of Bragg crystals used in WEST on their reflecting curves. 

Results:
----------
* This option is now available through the entry argument `use_non_parallelism = True`.
* This asymmetry is designed to vary between plus and minus the Bragg angle corresponding to the chosen wavelength, within 0.01 radians.
* The argument `na` let the choice of the number of steps between the asymmetry limits. It fixed to 51 steps by default.
* The `na` values of the integrated reflectivities, ratio between parallel and perpendicular components, widths of curves and non-parallelism angles are then printed.

Issues:
--------
* Fixes, in devel, issue #629 

Examples:
------------
![image](https://user-images.githubusercontent.com/81628304/155740614-70c87475-7233-4b52-91e3-69ce90a9ba80.png)
![image](https://user-images.githubusercontent.com/81628304/155739954-4ec90dd1-ef68-4b9b-a81c-f7ffcfc8ce68.png)
![image](https://user-images.githubusercontent.com/81628304/155740057-bdad79c1-e3cb-4883-b51f-cbe4cb09ae4d.png)
![image](https://user-images.githubusercontent.com/81628304/155740442-672085b1-acd7-43c4-9cbb-0c802f41cb3a.png)
