### PR TITLE
Issue641 imas hdf5

### DIFF
--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -139,10 +139,10 @@ class MultiIDSLoader(object):
     ###################################
 
     _def = {
-        'isget':False,
-        'ids':None,
-        'occ':0,
-        'needidd':True,
+        'isget': False,
+        'ids': None,
+        'occ': 0,
+        'needidd': True,
     }
     _defidd = dict(_defimas2tofu._IMAS_DIDD)
 
@@ -719,7 +719,7 @@ class MultiIDSLoader(object):
         lk = self._didd.keys()
         lc = [
             idd is None, type(idd) is str and idd in lk,
-            hasattr(idd,'__iter__') and all([ii in lk for ii in idd])
+            hasattr(idd, '__iter__') and all([ii in lk for ii in idd])
         ]
         assert any(lc)
 
@@ -758,23 +758,7 @@ class MultiIDSLoader(object):
         lidd = self._checkformat_get_idd(idd)
         for k in lidd:
             if self._didd[k]['isopen'] == False:
-                # if not all([
-                    # ss in self._didd[k]['params'].keys()
-                    # for ss in ['user', 'database', 'version']
-                # ]):
-                    # msg = (
-                        # "idd cannot be opened with user, database, version !\n"
-                        # f"\t- name : {k}"
-                    # )
-                    # raise Exception(msg)
-
-                # args = (
-                    # self._didd[k]['params']['user'],
-                    # self._didd[k]['params']['database'],
-                    # self._didd[k]['params']['version'],
-                # )
                 self._didd[k]['idd'].open()
-                # self._didd[k]['idd'].open_env( *args )
                 self._didd[k]['isopen'] = True
 
     def _get(
@@ -826,7 +810,7 @@ class MultiIDSLoader(object):
 
                 docc[ii][jj]['oc'] = oc
                 docc[ii][jj]['indoc'] = np.array([
-                    (occref==oc[ll]).nonzero()[0][0]
+                    (occref == oc[ll]).nonzero()[0][0]
                     for ll in range(len(oc))
                 ])
 
@@ -1217,7 +1201,7 @@ class MultiIDSLoader(object):
 
         if occ is None:
             occ = 0
-        lc = [type(occ) in [int, np.int], hasattr(occ,'__iter__')]
+        lc = [type(occ) in [int, np.int], hasattr(occ, '__iter__')]
         assert any(lc)
 
         if lc[0]:

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -53,14 +53,16 @@ except Exception as err:
 # imas
 try:
     import imas
+    from imas import imasdef
 except Exception as err:
     raise Exception('imas not available')
 
-__all__ = ['check_units_IMASvsDSHORT',
-           'MultiIDSLoader',
-           'load_Config', 'load_Plasma2D',
-           'load_Cam', 'load_Data',
-           '_save_to_imas']
+__all__ = [
+    'check_units_IMASvsDSHORT',
+    'MultiIDSLoader',
+    'load_Config', 'load_Plasma2D', 'load_Cam', 'load_Data',
+    '_save_to_imas',
+]
 
 
 # Root tofu path (for saving repo in IDS)
@@ -141,8 +143,9 @@ class MultiIDSLoader(object):
     _defidd = dict(_defimas2tofu._IMAS_DIDD)
 
     _lidsnames = [k for k in dir(imas) if k[0] != '_']
-    _lidsk = ['database', 'user', 'version',
-              'shot', 'run', 'refshot', 'refrun']
+    _lidsk = [
+        'database', 'user', 'version', 'shot', 'run', 'refshot', 'refrun',
+    ]
 
     # Known short version of signal str
     _dshort = _defimas2tofu._dshort
@@ -151,8 +154,10 @@ class MultiIDSLoader(object):
     _lidsdiag = _defimas2tofu._lidsdiag
     _lidslos = _defimas2tofu._lidslos
     _lidssynth = _defimas2tofu._lidssynth
-    _lidsplasma = ['equilibrium', 'core_profiles', 'core_sources',
-                   'edge_profiles', 'edge_sources']
+    _lidsplasma = [
+        'equilibrium', 'core_profiles', 'core_sources',
+        'edge_profiles', 'edge_sources',
+    ]
 
     # Computed signals
     _dcomp = _defimas2tofu._dcomp
@@ -878,8 +883,15 @@ class MultiIDSLoader(object):
             for kk,vv in defidd.items():
                 if params[kk] is None:
                     params[kk] = vv
-            idd = imas.ids(params['shot'], params['run'],
-                           params['refshot'], params['refrun'])
+
+            # update TBF
+            idd = imas.DBEntry(imasdef.HDF5_BACKEND, machine, shot, run, user)
+            idd.open()
+
+            idd = imas.ids(
+                params['shot'], params['run'],
+                params['refshot'], params['refrun'],
+            )
             isopen = False
 
         elif lc[1]:

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -861,7 +861,7 @@ class MultiIDSLoader(object):
                             or self._dids[ids]['isget'][indoc[ll]] == False
                         )
                         if c0:
