### PR TITLE
Debug jumps in etendue for spectrometer concave crystals

### DIFF
--- a/tofu/data/_class5_projections.py
+++ b/tofu/data/_class5_projections.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 
+import matplotlib.pyplot as plt
 import Polygon as plg
 
 
@@ -34,6 +35,8 @@ def _get_reflection(
     ptsvect_poly=None,
     # timing
     dt=None,
+    # debug
+    ii=None,
 ):
 
     # -------------------
@@ -83,11 +86,15 @@ def _get_reflection(
         # print('pts < 3')
         return None, None
 
-    # plt.figure()
-    # plt.plot(
-        # poly_x0, poly_x1, '.-k',
-        # p0, p1, '.-r',
-    # )
+    # --------- DEBUG ------------
+    # if ii in [214, 217]:
+    #     plt.figure()
+    #     plt.plot(
+    #         np.r_[poly_x0, poly_x0[0]], np.r_[poly_x1, poly_x1[0]], '.-k',
+    #         p0, p1, '.-r',
+    #     )
+    #     plt.gca().set_title(f"ii = {ii}, projection 0")
+    # ---------------------------
 
     p0, p1 = np.array(p_a.contour(0)).T
 

--- a/tofu/data/_class5_reflections_pts2pt.py
+++ b/tofu/data/_class5_reflections_pts2pt.py
@@ -155,7 +155,7 @@ def _get_pts2pt(
             return_x01=None,
             # number of k for interpolation
             nk=None,
-            debug=True,
+            debug=None,
             # timing
             dt=None,
         ):
@@ -247,21 +247,35 @@ def _get_pts2pt(
                 iok = np.isfinite(eq)
                 kk = kk[iok]
                 eq = eq[iok]
-
+                
                 # find indices of sign changes
                 i0 = (eq[:-1] * eq[1:] < 0).nonzero()[0]
                 if len(i0) == 1:
-                    roots = np.r_[
-                        kk[i0]
-                        - eq[i0]*(kk[i0+1] - kk[i0])
-                        / (eq[i0+1] - eq[i0])
-                    ]
-
-                    # roots = scpinterp.InterpolatedUnivariateSpline(
-                    # kk,
-                    # eq,
-                    # k=3,
-                    # ).roots()
+                    # indices used for linear fit
+                    ind = np.arange(max(0, i0-10), min(i0+10, kk.size))
+                    
+                    # linear least square fit
+                    xx_m = np.mean(kk[ind])
+                    yy_m = np.mean(eq[ind])
+                    xx2_m = np.mean(kk[ind]**2)
+                    xy_m = np.mean(kk[ind] * eq[ind])
+                    
+                    # coefs
+                    aa = (xy_m - xx_m*yy_m) / (xx2_m - xx_m**2)
+                    bb = yy_m - aa * xx_m
+                    
+                    # fit and threshold
+                    line = aa*kk[ind] + bb
+                    thr = abs(line[0] - line[-1]) * 0.05
+                    std = np.std(eq[ind] - line)
+                    if std > thr:
+                        continue
+                    roots = np.r_[-bb / aa]
+                    # roots = np.r_[
+                    #     kk[i0]
+                    #     - eq[i0]*(kk[i0+1] - kk[i0])
+                    #     / (eq[i0+1] - eq[i0])
+                    # ]
                 else:
                     continue
 
@@ -284,6 +298,39 @@ def _get_pts2pt(
                     -(nix*erot[0] + niy*erot[1] + niz*erot[2]),
                     nix*nin[0] + niy*nin[1] + niz*nin[2],
                 )
+                
+                                
+                # ------ DEBUG --------
+                # if debug:
+                #     Ex = pt_x + roots[0]*(pts_x[ii] - pt_x)
+                #     Ey = pt_y + roots[0]*(pts_y[ii] - pt_y)
+                #     Ez = pt_z + roots[0]*(pts_z[ii] - pt_z)
+                #     print()
+                #     print(f'\nii = {ii}', xxi, thetai)
+                #     print('rcs', rcs)
+                #     print('rca', rca)
+                #     print('nix, niy, niz', nix, niy, niz)
+                #     print('erot', erot)
+                #     print('nin', nin)
+                #     print('eax', eax)
+                #     print('O', O)
+                #     print('E', Ex, Ey, Ez)
+                #     print('OE', Ex - O[0], Ey - O[1], Ez - O[2])
+                #     print('roots', roots[0])
+                #     print('eax', eax)
+                #     plt.figure()
+                #     plt.plot(
+                #         kk, eq, '.-k',
+                #         kk[ind], line, '-r',
+                #         kk[ind], line + thr, '--r',
+                #         kk[ind], line - thr, '--r',
+                #         [kk[i0]], [eq[i0]], 'xr',
+                #     )
+                #     plt.axhline(0, c='k', ls='--')
+                #     plt.axvline(roots[0], c='k', ls='--')
+                #     plt.gca().set_title(f'std = {std} vs {thr}')
+                #     print()
+                # ---------------------
 
                 if strict is True:
                     if np.abs(xxi) > xmax or np.abs(thetai) > thetamax:
@@ -346,11 +393,12 @@ def _get_pts2pt(
             nin=dgeom['nin'],
             e0=dgeom['e0'],
             e1=dgeom['e1'],
+            # solving
+            nk=None,
             # return
             strict=None,
             return_xyz=None,
             return_x01=None,
-            nk=None,
             debug=None,
             # timing
             dt=None,
@@ -441,17 +489,32 @@ def _get_pts2pt(
                 # find indices of sign changes
                 i0 = (eq[:-1] * eq[1:] < 0).nonzero()[0]
                 if len(i0) == 1:
-                    roots = np.r_[
-                        kk[i0]
-                        - eq[i0]*(kk[i0+1] - kk[i0])
-                        / (eq[i0+1] - eq[i0])
-                    ]
+                    # indices used for linear fit
+                    ind = np.arange(max(0, i0-10), min(i0+10, kk.size))
+                    
+                    # linear least square fit
+                    xx_m = np.mean(kk[ind])
+                    yy_m = np.mean(eq[ind])
+                    xx2_m = np.mean(kk[ind]**2)
+                    xy_m = np.mean(kk[ind] * eq[ind])
+                    
+                    # coefs
+                    aa = (xy_m - xx_m*yy_m) / (xx2_m - xx_m**2)
+                    bb = yy_m - aa * xx_m
+                    
+                    # fit and threshold
+                    line = aa*kk[ind] + bb
+                    thr = abs(line[0] - line[-1]) * 0.05
+                    std = np.std(eq[ind] - line)
+                    if std > thr:
+                        continue
+                    roots = np.r_[-bb / aa]
+                    # roots = np.r_[
+                    #     kk[i0]
+                    #     - eq[i0]*(kk[i0+1] - kk[i0])
+                    #     / (eq[i0+1] - eq[i0])
+                    # ]
 
-                    # roots = scpinterp.InterpolatedUnivariateSpline(
-                    # kk,
-                    # eq,
-                    # k=3,
-                    # ).roots()
                 else:
                     continue
 
@@ -474,8 +537,6 @@ def _get_pts2pt(
                 phii = - rcs * np.arcsin(
                     (nix*e0[0] + niy*e0[1] + niz*e0[2]) / np.cos(dthetai)
                 )
-
-                # ----------
 
                 if strict is True:
                     if np.abs(phii) > phimax or np.abs(dthetai) > dthetamax:
@@ -641,6 +702,8 @@ def _get_Dnin_from_k_cyl(
     rcs=None,
     rca=None,
     nin=None,
+    # debug
+    debug=None,
 ):
     Ex = Ax + kk*(Bx - Ax)
     Ey = Ay + kk*(By - Ay)

--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -190,6 +190,8 @@ def equivalent_apertures(
             # options
             add_points=add_points,
             convex=convex,
+            # debug
+            ii=ii,
             # timing
             # dt=dt,
         )
@@ -220,19 +222,19 @@ def equivalent_apertures(
         x1.append(p1)
 
         # --- DEBUG ---------
-        # if ii in [10, 22, 34]:
-            # plt.figure()
-            # plt.plot(
-                # np.r_[p0, p0[0]],
-                # np.r_[p1, p1[0]],
-                # c='k',
-                # ls='-',
-                # lw=1.,
-                # marker='.',
-            # )
-            # plt.gca().set_title(f'local coordinates - {ii}', size=12)
-            # plt.gca().set_xlabel('x0 (local)', size=12)
-            # plt.gca().set_ylabel('x1 (local)', size=12)
+        if ii in [214, 217]:
+            plt.figure()
+            plt.plot(
+                np.r_[p0, p0[0]],
+                np.r_[p1, p1[0]],
+                c='k',
+                ls='-',
+                lw=1.,
+                marker='.',
+            )
+            plt.gca().set_title(f'local coordinates - {ii}', size=12)
+            plt.gca().set_xlabel('x0 (local)', size=12)
+            plt.gca().set_ylabel('x1 (local)', size=12)
         # --------------------
 
     # -------------------------------------------
@@ -318,35 +320,35 @@ def equivalent_apertures(
             ).center()
 
             # --- DEBUG ---------
-            # if ii in [6, 8, 22, 36, 38]:
-                # plt.figure()
-                # plt.plot(
-                    # np.r_[p0, p0[0]],
-                    # np.r_[p1, p1[0]],
-                    # c='k',
-                    # ls='-',
-                    # lw=1.,
-                    # marker='.',
-                # )
-                # plt.plot([cents0[ii]], [cents1[ii]], 'xk')
-                # ppx, ppy, ppz = coord_x01toxyz(
-                    # x0=np.r_[cents0[ii]],
-                    # x1=np.r_[cents1[ii]],
-                # )
-                # ddd = np.linalg.norm(
-                    # np.r_[ppx - cx[ip], ppy - cy[ip], ppz - cz[ip]]
-                # )
-                # plt.gca().text(
-                    # np.mean(p0),
-                    # np.mean(p1),
-                    # f'area\n{area[ii]:.3e} m2\ndist\n{ddd:.6e} m',
-                    # size=12,
-                    # horizontalalignment='center',
-                    # verticalalignment='center',
-                # )
-                # plt.gca().set_title(f'planar coordinates - {ii}', size=12)
-                # plt.gca().set_xlabel('x0 (m)', size=12)
-                # plt.gca().set_ylabel('x1 (m)', size=12)
+            # if ii in [214, 217]:
+            #     plt.figure()
+            #     plt.plot(
+            #         np.r_[p0, p0[0]],
+            #         np.r_[p1, p1[0]],
+            #         c='k',
+            #         ls='-',
+            #         lw=1.,
+            #         marker='.',
+            #     )
+            #     plt.plot([cents0[ii]], [cents1[ii]], 'xk')
+            #     ppx, ppy, ppz = coord_x01toxyz(
+            #         x0=np.r_[cents0[ii]],
+            #         x1=np.r_[cents1[ii]],
+            #     )
+            #     ddd = np.linalg.norm(
+            #         np.r_[ppx - cx[ip], ppy - cy[ip], ppz - cz[ip]]
+            #     )
+            #     plt.gca().text(
+            #         np.mean(p0),
+            #         np.mean(p1),
+            #         f'area\n{area[ii]:.3e} m2\ndist\n{ddd:.6e} m',
+            #         size=12,
+            #         horizontalalignment='center',
+            #         verticalalignment='center',
+            #     )
+            #     plt.gca().set_title(f'planar coordinates - {ii}', size=12)
+            #     plt.gca().set_xlabel('x0 (m)', size=12)
+            #     plt.gca().set_ylabel('x1 (m)', size=12)
             # --------------------
 
         centsx, centsy, centsz = coord_x01toxyz(
@@ -676,6 +678,8 @@ def _get_equivalent_aperture_spectro(
     convex=None,
     # timing
     dt=None,
+    # debug
+    ii=None,
 ):
 
     # loop on optics before crystal

--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -171,7 +171,7 @@ def equivalent_apertures(
         if verb is True:
             msg = f"\t- camera '{key_cam}': pixel {ii + 1} / {pixel.size}"
             end = '\n' if ii == len(pixel) - 1 else '\r'
-            print(msg, end=end , flush=True)
+            print(msg, end=end, flush=True)
 
         p0, p1 = func(
             p_a=p_a,
@@ -218,6 +218,22 @@ def equivalent_apertures(
         # append
         x0.append(p0)
         x1.append(p1)
+
+        # --- DEBUG ---------
+        # if ii in [10, 22, 34]:
+            # plt.figure()
+            # plt.plot(
+                # np.r_[p0, p0[0]],
+                # np.r_[p1, p1[0]],
+                # c='k',
+                # ls='-',
+                # lw=1.,
+                # marker='.',
+            # )
+            # plt.gca().set_title(f'local coordinates - {ii}', size=12)
+            # plt.gca().set_xlabel('x0 (local)', size=12)
+            # plt.gca().set_ylabel('x1 (local)', size=12)
+        # --------------------
 
     # -------------------------------------------
     # harmonize if necessary the initial polygons
@@ -300,6 +316,38 @@ def equivalent_apertures(
             cents0[ii], cents1[ii] = plg.Polygon(
                 np.array([x0[ii, :], x1[ii, :]]).T
             ).center()
+
+            # --- DEBUG ---------
+            # if ii in [6, 8, 22, 36, 38]:
+                # plt.figure()
+                # plt.plot(
+                    # np.r_[p0, p0[0]],
+                    # np.r_[p1, p1[0]],
+                    # c='k',
+                    # ls='-',
+                    # lw=1.,
+                    # marker='.',
+                # )
+                # plt.plot([cents0[ii]], [cents1[ii]], 'xk')
+                # ppx, ppy, ppz = coord_x01toxyz(
+                    # x0=np.r_[cents0[ii]],
+                    # x1=np.r_[cents1[ii]],
+                # )
+                # ddd = np.linalg.norm(
+                    # np.r_[ppx - cx[ip], ppy - cy[ip], ppz - cz[ip]]
+                # )
+                # plt.gca().text(
+                    # np.mean(p0),
+                    # np.mean(p1),
+                    # f'area\n{area[ii]:.3e} m2\ndist\n{ddd:.6e} m',
+                    # size=12,
+                    # horizontalalignment='center',
+                    # verticalalignment='center',
+                # )
+                # plt.gca().set_title(f'planar coordinates - {ii}', size=12)
+                # plt.gca().set_xlabel('x0 (m)', size=12)
+                # plt.gca().set_ylabel('x1 (m)', size=12)
+            # --------------------
 
         centsx, centsy, centsz = coord_x01toxyz(
             x0=cents0,

--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -237,10 +237,9 @@ def equivalent_apertures(
 
             elif ln[ii] < nmax:
                 ndif = nmax - ln[ii]
-                irand = np.random.random(ndif)
+                irand = np.random.randint(1, 9, ndif)/10.
                 irand = irand + np.random.randint(0, ln[ii]-1, ndif)
                 imax = np.sort(np.r_[np.arange(0, ln[ii]), irand])
-                imax = np.linspace(0, ln[ii]-1, nmax)
                 x0[ii] = scpinterp.interp1d(
                     np.arange(0, ln[ii]),
                     x0[ii],

--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -222,19 +222,19 @@ def equivalent_apertures(
         x1.append(p1)
 
         # --- DEBUG ---------
-        if ii in [214, 217]:
-            plt.figure()
-            plt.plot(
-                np.r_[p0, p0[0]],
-                np.r_[p1, p1[0]],
-                c='k',
-                ls='-',
-                lw=1.,
-                marker='.',
-            )
-            plt.gca().set_title(f'local coordinates - {ii}', size=12)
-            plt.gca().set_xlabel('x0 (local)', size=12)
-            plt.gca().set_ylabel('x1 (local)', size=12)
+        # if ii in [214, 217]:
+        #     plt.figure()
+        #     plt.plot(
+        #         np.r_[p0, p0[0]],
+        #         np.r_[p1, p1[0]],
+        #         c='k',
+        #         ls='-',
+        #         lw=1.,
+        #         marker='.',
+        #     )
+        #     plt.gca().set_title(f'local coordinates - {ii}', size=12)
+        #     plt.gca().set_xlabel('x0 (local)', size=12)
+        #     plt.gca().set_ylabel('x1 (local)', size=12)
         # --------------------
 
     # -------------------------------------------
@@ -732,6 +732,8 @@ def _get_equivalent_aperture_spectro(
             ptsvect_poly=lptsvect_poly[jj],
             # timing
             # dt=dt,
+            # debug
+            ii=ii,
         )
 
         if p0 is None:
@@ -739,15 +741,19 @@ def _get_equivalent_aperture_spectro(
             return p0, p1
 
         if np.all([p_a.isInside(xx, yy) for xx, yy in zip(p0, p1)]):
-            # print('inside: ', p1)
-            # plt.figure()
-            # plt.plot(
-                # np.array(p_a.contour(0))[:, 0],
-                # np.array(p_a.contour(0))[:, 1],
-                # '.-k',
-                # p0, p1, '.-r'
-            # )
+            # --- DEBUG ---------
+            # if ii in [214, 217]:
+            #     plt.figure()
+            #     plt.plot(
+            #         np.array(p_a.contour(0))[:, 0],
+            #         np.array(p_a.contour(0))[:, 1],
+            #         '.-k',
+            #         p0, p1, '.-r'
+            #     )
+            #     plt.gca().set_title(f"ii = {ii}, all in", size=12)
+            # ----------------------
             p_a = plg.Polygon(np.array([p0, p1]).T)
+            
         else:
             # convex hull
             if convex:
@@ -755,16 +761,30 @@ def _get_equivalent_aperture_spectro(
                     # plg.Polygon(np.array([p0, p1]).T)
                 # ).contour(0)).T
                 vert = ConvexHull(np.array([p0, p1]).T).vertices
+                # --- DEBUG ---------
+                # if ii in [214, 217]:
+                #     plt.figure()
+                #     plt.plot(
+                #         p0[vert],
+                #         p1[vert],
+                #         '.-k',
+                #         p0, p1, '.-r'
+                #     )
+                #     plt.gca().set_title(f"ii = {ii}, convexH", size=12)
+                # ----------------------
                 p0, p1 = p0[vert], p1[vert]
 
-            # plt.figure()
-            # plt.plot(
-                # np.array(p_a.contour(0))[:, 0],
-                # np.array(p_a.contour(0))[:, 1],
-                # '.-k',
-                # p0, p1, '.-r'
-            # )
-            # import pdb; pdb.set_trace()     # DB
+            # --- DEBUG ---------
+            # if ii in [214, 217]:
+            #     plt.figure()
+            #     plt.plot(
+            #         np.array(p_a.contour(0))[:, 0],
+            #         np.array(p_a.contour(0))[:, 1],
+            #         '.-k',
+            #         p0, p1, '.-r'
+            #     )
+            #     plt.gca().set_title(f"ii = {ii}, not all", size=12)
+            # ----------------------
 
             # intersection
             p_a = p_a & plg.Polygon(np.array([p0, p1]).T)


### PR DESCRIPTION
Main changes:
-----------------
Two minor bugs identified in the routines used to project an aperture (slit) on a concave crystal.
Concavity comes with numerical instability when the root-finding process comes close to the singular point that is the center of curvature.

Tofu implements a robust root-finding routine + interpolates reflected polygons to take out singular points.

**Bug 1:** the interpolation process was missing some corners of the polygons in some particular cases.

**Bug 2:** the root-finding algo wasn't robust enough for some particular pixels / configurations


Both bugs have been addressed in this PR, see issue #747 for examples

Several plotting / debugging sections have been added to the code to facilitate any later debugging in case another problem arises. They are commented out and left as such for later use.

Issues:
-------
* Fixes, in devel, issue #747 

 