### PR TITLE
#633: vr1 and vr2 were missing for 1d linear interpolation for triangular meshes

### DIFF
--- a/tofu/data/_core.py
+++ b/tofu/data/_core.py
@@ -3999,11 +3999,26 @@ class Plasma2D(utils.ToFuObject):
         # Note : Maybe consider using scipy.LinearNDInterpolator ?
         if idquant is not None:
             vquant = self._ddata[idquant]['data']
-            c0 = (self._ddata[idmesh]['data']['type'] == 'quadtri'
-                  and self._ddata[idmesh]['data']['ntri'] > 1)
+            if idref1d is not None:
+                vr1 = self._ddata[idref1d]['data']
+                vr2 = self._ddata[idref2d]['data']
+
+            c0 = (
+                self._ddata[idmesh]['data']['type'] == 'quadtri'
+                and self._ddata[idmesh]['data']['ntri'] > 1
+            )
             if c0:
-                vquant = np.repeat(vquant,
-                                   self._ddata[idmesh]['data']['ntri'], axis=0)
+                vquant = np.repeat(
+                    vquant,
+                    self._ddata[idmesh]['data']['ntri'],
+                    axis=0,
+                )
+                if idref1d is not None:
+                    vr2 = np.repeat(
+                        vr2,
+                        self._ddata[idmesh]['data']['ntri'],
+                        axis=0,
+                    )
         else:
             vq2dR   = self._ddata[idq2dR]['data']
             vq2dPhi = self._ddata[idq2dPhi]['data']
@@ -4031,6 +4046,8 @@ class Plasma2D(utils.ToFuObject):
             func = _comp.get_finterp_isotropic(
                 idquant, idref1d, idref2d,
                 vquant=vquant,
+                vr1=vr1,
+                vr2=vr2,
                 interp_t=interp_t,
                 interp_space=interp_space,
                 fill_value=fill_value,

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.0-235-ga951b6d4'
+__version__ = '1.5.0-263-g4cb7a9fe'


### PR DESCRIPTION
Main changes:
-------------------
* Added vr1 and vr2 were missing, added

Issues:
----------
* Fixes, in devel, issue #633 

Example:
------------

```
In [1]: import tofu as tf

In [2]: multi = tf.imas2tofu.MultiIDSLoader(shot=54178, ids=['equilibrium', 'core_profiles'])
Getting ids     [occ]  database  user         version  shot   run  refshot  refrun
--------------  -----  --------  -----------  -------  -----  ---  -------  ------
core_profiles   [0]    west      imas_public  3        54178  0    -1       -1    
equilibrium     [0]    "         "            "        "      "    "        "     
pulse_schedule  [0]    "         "            "        "      "    "        "     
wall            [0]    "         "            "        "      "    "        "     

In [3]: plasma = multi.to_Plasma2D()
/Home/DV226270/ToFu_All/tofu_git/tofu/tofu/imas2tofu/_comp.py:756: UserWarning: The following data could not be retrieved:
	- core_profiles:
		1dTi_av data:  empty data in core_profiles.1dTi_av
		1dnW data   :  'profiles_1d_ion__structArrayElement' object has no attribute 'identifier'
		ip data     :  empty data in core_profiles.ip
		vloop data  :  empty data in core_profiles.vloop
	- equilibrium:
		2dmeshR data:  list index out of range
		2dmeshZ data:  list index out of range
		x1 data     :  'x1R'
		x1R data    :  list index out of range
		x1Z data    :  list index out of range
  warnings.warn(msg)
/Home/DV226270/ToFu_All/tofu_git/tofu/tofu/imas2tofu/_comp_toobjects.py:283: UserWarning: 
ids wall has more limiter than mobile units
	- len(wall.description_2[0].limiter.unit) = 1
	- len(wall.description_2[0].mobile.unit) = 1
  => Choosing limiter by default
  warnings.warn(msg)
/Home/DV226270/ToFu_All/tofu_git/tofu/tofu/imas2tofu/_comp.py:756: UserWarning: The following data could not be retrieved:
	- core_profiles:
		ip data   :  empty data in core_profiles.ip
		vloop data:  empty data in core_profiles.vloop
  warnings.warn(msg)

In [4]: D = np.array([[0,0,0], [-4,-4,-4], [0,0,0]])

In [5]: u = np.array([[0,0,0], [0.9,1,0.9], [-0.1,0,0.1]]); u = u/np.linalg.norm(u)

In [6]: conf = tf.load_config('WEST-V0')

In [7]: cam = tf.geom.CamLOS1D(dgeom=(D, u), config=conf, Diag='UV', Exp='WEST', Name='V0')

In [8]: sig, units = cam.calc_signal_from_Plasma2D(plasma, quant='core_profiles.1dne', ref1d='core_profiles.1drhotn', ref2d='equilibrium.2drhotn')
```

![image](https://user-images.githubusercontent.com/5929562/161233043-6e5410f9-50bf-4584-90d0-80c562c1c3ec.png)
