### PR TITLE
Issue779 crystal size2d

### DIFF
--- a/tofu/spectro/__init__.py
+++ b/tofu/spectro/__init__.py
@@ -6,3 +6,4 @@ from ._fit12d import *
 from ._analysis_tools import *
 from ._plot import *
 from ._rockingcurve import *
+from ._spectralrange2d import *

--- a/tofu/spectro/_spectralrange2d.py
+++ b/tofu/spectro/_spectralrange2d.py
@@ -594,7 +594,8 @@ def _get_axes():
     )
 
     ax0.set_xlabel("x (m)", size=12)
-    ax0.set_xlabel("y (m)", size=12)
+    ax0.set_ylabel("y (m)", size=12)
+    ax0.set_title("2d ray tracing", size=12, fontweight='bold')
 
     # ax1 - cam
     ax1 = fig.add_subplot(
@@ -603,6 +604,7 @@ def _get_axes():
     )
 
     ax1.set_xlabel("x0 (m)", size=12)
+    ax1.set_title("Image on camera", size=12, fontweight='bold')
 
     # ------------
     # dict

--- a/tofu/spectro/_spectralrange2d.py
+++ b/tofu/spectro/_spectralrange2d.py
@@ -1,0 +1,493 @@
+# -*- coding: utf-8 -*-
+
+
+import numpy as np
+import matplotlib.pyplot as plt
+import datastock as ds
+
+
+__all__ = ['spectral_range_2d']
+
+
+# #################################################################
+# #################################################################
+#               Main
+# #################################################################
+
+
+def spectral_range_2d(
+    # crystal
+    lamb0=None,
+    bragg0=None,
+    # geometry basis
+    ap=None,
+    ex=None,
+    ey=None,
+    beta_max=None,
+    # geometry
+    xx=None,
+    length=None,
+    rcurve=None,
+    dist=None,
+    # camera
+    dcam=None,
+    # options
+    npts=None,
+    # plotting
+    plot=None,
+    ax=None,
+    # saving
+    save=None,
+    pfe_fig=None,
+    pfe_npz=None,
+):
+
+    # --------
+    # check
+
+    din, npts, plot, save, pfe_fig, pfe_npz = _check(**locals())
+
+    # --------------
+    # compute
+
+    crystx, crysty, endx, endy, lamb, Dlamb = _compute(
+        npts=npts,
+        beta_max=beta_max,
+        **din,
+    )
+
+    # -------------
+    # format output
+
+    dout = dict(din)
+    dout.update({
+        'crystx': crystx,
+        'crysty': crysty,
+        'endx': endx,
+        'endy': endy,
+        'Dlamb': Dlamb,
+    })
+
+    # ---------
+    # plot
+
+    if plot is True:
+        ax = _plot(
+            dcam=dcam,
+            pfe_fig=pfe_fig,
+            **dout,
+        )
+
+    # ----------
+    # save
+
+    if save is True:
+        np.savez(pfe_npz, **dout)
+
+    return dout
+
+
+# #################################################################
+# #################################################################
+#               Check
+# #################################################################
+
+
+def _check(
+    # crystal
+    lamb0=None,
+    bragg0=None,
+    # geometry basis
+    ap=None,
+    ex=None,
+    ey=None,
+    # geometry
+    xx=None,
+    length=None,
+    rcurve=None,
+    dist=None,
+    # options
+    npts=None,
+    # plotting
+    plot=None,
+    ax=None,
+    # saving
+    save=None,
+    pfe_fig=None,
+    pfe_npz=None,
+    # unused
+    **kwdargs,
+):
+
+    # --------------
+    # geometry basis
+
+    basis_def = {'ap': np.r_[0, 0], 'ex': np.r_[1, 0], 'ey': np.r_[0, 1]}
+    din_basis = {'ap': ap, 'ex': ex, 'ey': ey}
+    for k0, v0 in din_basis.items():
+
+        if v0 is None:
+            din_basis[k0] = basis_def[k0]
+
+        din_basis[k0] = np.atleast_1d(din_basis[k0]).ravel().astype(float)
+        if din_basis[k0].size != 2:
+            msg = f"Arg '{k0}' must be a 2d array!\nProvided: {din_basis[k0]}"
+            raise Exception(msg)
+
+    # normalize ex
+    din_basis['ex'] = din_basis['ex'] / np.linalg.norm(din_basis['ex'])
+
+    # perpendicular + normalize ey
+    sca = np.sum(din_basis['ex']*din_basis['ey'])
+    din_basis['ey'] = din_basis['ey'] - sca * din_basis['ex']
+    din_basis['ey'] = din_basis['ey'] / np.linalg.norm(din_basis['ey'])
+
+    # -----------------
+    # initialize dict
+
+    din = {
+        'lamb0': lamb0,
+        'bragg0': bragg0,
+        # geometry
+        'xx': xx,
+        'length': length,
+        'rcurve': rcurve,
+        'dist': dist,
+    }
+
+    # -------------
+    # get size
+
+    # make all arrays
+    for k0, v0 in din.items():
+        din[k0] = np.atleast_1d(v0).ravel().astype(float)
+
+    # sizes
+    lsizes = list(set([v0.size for v0 in din.values()]))
+    if len(lsizes) == 1:
+        pass
+    elif 1 in lsizes and len(lsizes) == 2:
+        size = [ss for ss in lsizes if ss != 1][0]
+        for k0, v0 in din.items():
+            if v0.size == 1:
+                din[k0] = np.full((size,), v0[0])
+    else:
+        lstr = [f"\t- '{k0}': {v0.size}" for k0, v0 in din.items()]
+        msg = (
+            "All args must be either scalar or 1d arrays of the same size:\n"
+            + "\n".join(lstr)
+        )
+        raise Exception(msg)
+
+    # -------
+    # values
+
+    for k0, v0 in din.items():
+        if k0 != 'rcurve':
+            c0 = np.all(np.isfinite(v0)) and np.all(v0 >= 0.)
+
+            if not c0:
+                msg = (
+                    f"Arg '{k0}' must be finite and positive\n"
+                    "Provided: {v0}"
+                )
+                raise Exception(msg)
+
+    # ------------
+    # add basis
+    din.update(din_basis)
+
+    # ---------
+    # npts
+
+    if npts is None:
+        npts = 101
+
+    # ---------
+    # plot
+
+    # plot
+    plot = ds._generic_check._check_var(
+        plot, 'plot',
+        types=bool,
+        default=True,
+    )
+
+    # ---------
+    # save
+
+    # save
+    save = ds._generic_check._check_var(
+        save, 'save',
+        types=bool,
+        default=False,
+    )
+
+    return din, npts, plot, save, pfe_fig, pfe_npz
+
+
+# #################################################################
+# #################################################################
+#               Compute
+# #################################################################
+
+
+def _compute(
+    # crystal
+    lamb0=None,
+    bragg0=None,
+    # geometry basis
+    ap=None,
+    ex=None,
+    ey=None,
+    beta_max=None,
+    # geometry
+    xx=None,
+    length=None,
+    rcurve=None,
+    dist=None,
+    # options
+    npts=None,
+):
+
+    # ------------
+    # initialize
+
+    size = lamb0.size
+    cx = np.full((size,), np.nan)
+    cy = np.full((size,), np.nan)
+    tx = np.full((size,), np.nan)
+    ty = np.full((size,), np.nan)
+    bx = np.full((size,), np.nan)
+    by = np.full((size,), np.nan)
+
+    crystx = np.full((npts, size), np.nan)
+    crysty = np.full((npts, size), np.nan)
+    vnx = np.full((npts, size), np.nan)
+    vny = np.full((npts, size), np.nan)
+
+    # ----------------
+    # compute geometry
+
+    # 2d
+    d2 = lamb0 / np.sin(bragg0)
+
+    # summit of crystal
+    sx = ap[0] + xx * ex[0]
+    sy = ap[1] + xx * ex[1]
+
+    # indices of curved crystals
+    indc = np.isfinite(rcurve)
+
+    # center of curvature
+    cx[indc] = sx[indc] - rcurve[indc] * np.sin(bragg0[indc])
+    cy[indc] = sy[indc] + rcurve[indc] * np.cos(bragg0[indc])
+
+    # half angular opening of crystal
+    dalpha = 0.5*length[indc] / rcurve[indc]
+    theta = (
+        np.pi/2. - bragg0[None, indc]
+        + dalpha * np.linspace(-1, 1, npts)[:, None]
+    )
+
+    # crystal plotting - curved
+    crystx[:, indc] = cx[None, indc] + rcurve[indc][None, :] * np.cos(theta)
+    crysty[:, indc] = cy[None, indc] - rcurve[indc][None, :] * np.sin(theta)
+
+    # crystal plotting - straight
+    ll = 0.5 * length[None, ~indc] * np.linspace(-1, 1, npts)[:, None]
+    crystx[:, ~indc] = sx[None, ~indc] + ll*np.cos(bragg0)[None, ~indc]
+    crysty[:, ~indc] = sy[None, ~indc] + ll*np.sin(bragg0)[None, ~indc]
+
+    # ----------------
+    # compute rays
+
+    # vectors of incident rays
+    vix = crystx - ap[0]
+    viy = crysty - ap[1]
+    vin = np.sqrt(vix**2 + viy**2)
+    vix = vix / vin
+    viy = viy / vin
+
+    # local normal vectors
+    vnx[:, indc] = -np.sin(np.pi/2 - theta)
+    vny[:, indc] = np.cos(np.pi/2. - theta)
+    vnx[:, ~indc] = -np.sin(bragg0[None, ~indc])
+    vny[:, ~indc] = np.cos(bragg0[None, ~indc])
+
+    # reflected vectors
+    sca = vix*vnx + viy*vny
+    vrx = vix - 2.*sca*vnx
+    vry = viy - 2.*sca*vny
+
+    # end of rays at dist
+    endx = crystx + dist * vrx
+    endy = crysty + dist * vry
+
+    # ----------------------
+    # compute spectral range
+
+    # get local bragg angle - top and bottom
+    bragg = np.pi/2. - np.arccos(sca)
+
+    # lamb
+    lamb = d2 * np.sin(bragg)
+
+    # beta_max
+    if beta_max is not None:
+        beta = np.arctan2(crysty - ap[1], crystx - ap[0])
+        ind = np.abs(beta) > beta_max
+        endx[ind] = np.nan
+        endy[ind] = np.nan
+        lamb[ind] = np.nan
+
+    # Dlamb
+    Dlamb = np.nanmax(lamb, axis=0) - np.nanmin(lamb, axis=0)
+
+    return crystx, crysty, endx, endy, lamb, Dlamb
+
+
+# #################################################################
+# #################################################################
+#               Plot
+# #################################################################
+
+
+def _plot(
+    # crystal
+    lamb0=None,
+    bragg0=None,
+    # geometry
+    xx=None,
+    length=None,
+    rcurve=None,
+    dist=None,
+    # computed
+    ap=None,
+    crystx=None,
+    crysty=None,
+    endx=None,
+    endy=None,
+    Dlamb=None,
+    # camera
+    dcam=None,
+    # plotting
+    ax=None,
+    # saving
+    pfe_fig=None,
+    # unused
+    **kwdargs,
+):
+
+    # ----------
+    # prepare
+
+    npts, size = crystx.shape
+
+    # envelop
+    iok = np.isfinite(endx)
+    i0 = tuple([iok[:, ii].nonzero()[0][0] for ii in range(size)])
+    i1 = tuple([iok[:, ii].nonzero()[0][-1] for ii in range(size)])
+    nind = tuple(range(size))
+
+    # envelop
+    envx = np.array([
+        endx[i1, nind], crystx[i1, nind],
+        np.full((size,), ap[0]),
+        crystx[i0, nind], endx[i0, nind],
+    ])
+    envy = np.array([
+        endy[i1, nind], crysty[i1, nind],
+        np.full((size,), ap[1]),
+        crysty[i0, nind], endy[i0, nind],
+    ])
+
+    # central rays
+    ind = int((npts-1)/2)
+    raycx = np.array([np.full((size,), ap[0]), crystx[ind, :], endx[ind, :]])
+    raycy = np.array([np.full((size,), ap[1]), crysty[ind, :], endy[ind, :]])
+
+    # dcam
+    if dcam is not None:
+        ninx, niny = dcam['nin'][:2]
+        e0x, e0y = -niny, ninx
+        clen = dcam['length']
+        camx = dcam['cent'][0] + 0.5*clen*np.r_[-1, 1] * e0x
+        camy = dcam['cent'][1] + 0.5*clen*np.r_[-1, 1] * e0y
+
+    # --------------
+    # prepare figure
+
+    if ax is None:
+        ax = _get_axes()
+
+    # -----------
+    # plot
+
+    for ii in range(size):
+
+        # crystals
+        ll, = ax.plot(
+            crystx[:, ii],
+            crysty[:, ii],
+            ls='-',
+            lw=2,
+            marker='None',
+        )
+
+        # central rays
+        ax.plot(
+            raycx[:, ii],
+            raycy[:, ii],
+            ls='--',
+            lw=1,
+            marker='None',
+            c=ll.get_color(),
+        )
+
+        # edge rays
+        ax.plot(
+            envx[:, ii],
+            envy[:, ii],
+            ls='-',
+            lw=1,
+            marker='None',
+            c=ll.get_color(),
+        )
+
+    # ------------
+    # camera
+
+    if dcam is not None:
+
+        ax.plot(
+            camx,
+            camy,
+            ls='-',
+            lw=2.,
+            marker='None',
+            c='k',
+        )
+
+    # ----------
+    # saving
+
+    if pfe_fig is not None:
+        ax.figure.savefig(pfe_fig, format='png', dpi=200)
+
+    return ax
+
+
+def _get_axes():
+
+    fig = plt.figure()
+    ax = fig.add_axes(
+        [0.1, 0.1, 0.8, 0.8],
+        aspect='equal',
+        adjustable='datalim',
+    )
+
+    ax.set_xlabel("x (m)", size=12)
+    ax.set_xlabel("y (m)", size=12)
+
+    return ax


### PR DESCRIPTION
Main changes:
--------------------
* `tf.spectro.spectral_range_2d()` implemented
    - can plot several crystals simultaneously
    - by default spans whole crystal length but can also be limited by `beta_max` (half-angular opening of beam from aperture) 


Issues:
---------
* Fixes, in devel, issue #779 


Examples:
--------------

```
In [1]: import tofu as tf

In [2]: dcam = {'cent': [4.77, 0.29], 'length': 75e-6*1024*2, 'nin': [-0.2, -0.6]}

In [3]: dout = tf.spectro.spectral_range_2d(bragg0=(np.pi/180)*np.r_[24.6, 24.2, 23.8], lamb0=1.e-10*np.r_[0.944, 2.72, 1.615], xx=4.5, dist=0.6, rcurve=0.65*np.r_[np.inf, np.inf, 1], length=0.15, dcam=dcam, beta_max=np.arctan2(0.05, 12))
```

![image](https://github.com/ToFuProject/tofu/assets/5929562/5a5a7622-a89b-4f28-97f0-c5ce28892e31)



