### PR TITLE
[#785] tf.load() implemented, operational for non-bsplines

### DIFF
--- a/tofu/data/__init__.py
+++ b/tofu/data/__init__.py
@@ -8,3 +8,4 @@ from ._spectrallines_class import *
 from ._class10_algos import get_available_inversions_algo
 from ._class10_Inversion import Inversion as Collection
 from ._spectralunits import *
+from ._saveload import *

--- a/tofu/data/_saveload.py
+++ b/tofu/data/_saveload.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+
+import os
+import datastock as ds
+
+
+__all__ = ['load']
+
+
+# ##################################################################
+# ##################################################################
+#                   Save
+# ##################################################################
+
+
+# ###################################################################
+# ###################################################################
+#               load
+# ###################################################################
+
+
+def load(
+    pfe=None,
+    cls=None,
+    allow_pickle=None,
+    sep=None,
+    verb=None,
+):
+
+    # --------------------
+    # use datastock.load()
+
+    from ._class10_Inversion import Inversion as Collection
+
+    coll = ds.load(
+        pfe=pfe,
+        cls=Collection,
+        allow_pickle=allow_pickle,
+        sep=sep,
+        verb=verb,
+    )
+
+    return coll


### PR DESCRIPTION
Main changes:
--------------------
* `tf.data.load()` implemented, calls `datastock.load()` with `Collection` class
* Uses `datastock` [PR 101](https://github.com/ToFuProject/datastock/pull/101) (available in the next release of `datastock`)


Issues:
----------
* Fixes, in devel, issue #785 

Examples:
----------------

**_Caveat_**: the following only works using the `devel` branch of `datastock` (until next release)

Using `tuto_real0.py` we easily create a Collection populated with several diagnostics:

```
# loading local branches of datastock and tofu
os.chdir('../datastock')
import datatsock
os.chdir('../tofu')
import tofu as tf

test = tf.tests.tests09_tutorials.tuto_real0

conf, coll = test.main()
```

Frist we remove all plasma `mesh` (saving / loading not yet operational for `meshes` / `bsplines`, only for diagnostics, will be implemented later). Removing meshes automatically removes bsplines based on those meshes:
```
coll.remove_mesh(['m0', 'mE', 'mr'])
```

Now we can save `coll` with all its content (all diagnostics and data) using `save()`.
Note you can specify and a `name` (='name' by default).
The file name will be built from the class, provided name, user name and date:
`Inversion_<name>_<user>_<date>-<time>,npz`

```
coll.save()
Saved in:
	/home/didier/Documents/Projects/tofu/Inversion_name_didier_20230619-135404.npz
```

Now we can load it into a separate instance `coll2` and compare its content with `coll` to check they are identical (although separate instances):

```
coll2 = tf.data.load('/home/didier/Documents/Projects/tofu/Inversion_name_didier_20230619-135404.npz')

coll is coll2
False

coll == coll2
True
```

`tofu` uses extensively `datastock` for these saving / loading operations, and for comparing instances.
The way they are compared is:
* each instance is converted to flattened `dict`
* All `(key, value)` pairs are compared one by one
* If differences are found they are listed.



 
