### PR TITLE
Correcting jumps in dlamb

### DIFF
--- a/tofu/data/_class5_reflections_pts2pt.py
+++ b/tofu/data/_class5_reflections_pts2pt.py
@@ -247,28 +247,27 @@ def _get_pts2pt(
                 iok = np.isfinite(eq)
                 kk = kk[iok]
                 eq = eq[iok]
-                
+
                 # find indices of sign changes
                 i0 = (eq[:-1] * eq[1:] < 0).nonzero()[0]
                 if len(i0) == 1:
                     # indices used for linear fit
                     ind = np.arange(max(0, i0-10), min(i0+10, kk.size))
-                    
+
                     # linear least square fit
                     xx_m = np.mean(kk[ind])
                     yy_m = np.mean(eq[ind])
                     xx2_m = np.mean(kk[ind]**2)
                     xy_m = np.mean(kk[ind] * eq[ind])
-                    
+
                     # coefs
                     aa = (xy_m - xx_m*yy_m) / (xx2_m - xx_m**2)
                     bb = yy_m - aa * xx_m
-                    
+
                     # fit and threshold
                     line = aa*kk[ind] + bb
-                    thr = abs(line[0] - line[-1]) * 0.05
-                    std = np.std(eq[ind] - line)
-                    if std > thr:
+                    thr = abs(line[0] - line[-1]) * 0.02
+                    if np.any(np.abs(eq[ind] - line) > thr):
                         continue
                     roots = np.r_[-bb / aa]
                     # roots = np.r_[
@@ -298,38 +297,38 @@ def _get_pts2pt(
                     -(nix*erot[0] + niy*erot[1] + niz*erot[2]),
                     nix*nin[0] + niy*nin[1] + niz*nin[2],
                 )
-                
-                                
+
+
                 # ------ DEBUG --------
                 # if debug:
-                #     Ex = pt_x + roots[0]*(pts_x[ii] - pt_x)
-                #     Ey = pt_y + roots[0]*(pts_y[ii] - pt_y)
-                #     Ez = pt_z + roots[0]*(pts_z[ii] - pt_z)
-                #     print()
-                #     print(f'\nii = {ii}', xxi, thetai)
-                #     print('rcs', rcs)
-                #     print('rca', rca)
-                #     print('nix, niy, niz', nix, niy, niz)
-                #     print('erot', erot)
-                #     print('nin', nin)
-                #     print('eax', eax)
-                #     print('O', O)
-                #     print('E', Ex, Ey, Ez)
-                #     print('OE', Ex - O[0], Ey - O[1], Ez - O[2])
-                #     print('roots', roots[0])
-                #     print('eax', eax)
-                #     plt.figure()
-                #     plt.plot(
-                #         kk, eq, '.-k',
-                #         kk[ind], line, '-r',
-                #         kk[ind], line + thr, '--r',
-                #         kk[ind], line - thr, '--r',
-                #         [kk[i0]], [eq[i0]], 'xr',
-                #     )
-                #     plt.axhline(0, c='k', ls='--')
-                #     plt.axvline(roots[0], c='k', ls='--')
-                #     plt.gca().set_title(f'std = {std} vs {thr}')
-                #     print()
+                    # Ex = pt_x + roots[0]*(pts_x[ii] - pt_x)
+                    # Ey = pt_y + roots[0]*(pts_y[ii] - pt_y)
+                    # Ez = pt_z + roots[0]*(pts_z[ii] - pt_z)
+                    # print()
+                    # print(f'\nii = {ii}', xxi, thetai)
+                    # print('rcs', rcs)
+                    # print('rca', rca)
+                    # print('nix, niy, niz', nix, niy, niz)
+                    # print('erot', erot)
+                    # print('nin', nin)
+                    # print('eax', eax)
+                    # print('O', O)
+                    # print('E', Ex, Ey, Ez)
+                    # print('OE', Ex - O[0], Ey - O[1], Ez - O[2])
+                    # print('roots', roots[0])
+                    # print('eax', eax)
+                    # plt.figure()
+                    # plt.plot(
+                        # kk, eq, '.-k',
+                        # kk[ind], line, '-r',
+                        # kk[ind], line + thr, '--r',
+                        # kk[ind], line - thr, '--r',
+                        # [kk[i0]], [eq[i0]], 'xr',
+                    # )
+                    # plt.axhline(0, c='k', ls='--')
+                    # plt.axvline(roots[0], c='k', ls='--')
+                    # plt.gca().set_title(f'thr = {thr}')
+                    # print()
                 # ---------------------
 
                 if strict is True:
@@ -491,22 +490,21 @@ def _get_pts2pt(
                 if len(i0) == 1:
                     # indices used for linear fit
                     ind = np.arange(max(0, i0-10), min(i0+10, kk.size))
-                    
+
                     # linear least square fit
                     xx_m = np.mean(kk[ind])
                     yy_m = np.mean(eq[ind])
                     xx2_m = np.mean(kk[ind]**2)
                     xy_m = np.mean(kk[ind] * eq[ind])
-                    
+
                     # coefs
                     aa = (xy_m - xx_m*yy_m) / (xx2_m - xx_m**2)
                     bb = yy_m - aa * xx_m
-                    
+
                     # fit and threshold
                     line = aa*kk[ind] + bb
-                    thr = abs(line[0] - line[-1]) * 0.05
-                    std = np.std(eq[ind] - line)
-                    if std > thr:
+                    thr = abs(line[0] - line[-1]) * 0.02
+                    if np.any(np.abs(eq[ind] - line) > thr):
                         continue
                     roots = np.r_[-bb / aa]
                     # roots = np.r_[

--- a/tofu/data/_class8_compute.py
+++ b/tofu/data/_class8_compute.py
@@ -342,6 +342,7 @@ def _interp_poly(
     closed=None,
     ravel=None,
     min_threshold=1.e-6,
+    debug=None,
 ):
 
     # ------------

--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -236,13 +236,13 @@ def equivalent_apertures(
             )
 
             # --- DEBUG ---------
-            if ii in [97]:
-                _debug_plot(
-                    pa0=p0, pa1=p1,
-                    pb0=p0[vert], pb1=p1[vert],
-                    pc0=p0c/curve_mult[0], pc1=p1c/curve_mult[1],
-                    ii=ii, tit='curve_mult',
-                )
+            # if ii in [97]:
+                # _debug_plot(
+                    # pa0=p0, pa1=p1,
+                    # pb0=p0[vert], pb1=p1[vert],
+                    # pc0=p0c/curve_mult[0], pc1=p1c/curve_mult[1],
+                    # ii=ii, tit='curve_mult',
+                # )
             # --------------------
             p0, p1 = p0c / curve_mult[0], p1c / curve_mult[1]
 

--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -30,6 +30,7 @@ def equivalent_apertures(
     pixel=None,
     # inital contour
     add_points=None,
+    min_threshold=None,
     # options
     convex=None,
     harmonize=None,
@@ -67,6 +68,7 @@ def equivalent_apertures(
         cz,
         pixel,
         add_points,
+        min_threshold,
         convex,
         harmonize,
         reshape,
@@ -79,6 +81,7 @@ def equivalent_apertures(
         key_cam=key_cam,
         pixel=pixel,
         add_points=add_points,
+        min_threshold=min_threshold,
         convex=convex,
         harmonize=harmonize,
         reshape=reshape,
@@ -224,21 +227,22 @@ def equivalent_apertures(
             p0c, p1c = _compute._interp_poly(
                 lp=[p0 * curve_mult[0], p1 * curve_mult[1]],
                 add_points=1,
-                mode='min',
+                mode='thr',
                 isclosed=False,
                 closed=False,
                 ravel=True,
-                min_threshold=50.e-6,
+                min_threshold=min_threshold,
+                debug=True,
             )
 
             # --- DEBUG ---------
-            # if ii in [97]:
-                # _debug_plot(
-                    # pa0=p0, pa1=p1,
-                    # pb0=p0[vert], pb1=p1[vert],
-                    # pc0=p0c/curve_mult[0], pc1=p1c/curve_mult[1],
-                    # ii=ii, tit='curve_mult',
-                # )
+            if ii in [97]:
+                _debug_plot(
+                    pa0=p0, pa1=p1,
+                    pb0=p0[vert], pb1=p1[vert],
+                    pc0=p0c/curve_mult[0], pc1=p1c/curve_mult[1],
+                    ii=ii, tit='curve_mult',
+                )
             # --------------------
             p0, p1 = p0c / curve_mult[0], p1c / curve_mult[1]
 
@@ -396,6 +400,7 @@ def _check(
     key_cam=None,
     pixel=None,
     add_points=None,
+    min_threshold=None,
     convex=None,
     harmonize=None,
     reshape=None,
@@ -526,6 +531,16 @@ def _check(
     )
 
     # -----------
+    # min_threshold
+
+    min_threshold = ds._generic_check._check_var(
+        min_threshold, 'min_threshold',
+        types=float,
+        default=400e-6,
+        sign='>0',
+    )
+
+    # -----------
     # convex
 
     isconvex = any(coll.get_optics_isconvex(doptics['optics']))
@@ -601,6 +616,7 @@ def _check(
         cz,
         pixel,
         add_points,
+        min_threshold,
         convex,
         harmonize,
         reshape,

--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -39,6 +39,8 @@ def equivalent_apertures(
     verb=None,
     plot=None,
     store=None,
+    # debug
+    debug=None,
 ):
 
     # -------------
@@ -51,6 +53,9 @@ def equivalent_apertures(
         cref,
         spectro,
         ispectro,
+        curved,
+        concave,
+        curve_mult,
         lop_pre,
         lop_pre_cls,
         lop_post,
@@ -207,23 +212,43 @@ def equivalent_apertures(
             vert = ConvexHull(np.array([p0, p1]).T).vertices
             p0, p1 = p0[vert], p1[vert]
 
-            p0, p1 = _compute._interp_poly(
-                lp=[p0, p1],
-                add_points=add_points,
-                mode='mean',
+            # --- DEBUG ---------
+            # if ii in [97]:
+                # _debug_plot(
+                    # pa0=p0, pa1=p1,
+                    # pb0=p0[vert], pb1=p1[vert],
+                    # ii=ii, tit='local coords',
+                # )
+            # --------------------
+
+            p0c, p1c = _compute._interp_poly(
+                lp=[p0 * curve_mult[0], p1 * curve_mult[1]],
+                add_points=1,
+                mode='min',
                 isclosed=False,
                 closed=False,
                 ravel=True,
-                min_threshold=1.e-5,
+                min_threshold=50.e-6,
             )
+
+            # --- DEBUG ---------
+            # if ii in [97]:
+                # _debug_plot(
+                    # pa0=p0, pa1=p1,
+                    # pb0=p0[vert], pb1=p1[vert],
+                    # pc0=p0c/curve_mult[0], pc1=p1c/curve_mult[1],
+                    # ii=ii, tit='curve_mult',
+                # )
+            # --------------------
+            p0, p1 = p0c / curve_mult[0], p1c / curve_mult[1]
 
         # append
         x0.append(p0)
         x1.append(p1)
 
         # --- DEBUG ---------
-        # if ii in [214, 217]:
-        #     _debug_plot(pa0=p0, pa1=p1, ii=ii, tit='local coords')
+        # if ii in [97]:
+            # _debug_plot(pa0=p0, pa1=p1, ii=ii, tit='local coords')
         # --------------------
 
     # -------------------------------------------
@@ -231,35 +256,11 @@ def equivalent_apertures(
     # -------------------------------------------
 
     if harmonize:
-
-        ln = [p0.size if p0 is not None else 0 for p0 in x0]
-        nmax = np.max(ln)
-        nan = np.full((nmax,), np.nan)
-
-        for ii in range(pixel.size):
-
-            if ln[ii] == 0:
-                x0[ii] = nan
-                x1[ii] = nan
-
-            elif ln[ii] < nmax:
-                ndif = nmax - ln[ii]
-                irand = np.random.randint(1, 9, ndif)/10.
-                irand = irand + np.random.randint(0, ln[ii]-1, ndif)
-                imax = np.sort(np.r_[np.arange(0, ln[ii]), irand])
-                x0[ii] = scpinterp.interp1d(
-                    np.arange(0, ln[ii]),
-                    x0[ii],
-                    kind='linear',
-                )(imax)
-                x1[ii] = scpinterp.interp1d(
-                    np.arange(0, ln[ii]),
-                    x1[ii],
-                    kind='linear',
-                )(imax)
-
-        x0 = np.array(x0)
-        x1 = np.array(x1)
+        x0, x1 = _compute._harmonize_polygon_sizes(
+            lp0=x0,
+            lp1=x1,
+            nmin=100 if curved else 0,
+        )
 
     # -------------
     # xyz
@@ -309,13 +310,15 @@ def equivalent_apertures(
             ).center()
 
             # --- DEBUG ---------
-            # if ii in [214, 217]:
+            # if ii in [97]:
                 # _debug_plot2(
                     # p0=p0, p1=p1,
                     # cents0=cents0, cents1=cents1,
                     # ii=ii,
+                    # ip=ip,
                     # coord_x01toxyz=coord_x01toxyz,
                     # cx=cx, cy=cy, cz=cz,
+                    # area=area,
                 # )
             # --------------------
 
@@ -325,6 +328,13 @@ def equivalent_apertures(
         )
 
         plane_nin = coll.dobj[cref][kref]['dgeom']['nin']
+
+        # ------ DEBUG --------
+        # if True:
+            # plt.figure()
+            # plt.plot(pixel, area, '.-k')
+            # plt.gca().set_title('area')
+        # --------------------
 
     else:
         cents0, cents1 = None, None
@@ -425,6 +435,25 @@ def _check(
     optics = doptics['optics']
     optics_cls = doptics['cls']
     ispectro = doptics.get('ispectro')
+
+    # --------
+    # curvature
+
+    if spectro:
+        clssp = optics_cls[ispectro[0]]
+        ksp = optics[ispectro[0]]
+        rcurve = coll.dobj[clssp][ksp]['dgeom']['curve_r']
+        iok = np.isfinite(rcurve)
+        curved = np.any(iok)
+        concave = np.any(np.r_[rcurve][iok] > 0.)
+
+        curve_mult = np.copy(rcurve)
+        curve_mult[~iok] = 1
+
+    else:
+        curved = False
+        concave = False
+        curve_mult = [1., 1.]
 
     # -------------------------------------------------
     # ldeti: list of individual camera dict (per pixel)
@@ -558,6 +587,9 @@ def _check(
         cref,
         spectro,
         ispectro,
+        curved,
+        concave,
+        curve_mult,
         lop_pre,
         lop_pre_cls,
         lop_post,
@@ -714,7 +746,7 @@ def _get_equivalent_aperture_spectro(
             #     _debug_plot(p_a=p_a, pa0=p0, pa1=p1, ii=ii, tit='allin')
             # ----------------------
             p_a = plg.Polygon(np.array([p0, p1]).T)
-            
+
         else:
             # convex hull
             if convex:
@@ -816,6 +848,8 @@ def _debug_plot(
     pa1=None,
     pb0=None,
     pb1=None,
+    pc0=None,
+    pc1=None,
     ii=None,
     tit=None,
 ):
@@ -830,7 +864,9 @@ def _debug_plot(
             p_a[ind, 0],
             p_a[ind, 1],
             ls='-',
-            lw=1.
+            lw=1.,
+            marker='.',
+            label=f'p_a ({p_a.shape[0]} pts)',
         )
 
     # pa
@@ -840,7 +876,9 @@ def _debug_plot(
             pa0[ind],
             pa1[ind],
             ls='-',
-            lw=1.
+            lw=1.,
+            marker='x',
+            label=f'pa ({pa0.size} pts)',
         )
 
     # pb
@@ -850,8 +888,24 @@ def _debug_plot(
             pb0[ind],
             pb1[ind],
             ls='-',
-            lw=1.
+            lw=1.,
+            marker='+',
+            label=f'pb ({pb0.size} pts)',
         )
+
+    # pc
+    if pc0 is not None:
+        ind = np.r_[np.arange(0, pc0.size), 0]
+        plt.plot(
+            pc0[ind],
+            pc1[ind],
+            ls='-',
+            lw=1.,
+            marker='+',
+            label=f'pc ({pc0.size} pts)',
+        )
+
+    plt.legend()
 
     if ii is not None:
         tit0 = f'ii = {ii}'
@@ -868,10 +922,12 @@ def _debug_plot2(
     cents0=None,
     cents1=None,
     ii=None,
+    ip=None,
     coord_x01toxyz=None,
     cx=None,
     cy=None,
     cz=None,
+    area=None,
 ):
 
     plt.figure()

--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -259,7 +259,7 @@ def equivalent_apertures(
         x0, x1 = _compute._harmonize_polygon_sizes(
             lp0=x0,
             lp1=x1,
-            nmin=100 if curved else 0,
+            nmin=150 if curved else 0,
         )
 
     # -------------

--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -223,18 +223,7 @@ def equivalent_apertures(
 
         # --- DEBUG ---------
         # if ii in [214, 217]:
-        #     plt.figure()
-        #     plt.plot(
-        #         np.r_[p0, p0[0]],
-        #         np.r_[p1, p1[0]],
-        #         c='k',
-        #         ls='-',
-        #         lw=1.,
-        #         marker='.',
-        #     )
-        #     plt.gca().set_title(f'local coordinates - {ii}', size=12)
-        #     plt.gca().set_xlabel('x0 (local)', size=12)
-        #     plt.gca().set_ylabel('x1 (local)', size=12)
+        #     _debug_plot(pa0=p0, pa1=p1, ii=ii, tit='local coords')
         # --------------------
 
     # -------------------------------------------
@@ -321,34 +310,13 @@ def equivalent_apertures(
 
             # --- DEBUG ---------
             # if ii in [214, 217]:
-            #     plt.figure()
-            #     plt.plot(
-            #         np.r_[p0, p0[0]],
-            #         np.r_[p1, p1[0]],
-            #         c='k',
-            #         ls='-',
-            #         lw=1.,
-            #         marker='.',
-            #     )
-            #     plt.plot([cents0[ii]], [cents1[ii]], 'xk')
-            #     ppx, ppy, ppz = coord_x01toxyz(
-            #         x0=np.r_[cents0[ii]],
-            #         x1=np.r_[cents1[ii]],
-            #     )
-            #     ddd = np.linalg.norm(
-            #         np.r_[ppx - cx[ip], ppy - cy[ip], ppz - cz[ip]]
-            #     )
-            #     plt.gca().text(
-            #         np.mean(p0),
-            #         np.mean(p1),
-            #         f'area\n{area[ii]:.3e} m2\ndist\n{ddd:.6e} m',
-            #         size=12,
-            #         horizontalalignment='center',
-            #         verticalalignment='center',
-            #     )
-            #     plt.gca().set_title(f'planar coordinates - {ii}', size=12)
-            #     plt.gca().set_xlabel('x0 (m)', size=12)
-            #     plt.gca().set_ylabel('x1 (m)', size=12)
+                # _debug_plot2(
+                    # p0=p0, p1=p1,
+                    # cents0=cents0, cents1=cents1,
+                    # ii=ii,
+                    # coord_x01toxyz=coord_x01toxyz,
+                    # cx=cx, cy=cy, cz=cz,
+                # )
             # --------------------
 
         centsx, centsy, centsz = coord_x01toxyz(
@@ -742,15 +710,8 @@ def _get_equivalent_aperture_spectro(
 
         if np.all([p_a.isInside(xx, yy) for xx, yy in zip(p0, p1)]):
             # --- DEBUG ---------
-            # if ii in [214, 217]:
-            #     plt.figure()
-            #     plt.plot(
-            #         np.array(p_a.contour(0))[:, 0],
-            #         np.array(p_a.contour(0))[:, 1],
-            #         '.-k',
-            #         p0, p1, '.-r'
-            #     )
-            #     plt.gca().set_title(f"ii = {ii}, all in", size=12)
+            # if ii in [32, 37, 42]:
+            #     _debug_plot(p_a=p_a, pa0=p0, pa1=p1, ii=ii, tit='allin')
             # ----------------------
             p_a = plg.Polygon(np.array([p0, p1]).T)
             
@@ -762,28 +723,18 @@ def _get_equivalent_aperture_spectro(
                 # ).contour(0)).T
                 vert = ConvexHull(np.array([p0, p1]).T).vertices
                 # --- DEBUG ---------
-                # if ii in [214, 217]:
-                #     plt.figure()
-                #     plt.plot(
-                #         p0[vert],
-                #         p1[vert],
-                #         '.-k',
-                #         p0, p1, '.-r'
-                #     )
-                #     plt.gca().set_title(f"ii = {ii}, convexH", size=12)
+                # if ii in [32, 37]:
+                    # _debug_plot(
+                        # pa0=p0, pa1=p1,
+                        # pb0=p0[vert], pb1=p1[vert],
+                        # ii=ii, tit='convexH',
+                    # )
                 # ----------------------
                 p0, p1 = p0[vert], p1[vert]
 
             # --- DEBUG ---------
             # if ii in [214, 217]:
-            #     plt.figure()
-            #     plt.plot(
-            #         np.array(p_a.contour(0))[:, 0],
-            #         np.array(p_a.contour(0))[:, 1],
-            #         '.-k',
-            #         p0, p1, '.-r'
-            #     )
-            #     plt.gca().set_title(f"ii = {ii}, not all", size=12)
+            #     _debug_plot(p_a=p_a, pa0=p0, pa1=p1, ii=ii, tit='not all')
             # ----------------------
 
             # intersection
@@ -851,3 +802,103 @@ def _plot(
 
     ax.legend()
     return
+
+
+# ##############################################################
+# ##############################################################
+#           Debug plots
+# ##############################################################
+
+
+def _debug_plot(
+    p_a=None,
+    pa0=None,
+    pa1=None,
+    pb0=None,
+    pb1=None,
+    ii=None,
+    tit=None,
+):
+
+    plt.figure()
+
+    # p_a
+    if p_a is not None:
+        p_a = np.array(p_a.contour(0))
+        ind = np.r_[np.arange(0, p_a.shape[0]), 0]
+        plt.plot(
+            p_a[ind, 0],
+            p_a[ind, 1],
+            ls='-',
+            lw=1.
+        )
+
+    # pa
+    if pa0 is not None:
+        ind = np.r_[np.arange(0, pa0.size), 0]
+        plt.plot(
+            pa0[ind],
+            pa1[ind],
+            ls='-',
+            lw=1.
+        )
+
+    # pb
+    if pb0 is not None:
+        ind = np.r_[np.arange(0, pb0.size), 0]
+        plt.plot(
+            pb0[ind],
+            pb1[ind],
+            ls='-',
+            lw=1.
+        )
+
+    if ii is not None:
+        tit0 = f'ii = {ii}'
+        if tit is None:
+            tit = tit0
+        else:
+            tit = tit0 + ', ' + tit
+        plt.gca().set_title(tit, size=12)
+
+
+def _debug_plot2(
+    p0=None,
+    p1=None,
+    cents0=None,
+    cents1=None,
+    ii=None,
+    coord_x01toxyz=None,
+    cx=None,
+    cy=None,
+    cz=None,
+):
+
+    plt.figure()
+    plt.plot(
+        np.r_[p0, p0[0]],
+        np.r_[p1, p1[0]],
+        c='k',
+        ls='-',
+        lw=1.,
+        marker='.',
+    )
+    plt.plot([cents0[ii]], [cents1[ii]], 'xk')
+    ppx, ppy, ppz = coord_x01toxyz(
+        x0=np.r_[cents0[ii]],
+        x1=np.r_[cents1[ii]],
+    )
+    ddd = np.linalg.norm(
+        np.r_[ppx - cx[ip], ppy - cy[ip], ppz - cz[ip]]
+    )
+    plt.gca().text(
+        np.mean(p0),
+        np.mean(p1),
+        f'area\n{area[ii]:.3e} m2\ndist\n{ddd:.6e} m',
+        size=12,
+        horizontalalignment='center',
+        verticalalignment='center',
+    )
+    plt.gca().set_title(f'planar coordinates - {ii}', size=12)
+    plt.gca().set_xlabel('x0 (m)', size=12)
+    plt.gca().set_ylabel('x1 (m)', size=12)

--- a/tofu/data/_class8_vos_spectro.py
+++ b/tofu/data/_class8_vos_spectro.py
@@ -47,6 +47,7 @@ def _vos(
     res_ang_rocking_curve=None,
     bool_cross=None,
     # parameters
+    min_threshold=None,
     margin_poly=None,
     visibility=None,
     verb=None,
@@ -320,6 +321,7 @@ def _vos(
                         nop_pre=len(lpoly_pre),
                         lpoly_pre=lpoly_pre,
                         ptsvect=ptsvect_plane,
+                        min_threshold=min_threshold,
                     )
 
                     # skip if no intersection

--- a/tofu/tests/tests09_tutorials/tuto_real0.py
+++ b/tofu/tests/tests09_tutorials/tuto_real0.py
@@ -30,13 +30,13 @@ def main():
     # add several diagnostics
 
     # add broadband
-    # _add_broadband(coll, conf)
+    _add_broadband(coll, conf)
 
     # add 2d camera
-    # _add_2d(coll, conf)
+    _add_2d(coll, conf)
 
     # add PHA
-    # _add_PHA(coll, conf)
+    _add_PHA(coll, conf)
 
     # add spectrometer
     _add_spectrometer(coll, conf) # , crystals=['c0'])

--- a/tofu/tests/tests09_tutorials/tuto_real0.py
+++ b/tofu/tests/tests09_tutorials/tuto_real0.py
@@ -30,10 +30,10 @@ def main():
     # add several diagnostics
 
     # add broadband
-    _add_broadband(coll, conf)
+    # _add_broadband(coll, conf)
 
     # add 2d camera
-    _add_2d(coll, conf)
+    # _add_2d(coll, conf)
 
     # add PHA
     # _add_PHA(coll, conf)
@@ -344,14 +344,14 @@ def _add_spectrometer(
             # parameters
             cam_on_e0=False,
             cam_tangential=True,
-            cam_dimensions=[5e-2, 3e-2],
+            cam_dimensions=np.r_[1028, 512]*75e-6,
             pinhole_distance=2.,
             # store
             store=True,
             key_cam=f'{k0}_cam',
             aperture_dimensions=[100e-6, 1e-2],
             pinhole_radius=100e-6,
-            cam_pixels_nb=[10, 5],
+            cam_pixels_nb=[33, 5],
             # returnas
             returnas=list,
         )
@@ -390,7 +390,10 @@ def _crystals(coll=None, crystals=None):
     # -------
     # geom
 
-    start, vect, v0, v1 = _ref_line(start=np.r_[7, 0., 0.001])
+    start, vect, v0, v1 = _ref_line(
+        start=np.r_[17.918, -2.157, 0.043],
+        vect=np.r_[-0.29770273, 0.95465862, 0.],
+    )
 
     # cryst0: planar
     cent = start + 0. * vect
@@ -399,7 +402,7 @@ def _crystals(coll=None, crystals=None):
         vect=vect,
         v0=v0,
         v1=v1,
-        theta=-np.pi/4,
+        theta=0,  # -np.pi/4,
         phi=0.,
     )
 
@@ -408,7 +411,7 @@ def _crystals(coll=None, crystals=None):
     # c1: cylindrical (von hamos)
     if 'c0' in crystals:
         size = 1.e-2
-        rc = 2.
+        rc = 1.03
         c0 = {
             'key': 'c0',
             'dgeom': {
@@ -419,7 +422,13 @@ def _crystals(coll=None, crystals=None):
                 'extenthalf': size * np.r_[1, 1/rc],
                 'curve_r': [np.inf, rc],
             },
-            'dmat': 'Quartz_110',
+            #'dmat': 'Quartz_110',
+            'dmat': {
+                'd_hkl': 0.944e-10 / (2*np.sin(24.2*np.pi/180.)),
+                'target': {
+                    'lamb': 0.944e-10,
+                },
+            },
             'configuration': 'von hamos',
         }
         dc['c0'] = c0


### PR DESCRIPTION
Main changes:
-------------------
* After fixing bugs in reflected polygon root-finding and interpolation, @cjperks7  commented that while it had fixed the `etendue`, some instabilities remained in the computation of `dlamb`, see PR #751 for details
* After investigating, it comes not from a bug but simply from an unsufficient number of interpolation points for the polygon interpolation
* The number of interpolation points has been increased, resulting in better results at the cost of slower computation

Issues:
---------
* This partially fixes issue #748, as it addresses the stability aspect of `dlamb`, but does not yet answer why `dlamb` is generally larger than expected


Examples:
--------------

This is an example of a reflection of the slit as seen through the crystal by a pixel, without correction:

![image](https://user-images.githubusercontent.com/5929562/235133153-45f29562-3265-4022-9e3f-1acddcdbbe0a.png)

Same reflection after increasing the number of interpolation points:

![image](https://user-images.githubusercontent.com/5929562/235133474-741f4724-86a0-479b-9422-cfae4a2d4a0e.png)

The area is computed more accurately, resulting in a more accurate etendue, andmore points are tested for dlamb, resulting in better results too

After correction, dlamb is smoother:
![image](https://user-images.githubusercontent.com/5929562/235133982-c6f64269-8dea-4f12-8daf-adc45cef9ffb.png)
















