### PR TITLE
Decrease memory footprint of compute_diagnostic_solidangle_from_plane()

### DIFF
--- a/tofu/data/_class8_plane_perp_to_los.py
+++ b/tofu/data/_class8_plane_perp_to_los.py
@@ -1211,10 +1211,7 @@ def _check_plot(
         )[0][key_cam]
 
         etend_lamb = etend * dlamb
-        etend_plane_lamb = np.nansum(
-            np.nansum(np.nansum(sang_lamb['data'], axis=-1), axis=-1),
-            axis=-1,
-        ) * ds
+        etend_plane_lamb = sang_lamb['data'] * ds
 
     else:
         etend_plane0 = np.nansum(np.nansum(sang0['data'], axis=-1), axis=-1) * ds

--- a/tofu/data/_class8_reverse_ray_tracing.py
+++ b/tofu/data/_class8_reverse_ray_tracing.py
@@ -175,9 +175,6 @@ def _from_pts(
             dout[k0] = dout[k0].reshape(shape_new)
         for k0 in ['sang0']:
             dout[k0] = dout[k0].reshape(shape_new)
-        shape_new = tuple(np.r_[shape_cam, shape, nlamb])
-        for k0 in ['sang_lamb']:
-            dout[k0] = dout[k0].reshape(shape_new)
 
     # -------
     # plot
@@ -662,7 +659,7 @@ def _loop0(
     ncounts = np.full(shape_cam, 0.)
     sang = np.full(tuple(np.r_[shape_cam, ptsx.size]), 0.)
     sang0 = np.full(tuple(np.r_[shape_cam, ptsx.size]), 0.)
-    sang_lamb = np.full(tuple(np.r_[shape_cam, ptsx.size, lamb.size]), 0.)
+    sang_lamb = np.full(shape_cam, 0.)
 
     if append is True:
         lp0, lp1 = [], []
@@ -861,7 +858,7 @@ def _loop0(
                     )
 
                     # update power_ratio * solid angle
-                    sang_lamb[ii, jj, i0, kk] += np.sum(
+                    sang_lamb[ii, jj] += np.sum(
                         pow_ratio[inds]
                         * dsang[indj][ilamb[:, kk]]
                     )

--- a/tofu/tests/tests09_tutorials/tuto_real0.py
+++ b/tofu/tests/tests09_tutorials/tuto_real0.py
@@ -42,13 +42,13 @@ def main():
     _add_2d(coll, conf)
 
     # add PHA
-    # _add_PHA(coll, conf)
+    _add_PHA(coll, conf)
 
     # add spectrometer
     _add_spectrometer(coll, conf)   # , crystals=['c0'])
 
     # add spectro-like without crystal
-    _add_spectrometer_like(coll, config=conf, key_diag='d02')
+    # _add_spectrometer_like(coll, config=conf, key_diag='d02')
 
     # ------------------------
     # compute synthetic signal
@@ -493,6 +493,7 @@ def _add_spectrometer(
             aperture_dimensions=[100e-6, 1e-2],
             pinhole_radius=100e-6 if v0['configuration'] == 'pinhole' else None,
             cam_pixels_nb=[7, 3],
+            # cam_pixels_nb=[41, 41],
             # returnas
             returnas=list,
         )


### PR DESCRIPTION
Context:
-----------
`compute_diagnostic_solidangle_from_plane()` was taking up too much memory when used with fine resolution on a camera with several thousand pixels and fine wavelength sampling.
The main issue was the allocation of array `sang_lamb` with shape `(npix0, npix1, npts0, npts1, nlamb)`.
That array quickly got huge, leading to memory shortage and crashes.


Main changes:
---------------------
* The `sang_dlamb` array in was in fact only used to later be summed over the 3 last dimensions.
* It has been replaced by a `(npix0, npix1)` array summed over iteratively
