### PR TITLE
Optimisation of the solid angle computation with aperture obstruction

### DIFF
--- a/tofu/geom/_comp_solidangles.py
+++ b/tofu/geom/_comp_solidangles.py
@@ -13,7 +13,6 @@ import datastock as ds
 # local
 from . import _GG
 
-
 _APPROX = True
 _ANISO = False
 _BLOCK = True
@@ -1249,7 +1248,6 @@ def calc_solidangle_apertures(
 
     # ----------------
     # pre-format input
-
     (
         ndim0, shape0, mask,
         pts_x, pts_y, pts_z,
@@ -1316,7 +1314,7 @@ def calc_solidangle_apertures(
         (
             solid_angle,
             unit_vector_x, unit_vector_y, unit_vector_z,
-        ) = _GG.compute_solid_angle_apertures_unitvectors(
+        ) = _GG.compute_solid_angle_apertures_light(
             # pts as 1d arrays
             pts_x=pts_x,
             pts_y=pts_y,
@@ -1344,6 +1342,9 @@ def calc_solidangle_apertures(
             ap_norm_x=ap_nin_x,
             ap_norm_y=ap_nin_y,
             ap_norm_z=ap_nin_z,
+            # return flags
+            return_sa_array=True,
+            return_unit_vect=True,
         )
 
         if visibility:
@@ -1406,67 +1407,37 @@ def calc_solidangle_apertures(
         # call fastest / simplest version
         # (no computation / storing of unit vector)
 
-        if summed is True:
-            solid_angle = _GG.compute_solid_angle_apertures_light_summed(
-                # pts as 1d arrays
-                pts_x=pts_x,
-                pts_y=pts_y,
-                pts_z=pts_z,
-                # detector polygons as 1d arrays
-                det_outline_x0=det_outline_x0,
-                det_outline_x1=det_outline_x1,
-                det_cents_x=det_cents_x,
-                det_cents_y=det_cents_y,
-                det_cents_z=det_cents_z,
-                det_norm_x=det_nin_x,
-                det_norm_y=det_nin_y,
-                det_norm_z=det_nin_z,
-                det_e0_x=det_e0_x,
-                det_e0_y=det_e0_y,
-                det_e0_z=det_e0_z,
-                det_e1_x=det_e1_x,
-                det_e1_y=det_e1_y,
-                det_e1_z=det_e1_z,
-                # apertures
-                ap_ind=ap_ind,
-                ap_x=ap_x,
-                ap_y=ap_y,
-                ap_z=ap_z,
-                ap_norm_x=ap_nin_x,
-                ap_norm_y=ap_nin_y,
-                ap_norm_z=ap_nin_z,
-            )
-
-        else:
-            solid_angle = _GG.compute_solid_angle_apertures_light(
-                # pts as 1d arrays
-                pts_x=pts_x,
-                pts_y=pts_y,
-                pts_z=pts_z,
-                # detector polygons as 1d arrays
-                det_outline_x0=det_outline_x0,
-                det_outline_x1=det_outline_x1,
-                det_cents_x=det_cents_x,
-                det_cents_y=det_cents_y,
-                det_cents_z=det_cents_z,
-                det_norm_x=det_nin_x,
-                det_norm_y=det_nin_y,
-                det_norm_z=det_nin_z,
-                det_e0_x=det_e0_x,
-                det_e0_y=det_e0_y,
-                det_e0_z=det_e0_z,
-                det_e1_x=det_e1_x,
-                det_e1_y=det_e1_y,
-                det_e1_z=det_e1_z,
-                # apertures
-                ap_ind=ap_ind,
-                ap_x=ap_x,
-                ap_y=ap_y,
-                ap_z=ap_z,
-                ap_norm_x=ap_nin_x,
-                ap_norm_y=ap_nin_y,
-                ap_norm_z=ap_nin_z,
-            )
+        solid_angle = _GG.compute_solid_angle_apertures_light(
+            # pts as 1d arrays
+            pts_x=pts_x,
+            pts_y=pts_y,
+            pts_z=pts_z,
+            # detector polygons as 1d arrays
+            det_outline_x0=det_outline_x0,
+            det_outline_x1=det_outline_x1,
+            det_cents_x=det_cents_x,
+            det_cents_y=det_cents_y,
+            det_cents_z=det_cents_z,
+            det_norm_x=det_nin_x,
+            det_norm_y=det_nin_y,
+            det_norm_z=det_nin_z,
+            det_e0_x=det_e0_x,
+            det_e0_y=det_e0_y,
+            det_e0_z=det_e0_z,
+            det_e1_x=det_e1_x,
+            det_e1_y=det_e1_y,
+            det_e1_z=det_e1_z,
+            # apertures
+            ap_ind=ap_ind,
+            ap_x=ap_x,
+            ap_y=ap_y,
+            ap_z=ap_z,
+            ap_norm_x=ap_nin_x,
+            ap_norm_y=ap_nin_y,
+            ap_norm_z=ap_nin_z,
+            # return flags
+            return_sa_array=(not summed),
+        )
 
     # -------------
     # format output

--- a/tofu/geom/_etendue.py
+++ b/tofu/geom/_etendue.py
@@ -7,7 +7,6 @@ import matplotlib.lines as mlines
 
 import datastock as ds
 
-
 from . import _comp_solidangles
 
 
@@ -566,6 +565,7 @@ def _compute_etendue_numerical(
     # Get plane perpendicular to los
 
     etendue = np.full((res.size, cents_x.size), np.nan)
+
     for ii in range(nd):
 
         if verb is True:
@@ -705,6 +705,7 @@ def _compute_etendue_numerical(
             # compute solid angle for each pixel
 
             if check is True:
+
                 solid_angle = _comp_solidangles.calc_solidangle_apertures(
                     # observation points
                     pts_x=pts_x,

--- a/tofu/geom/_vignetting_tools.pyx
+++ b/tofu/geom/_vignetting_tools.pyx
@@ -138,8 +138,8 @@ cdef inline void are_points_reflex_2d(
 
     # do first point:
     are_reflex[0] = is_reflex_2d(
-        &diff[0*nvert + 9],         # u0
-        &diff[1*nvert + 9],         # u1
+        &diff[0*nvert + nvert - 1],         # u0
+        &diff[1*nvert + nvert - 1],         # u1
         &diff[0*nvert + 0],     # v0
         &diff[1*nvert + 0],     # v1
     )
@@ -318,13 +318,13 @@ cdef inline int get_one_ear(
                 return i # if not, we found an ear
 
     # if we havent returned, either, there was an error somerwhere
-    with gil:
-        msg = (
-            "Got here but shouldn't have\n"
-            f"\t- i: {i} / {nv-1}\n"
-            f"\t- j: {j} / {nv}\n"
-        )
-        raise Exception(msg)
+#    with gil:
+#        msg = (
+#            "Got here but shouldn't have\n"
+#            f"\t- i: {i} / {nv-1}\n"
+#            f"\t- j: {j} / {nv}\n"
+#        )
+#        raise Exception(msg)
 
     return -1
 


### PR DESCRIPTION
This MR is a follow up to #663 providing major performance improvement to all to the 3 functions `compute_solid_angle_apertures_light` (which have also all been merged into one) as well as OMP parallelisation. In my tests, the speedup was about 60x in sequential (`OMP_NUM_THREADS=1`). The computation seems to be mostly memory-bound so the parallelisation efficiency is not very large (x3 with 8 threads), but it is still better than nothing and I'm not sure much more can be gained.

