### PR TITLE
Issue774 overestimated etendue

### DIFF
--- a/tofu/data/_class08_Diagnostic.py
+++ b/tofu/data/_class08_Diagnostic.py
@@ -200,7 +200,9 @@ class Diagnostic(Previous):
         margin_par=None,
         margin_perp=None,
         # spectro-only
+        ind_ap_lim_spectral=None,
         rocking_curve_fw=None,
+        rocking_curve_max=None,
         # equivalent aperture
         add_points=None,
         convex=None,
@@ -235,7 +237,9 @@ class Diagnostic(Previous):
             margin_par=margin_par,
             margin_perp=margin_perp,
             # spectro-only
+            ind_ap_lim_spectral=ind_ap_lim_spectral,
             rocking_curve_fw=rocking_curve_fw,
+            rocking_curve_max=rocking_curve_max,
             # equivalent aperture
             add_points=add_points,
             convex=convex,
@@ -416,6 +420,7 @@ class Diagnostic(Previous):
         # inital contour
         add_points=None,
         # options
+        ind_ap_lim_spectral=None,
         convex=None,
         harmonize=None,
         reshape=None,
@@ -434,6 +439,7 @@ class Diagnostic(Previous):
             # inital contour
             add_points=add_points,
             # options
+            ind_ap_lim_spectral=ind_ap_lim_spectral,
             convex=convex,
             harmonize=harmonize,
             reshape=reshape,

--- a/tofu/data/_class5_projections.py
+++ b/tofu/data/_class5_projections.py
@@ -37,6 +37,7 @@ def _get_reflection(
     dt=None,
     # debug
     ii=None,
+    ij=None,
 ):
 
     # -------------------
@@ -78,6 +79,16 @@ def _get_reflection(
 
     # isinside
     if np.all([pa.isInside(xx, yy) for xx, yy in zip(p0, p1)]):
+        # if ij in [104]:
+        #     plt.figure()
+        #     plt.plot(
+        #         np.r_[poly_x0, poly_x0[0]],
+        #         np.r_[poly_x1, poly_x1[0]],
+        #         '.-k',
+        #         p0, p1, 
+        #         '.-r',
+        #     )
+        #     plt.gca().set_title(f"ii = {ii}, projection 0")
         return x0, x1
 
     # intersection
@@ -87,10 +98,12 @@ def _get_reflection(
         return None, None
 
     # --------- DEBUG ------------
-    # if ii in [214, 217]:
+    # if ij in [104]:
     #     plt.figure()
     #     plt.plot(
-    #         np.r_[poly_x0, poly_x0[0]], np.r_[poly_x1, poly_x1[0]], '.-k',
+    #         np.r_[poly_x0, poly_x0[0]],
+    #         np.r_[poly_x1, poly_x1[0]],
+    #         '.-k',
     #         p0, p1, '.-r',
     #     )
     #     plt.gca().set_title(f"ii = {ii}, projection 0")
@@ -137,6 +150,7 @@ def _get_reflection(
 # ##############################################################
 #           Global to local coordinates
 # ##############################################################
+
 
 # DEPRECATED ????
 # def _get_project_plane(

--- a/tofu/data/_class8_etendue_los.py
+++ b/tofu/data/_class8_etendue_los.py
@@ -37,6 +37,7 @@ def compute_etendue_los(
     # options
     add_points=None,
     # spectro-only
+    ind_ap_lim_spectral=None,
     rocking_curve_fw=None,
     rocking_curve_max=None,
     # bool
@@ -102,6 +103,7 @@ def compute_etendue_los(
             # inital contour
             add_points=add_points,
             # options
+            ind_ap_lim_spectral=ind_ap_lim_spectral,
             convex=convex,
             harmonize=True,
             reshape=False,


### PR DESCRIPTION
Main changes:
----------------
* The overestimation was only showing in cases with multiple apertures after the crystal
* In those cases, the distance used as reference for estimating the effect of the rocking curve was taken using the furthermost aperture (from the crystal)
* In fact, it should be the aperture that is the most limiting to the spectral range

As an easy fix, the new keyword arg `ind_ap_lim_spectral` is introduced to methods `compute_diagnostic_etendue_los()` and `get_diagnostic_equivalent_aperture()`.
It is set to 0 by default (because it is usually actually the closest aperture to the crystal that limits the spectral range).
But it can be set to a custom value by the user.


Issues:
-------
* fixes, in devel, issue #774 


