### PR TITLE
Issue756 flat crystal etendue

### DIFF
--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -219,6 +219,11 @@ def equivalent_apertures(
         x0.append(p0)
         x1.append(p1)
 
+        # --- DEBUG ---------
+        # if ii in [14, 15, 16, 17]:
+            # _debug_plot(pa0=p0, pa1=p1, ii=ii, tit='local coords')
+        # --------------------
+
     # -------------------------------------------
     # harmonize if necessary the initial polygons
     # -------------------------------------------
@@ -573,6 +578,8 @@ def _get_equivalent_aperture(
     nop_pre=None,
     lpoly_pre=None,
     ptsvect=None,
+    # debug
+    ii=None,
     **kwdargs,
 ):
 
@@ -590,6 +597,11 @@ def _get_equivalent_aperture(
             strict=False,
             return_x01=True,
         )[-2:]
+
+        # --- DEBUG ---------
+        # if ii in [14, 15, 16, 17]:
+            # _debug_plot(p_a=p_a, pa0=p0, pa1=p1, ii=ii, tit='local coords')
+        # --------------------
 
         # inside
         if np.all([p_a.isInside(xx, yy) for xx, yy in zip(p0, p1)]):
@@ -687,15 +699,12 @@ def _get_equivalent_aperture_spectro(
             # print('\t \t None 0')
             return p0, p1
 
+        # --- DEBUG ---------
+        # if ii in [12, 13, 14, 15, 16, 17]:
+            # _debug_plot(p_a=p_a, pa0=p0, pa1=p1, ii=ii, tit='allin')
+        # ----------------------
+
         if np.all([p_a.isInside(xx, yy) for xx, yy in zip(p0, p1)]):
-            # print('inside: ', p1)
-            # plt.figure()
-            # plt.plot(
-                # np.array(p_a.contour(0))[:, 0],
-                # np.array(p_a.contour(0))[:, 1],
-                # '.-k',
-                # p0, p1, '.-r'
-            # )
             p_a = plg.Polygon(np.array([p0, p1]).T)
         else:
             # convex hull
@@ -706,14 +715,10 @@ def _get_equivalent_aperture_spectro(
                 vert = ConvexHull(np.array([p0, p1]).T).vertices
                 p0, p1 = p0[vert], p1[vert]
 
-            # plt.figure()
-            # plt.plot(
-                # np.array(p_a.contour(0))[:, 0],
-                # np.array(p_a.contour(0))[:, 1],
-                # '.-k',
-                # p0, p1, '.-r'
-            # )
-            # import pdb; pdb.set_trace()     # DB
+            # --- DEBUG ---------
+            # if ii in [214, 217]:
+                # _debug_plot(p_a=p_a, pa0=p0, pa1=p1, ii=ii, tit='not all')
+            # ----------------------
 
             # intersection
             p_a = p_a & plg.Polygon(np.array([p0, p1]).T)

--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -700,7 +700,7 @@ def _get_equivalent_aperture_spectro(
             return p0, p1
 
         # --- DEBUG ---------
-        # if ii in [12, 13, 14, 15, 16, 17]:
+        # if ii in [14, 15, 16]:
             # _debug_plot(p_a=p_a, pa0=p0, pa1=p1, ii=ii, tit='allin')
         # ----------------------
 

--- a/tofu/data/_class8_plot_vos.py
+++ b/tofu/data/_class8_plot_vos.py
@@ -97,7 +97,7 @@ def _plot_diagnostic_vos(
     # single camera + get dvos
     key_cam = key_cam[:1]
     if dvos is None:
-        dvos = coll.dobj['diagnostic'][key]['doptics'][key_cam]['dvos']
+        dvos = coll.dobj['diagnostic'][key]['doptics'][key_cam[0]]['dvos']
 
     spectro = coll.dobj['diagnostic'][key]['spectro']
     if spectro:
@@ -139,11 +139,21 @@ def _plot_diagnostic_vos(
             add_points=False,
             total=True,
         )
-        k0, k1 = coll.dobj['camera'][key_cam[0]]['dgeom']['cents']
+
+        dgeom = coll.dobj['camera'][key_cam[0]]['dgeom']
+        k0, k1 = dgeom['cents']
         x0 = coll.ddata[k0]['data']
         x1 = coll.ddata[k1]['data']
-        dx0 = x0[1] - x0[0]
-        dx1 = x1[1] - x1[0]
+        if x0.size == 1:
+            dx0 = coll.ddata[dgeom['outline'][0]]['data']
+            dx0 = dx0.max() - dx0.min()
+        else:
+            dx0 = x0[1] - x0[0]
+        if x1.size == 1:
+            dx1 = coll.ddata[dgeom['outline'][1]]['data']
+            dx1 = dx1.max() - dx1.min()
+        else:
+            dx1 = x1[1] - x1[0]
         extent_cam = (
             x0[0] - 0.5*dx0,
             x0[-1] + 0.5*dx0,


### PR DESCRIPTION
Main changes:
-------------------
* None, except a minor extra piece of copy-pasted code to help that kind of cases debugging 

Issues:
-----------
* Issue #756  was due to wrong input, no bug detected

Example:
------------

The outline of the crystal was provided such that the crystal was self-intersecting, resulting in reflected slit that was plummeting to 0 for central pixels

![image](https://user-images.githubusercontent.com/5929562/236401304-0f20cfca-8c52-481c-a327-0bf920c4e720.png)

![image](https://user-images.githubusercontent.com/5929562/236401154-0c4a4ccb-2f53-44b3-9eec-bd2e5a7b22b8.png)
![image](https://user-images.githubusercontent.com/5929562/236401235-580df021-d8ac-46b5-825c-158af9ec748e.png)

Indeed, the reflection of the slit on the crystal gradually disappears as we go from edge pixels to central pixels (index ii = 16)

![image](https://user-images.githubusercontent.com/5929562/236402123-5bbb45ff-8b2d-4d95-9a6e-62228a74d6d4.png)

A simple fix is to provide the outline in good order to avoid self-intersection of the polygon:
![image](https://user-images.githubusercontent.com/5929562/236402400-d40ba039-38dc-4498-a7ea-5bc1644217bd.png)

Which results in:

![image](https://user-images.githubusercontent.com/5929562/236402484-8031ccc2-a549-4f96-a460-1a7a1d924fcf.png)











