### PR TITLE
Issue731 installation missing numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
 requires = [
         "setuptools>=40.8.0",
-	    "wheel",
-	    ]
+	"wheel",
+	"Cython>=0.26",
+	"numpy",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ Polygon3
 
 ######## Requirements with Version Specifier ########
 bsplines2d>=0.0.2
-bsplines2d
+Cython>=0.26

--- a/setup.py
+++ b/setup.py
@@ -323,7 +323,7 @@ setup(
         "requests",
         "svg.path",
         "Polygon3",
-        "cython",
+        "cython>=0.26",
         "bsplines2d>=0.0.2",
     ],
     python_requires=">=3.6",


### PR DESCRIPTION
Main changes:
--------------------
* Re-instanciate dependency `Cython>=0.26` in `setup.py`, `requirements.txt` and `pyproject.toml`
* Re-instanciate `numpy` in `pyproject.toml` (necessary)