-                            self._dids[ids]['ids'] = idd.get(
+                            self._dids[ids]['ids'][ll] = idd.get(
                                 ids,
                                 occurrence=oc[ll],
                             )

--- a/tofu/imas2tofu/_def.py
+++ b/tofu/imas2tofu/_def.py
@@ -48,6 +48,7 @@ _IMAS_DIDD = {
     'user': _IMAS_USER_PUBLIC,
     'database': 'west',
     'version': '3',
+    'backend': 'hdf5',
 }
 
 _T0 = False

--- a/tofu/utils.py
+++ b/tofu/utils.py
@@ -774,7 +774,6 @@ def _get_exception(q, ids, qtype='quantity'):
     # -------------------
     # import imas2tofu
     try:
-        import imas
         from tofu.imas2tofu import MultiIDSLoader
     except Exception as err:
         msg = str(err)

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.1-32-g4a4e1f05'
+__version__ = '1.5.1-33-g837a1d31'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.1-14-g78324865'
+__version__ = '1.5.1-32-g4a4e1f05'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.1-35-gf63f65ab'
+__version__ = '1.5.1-36-g3705fc34'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.1-33-g837a1d31'
+__version__ = '1.5.1-34-g272c730a'

--- a/tofu/version.py
+++ b/tofu/version.py
@@ -1,2 +1,2 @@
 # Do not edit, pipeline versioning governed by git tags!
-__version__ = '1.5.1-34-g272c730a'
+__version__ = '1.5.1-35-gf63f65ab'


### PR DESCRIPTION
Main changes:
----------------
* imas2tofu updated to handle HDF5 backend

Example:
----------
* The two following command are equivalent since HDF5 is now the default backend

```
In [1]: import tofu as tf

In [2]: multi = tf.imas2tofu.MultiIDSLoader(ids=['equilibrium', 'core_profiles'], shot=56757, backend='hdf5')
Getting ids     [occ]  database  user         version  shot   run  refshot  refrun
--------------  -----  --------  -----------  -------  -----  ---  -------  ------
core_profiles   [0]    west      imas_public  3        56757  0    -1       -1    
equilibrium     [0]    "         "            "        "      "    "        "     
pulse_schedule  [0]    "         "            "        "      "    "        "     
wall            [0]    "         "            "        "      "    "        "    

In [3]: multi = tf.imas2tofu.MultiIDSLoader(ids=['equilibrium', 'core_profiles'], shot=56757)
Getting ids     [occ]  database  user         version  shot   run  refshot  refrun
--------------  -----  --------  -----------  -------  -----  ---  -------  ------
core_profiles   [0]    west      imas_public  3        56757  0    -1       -1    
equilibrium     [0]    "         "            "        "      "    "        "     
pulse_schedule  [0]    "         "            "        "      "    "        "     
wall            [0]    "         "            "        "      "    "        "
```