### PR TITLE
Issue801 scope integrated reflectivity

### DIFF
--- a/tofu/data/_class5_check.py
+++ b/tofu/data/_class5_check.py
@@ -52,7 +52,7 @@ def _dmat(
         return dmat
 
     # If using hardcoded known crystal
-    ready_to_compute = False
+    err = False
     if isinstance(dmat, str):
         if dmat not in _rockingcurve_def._DCRYST.keys():
             msg = (
@@ -60,13 +60,50 @@ def _dmat(
             )
             raise Exception(msg)
         dmat = _rockingcurve_def._DCRYST[dmat]
+        ready_to_compute = True
+
+    elif isinstance(dmat, dict):
+        lk = ['name', 'material', 'miller', 'target']
+
+        c0 = (
+            isinstance(dmat.get('drock'), dict)
+            and isinstance(dmat.get('d_hkl'), float)
+        )
+        if isinstance(dmat.get('drock'), dict):
+            if not isinstance(dmat.get('d_hkl'), float):
+                msg = (
+                    "If dmat is provided as a dict with 'drock' "
+                    "(user-provided rocking curve), "
+                    "it must also have:\n"
+                    "\t- 'd_hkl': float\n"
+                    "\t- 'target': {'lamb': float}\n"
+                )
+                raise Exception(msg)
+
+            ready_to_compute = False
+
+        elif all([kk in dmat.keys() for kk in lk]):
+            ready_to_compute = True
+
+        else:
+            err = True
+
+    else:
+        err = True
+
+    # Raise error
+    if err is True:
+        msg = f"Don't know how to interpret dmat for crystal '{key}':\n{dmat}"
+        raise Exception(msg)
+
+    dmat['ready_to_compute'] = ready_to_compute
 
     # ---------------------
     # check dict integrity
     # ---------------------
-    #NOTE: Especially in the case of user-defined crystals
+    # NOTE: Especially in the case of user-defined crystals
 
-    # Check dict typeand content (each key is a valid string)
+    # Check dict type and content (each key is a valid string)
     dmat = ds._generic_check._check_dict_valid_keys(
         var=dmat,
         varname='dmat',
@@ -75,33 +112,6 @@ def _dmat(
         keys_can_be_None=True,
         dkeys=_DMAT_KEYS,
     )
-
-    ready_to_compute = True
-
-    # -----------
-    # safety check
-
-    c0 = (
-        isinstance(dmat.get('d_hkl'), float)
-        and dmat.get('target') is not None
-        and isinstance(dmat['target'].get('lamb'), float)
-    )
-    if not c0:
-        msg = (
-            f"For crystal '{key}', "
-            "if dmat is provided, it should contain at least:\n"
-            "\t- 'd_hkl': inter-reticular planes distance\n"
-            "\t- 'target': {'lamb': float} the target wavelength\n"
-            "Optionally, you can also provide:\n"
-            "\t- 'drock': a sub-dict with the rocking curve:\n"
-            "\t\t- 'angle_rel': (na,) array of angles (rad)\n"
-            "\t\t- 'power_ratio': (na,) array of power ratio\n"
-            "Provided:\n"
-            f"{dmat}"
-        )
-        raise Exception(msg)
-
-    dmat['ready_to_compute'] = ready_to_compute
 
     # -------------------------------
     # check parallelism
@@ -120,12 +130,18 @@ def _dmat(
 
     dref = None
     if ready_to_compute:
+
+        # provide lamb is AA
+        lamb = dmat['target']['lamb']
+        if lamb < 1e-6:
+            lamb *= 1e10
+
         drock = _rockingcurve.compute_rockingcurve(
             # Type of crystal
             crystal=dmat['name'],
             din=dmat,
             # Wavelength
-            lamb=dmat['target']['lamb'],
+            lamb=lamb,     # rocking_curve/py uses AA
             # Lattice modifications
             miscut=dmat['miscut'],
             nn=None,
@@ -163,8 +179,10 @@ def _dmat(
             k0: copy.deepcopy(drock[k0])
             for k0 in lk0
         }
-        dmat['d_hkl'] *= 1e-10
-        dmat['target']['lamb'] *= 1e-10
+
+        if dmat['d_hkl'] > 1e-6:
+            dmat['d_hkl'] *= 1e-10
+        dmat['target']['lamb'] = lamb * 1e-10
 
         dmat['mesh'] = {'type': str(drock['mesh']['type'])}
 
@@ -258,13 +276,13 @@ def _extract_rocking_curve(key=None, drock=None, alpha=None):
         [
             drock['Power ratio'][0, indtref, ind_alpha, :],
             interp1d(
-                drock['Glancing angles'][1, indtref, ind_alpha, :], 
+                drock['Glancing angles'][1, indtref, ind_alpha, :],
                 drock['Power ratio'][1, indtref, ind_alpha, :],
                 bounds_error=False,
                 fill_value=(
-                    drock['Power ratio'][1,indtref,ind_alpha,0], 
+                    drock['Power ratio'][1,indtref,ind_alpha,0],
                     drock['Power ratio'][1,indtref,ind_alpha,-1]
-                    )  
+                    )
                 )(drock['Glancing angles'][0, indtref, ind_alpha, :])
             ],
             axis = 0

--- a/tofu/spectro/__init__.py
+++ b/tofu/spectro/__init__.py
@@ -6,4 +6,5 @@ from ._fit12d import *
 from ._analysis_tools import *
 from ._plot import *
 from ._rockingcurve import *
+from ._rockingcurve_tools import *
 from ._spectralrange2d import *

--- a/tofu/spectro/_rockingcurve.py
+++ b/tofu/spectro/_rockingcurve.py
@@ -234,7 +234,7 @@ def compute_rockingcurve(
         F_im1[ee] = np.sum(f_im[ee]*np.cos(2*np.pi*phase))
         F_im2[ee] = np.sum(f_im[ee]*np.sin(2*np.pi*phase))
 
-    # Sums structure factor compenents over species 
+    # Sums structure factor compenents over species
     F_re_cos = np.sum(F_re1, axis=0) # dim(temp,)
     F_re_sin = np.sum(F_re2, axis=0) # dim(temp,)
 
@@ -299,7 +299,7 @@ def compute_rockingcurve(
             # Zero-order imaginary part (averaged)
             psi0_im[ii] += (
                 -re*(lamb**2)
-                * din['mesh']['positions'][el]['N'] 
+                * din['mesh']['positions'][el]['N']
                 * f_im[ee]
                 )/(np.pi*Volume[ii])
 
@@ -450,11 +450,11 @@ def compute_rockingcurve(
         return dreturn
 
 
-# ####################################################################
-# ####################################################################
+# ################################################################
+# ################################################################
 #               Checks
-# ####################################################################
-# ####################################################################
+# ################################################################
+# ################################################################
 
 
 def _checks(
@@ -482,24 +482,7 @@ def _checks(
     # ------------
     # crystal
 
-    # Builds crystal dictionary
-    try:
-        din = _def._build_cry(crystal=crystal, din=din)
-    
-    # Exception handling
-    except:
-        lk1 = ['material', 'symbol', 'miller', 'target']
-        dstr = {
-            k0: "\n".join([f"\t\t{k1}: {v0[k1]}" for k1 in lk1])
-            for k0, v0 in _def._DCRYST.items()
-        }
-        lstr = [f"\t- {k0}:\n{v0}" for k0, v0 in dstr.items()]
-        msg = (
-            "You must choose a type of crystal from "
-            + "tofu/spectro/_rockingcurve_def.py to use among:\n"
-            + "\n".join(lstr)
-        )
-        raise Exception(msg)
+    din = _def._build_cry(crystal=crystal, din=din)
 
     # lamb
     if lamb is None:
@@ -569,12 +552,12 @@ def _checks(
     )
 
 
-# #############################################################################
-# #############################################################################
+# ################################################################
+# ################################################################
 #          Plot variations of RC components vs temperature & asymetry
 #                        for multiple wavelengths
-# #############################################################################
-# #############################################################################
+# ################################################################
+# ################################################################
 
 
 def plot_var_temp_changes_wavelengths(
@@ -1062,6 +1045,8 @@ def CrystBragg_comp_lattice_spacing(
             msg = (
                 "According to Bragg law, Bragg scattering need d > lamb/2!\n"
                 "Please check your wavelength argument.\n"
+                f"\t- d_atom[{ii}] = {d_atom[ii]}\n"
+                f"\t- lamb/2 = {lamb} / 2.\n"
             )
             raise Exception(msg)
 
@@ -1271,7 +1256,7 @@ def CrystBragg_comp_integrated_reflect(
                     f"\t- bb[{i}, {j}] = {bb[i, j]}\n"
                     f"\t- psi0_im[i] = {psi0_im[i]}\n"
                     f"\t- psi_re[i] = {psi_re[i]}\n"
-                    f"\t- polar[:][{i}] = {polar[:, i]}\n"                    
+                    f"\t- polar[:][{i}] = {polar[:, i]}\n"
                     f"\t- power_ratiob[{i}, {j}, :] = {power_ratiob[i, j, :]}\n"
                     f"\t- al[:, {i}, {j}, :] = {al[:, i, j, :]}\n"
                 )

--- a/tofu/spectro/_rockingcurve.py
+++ b/tofu/spectro/_rockingcurve.py
@@ -1195,7 +1195,7 @@ def CrystBragg_comp_integrated_reflect(
                 ))/np.sqrt(((kk[i])**2 - 1.)**2 + 4.*(rek[i]**2))
                 # Reflecting power
                 power_ratio[h, i, j, ...] = (Fmod[i]/Fbmod[i])*(
-                    al[h, i, j, :] - np.sqrt((al[h, i, j, :]**2) - 1.)
+                    al[h, i, j, :] - np.sqrt(al[h, i, j, :]**2 - 1.)
                 )
                 # Power ratio maximum and its index
                 max_pr[h,i,j] = np.nanmax(power_ratio[h,i,j])
@@ -1257,12 +1257,26 @@ def CrystBragg_comp_integrated_reflect(
             P_dyn[i, j] = np.sum(rhg[:, i, j])/2.
             if P_dyn[i, j] < 1e-9:
                 msg = (
-                    "Please check the equations for integrated reflectivity:\n"
-                    "the value of P_dyn ({}) is less than 1e-9.\n".format(
-                        P_dyn[j],
-                    )
+                    "Please check the equations for integrated reflectivity, "
+                    "some values lower than 1e-9:\n"
+                    f"\t- P_dyn[{i}, {j}] = {P_dyn[i, j]}\n"
+                    f"\t- rhg[:, {i}, {j}] = {rhg[:, i, j]}\n"
+                    f"\t- conv_ygscale[:, {i}, {j}] = {conv_ygscale[:, i, j]}\n"
+                    f"\t- rhy[{i}, {j}] = {rhy[i, j]}\n"
+                    f"\t- dy = {np.mean(dy)}\n"
+                    f"\t- Fmod[{i}]/Fbmod[{i}] = {Fmod[i]/Fbmod[i]}\n"
+                    f"\t- g[:, {i}, {j}] = {g[:, i, j]}\n"
+                    f"\t- kk[{i}] = {kk[i]}\n"
+                    f"\t- rek[{i}] = {rek[i]}\n"
+                    f"\t- bb[{i}, {j}] = {bb[i, j]}\n"
+                    f"\t- psi0_im[i] = {psi0_im[i]}\n"
+                    f"\t- psi_re[i] = {psi_re[i]}\n"
+                    f"\t- polar[:][{i}] = {polar[:, i]}\n"                    
+                    f"\t- power_ratiob[{i}, {j}, :] = {power_ratiob[i, j, :]}\n"
+                    f"\t- al[:, {i}, {j}, :] = {al[:, i, j, :]}\n"
                 )
                 raise Exception(msg)
+
             # Coordinates of full width at mid high sides of FWHM
             hmx_perp = half_max_x(dth[0, i, j, :], power_ratio[0, i, j, :])
             hmx_para = half_max_x(dth[1, i, j, :], power_ratio[1, i, j, :])

--- a/tofu/spectro/_rockingcurve_def.py
+++ b/tofu/spectro/_rockingcurve_def.py
@@ -145,11 +145,11 @@ _DCRYST_MAT = {
         },
         'sin_theta_lambda': {
             'Ge': np.r_[
-                0., 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 
-                0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1., 1.1, 1.2, 
+                0., 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35,
+                0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1., 1.1, 1.2,
                 1.3, 1.4, 1.5
             ], # [1/AA],
-            'sources': 
+            'sources':
                 'Int. Tab. X-Ray Crystallography, Vol.I,II,III,IV (1985), Table 3.3.1A',
         },
         'atomic_scattering': {
@@ -157,11 +157,11 @@ _DCRYST_MAT = {
                 'Ge': np.r_[
                     32.0, 31.28, 29.52, 27.48, 25.53, 23.76,
                     22.11, 20.54, 19.02, 16.19, 13.72, 11.68,
-                    10.08, 8.87, 7.96, 7.29, 6.77, 6.37, 
+                    10.08, 8.87, 7.96, 7.29, 6.77, 6.37,
                     6.02, 5.72
                 ]
             },
-            'sources': 
+            'sources':
                 'Int. Tab. X-Ray Crystallography, Vol.I,II,III,IV (1985), Table 3.3.1A',
         },
     },
@@ -371,7 +371,7 @@ def _positions_germanium(
     dcryst_mat[k0]['mesh']['positions']['Ge']['N'] = np.size(
         dcryst_mat[k0]['mesh']['positions']['Ge']['x']
     )
-    
+
 
 
 # ##################################################################
@@ -599,6 +599,17 @@ def _complement_dict_cut(dcryst_mat=None, dcryst_cut=None):
         # ------------------------
         # complement with material
 
+        # safety check on material
+        if v0.get('material') not in dcryst_mat.keys():
+            lstr = [f"\t- '{k0}'" for k0 in dcryst_mat.keys()]
+            msg = (
+                f"Please, for '{k0}', select a material from:\n"
+                + "\n".join(lstr)
+                + f"\nProvided: {v0.get('material')}\n"
+            )
+            raise Exception(msg)
+
+        # complement dict
         for k1, v1 in dcryst_mat[v0['material']].items():
             dcryst_cut[k0][k1] = copy.deepcopy(v1)
 
@@ -737,7 +748,7 @@ _complement_dict_cut(dcryst_mat=_DCRYST_MAT, dcryst_cut=_DCRYST)
 def _build_cry(
     crystal=None,
     din=None,
-    ):
+):
     '''
     _build_cry is a function meant to populate a crystal dictionary
     using either hardcoded WEST default crystal names ['Quartz_110', 'Quartz_102']
@@ -767,7 +778,7 @@ def _build_cry(
     elif isinstance(din, dict):
         dcry = {
             crystal: din
-            }
+        }
 
     # Builds the crystal dictionary
     _complement_dict_cut(dcryst_mat=_DCRYST_MAT, dcryst_cut=dcry)

--- a/tofu/spectro/_rockingcurve_tools.py
+++ b/tofu/spectro/_rockingcurve_tools.py
@@ -47,7 +47,7 @@ def scope_reflected_intensities(
     
     """
     
-    Provide target_lamb in AA
+    Provide target_lamb in m
     
     """
 

--- a/tofu/spectro/_rockingcurve_tools.py
+++ b/tofu/spectro/_rockingcurve_tools.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Jul  7 16:34:30 2023
+
+@author: dvezinet
+"""
+
+import itertools as itt
+
+
+import numpy as np
+from scipy.interpolate import interp1d
+import datastock as ds
+import matplotlib.pyplot as plt
+import matplotlib.lines as mlines
+
+
+from . import _rockingcurve as rc
+
+
+__all__ = [
+    'scope_reflected_intensities',
+]
+
+
+_DMARKER = {
+    'Germanium': {'marker': 'o', 'ms': 8, 'mfc': 'None', 'lw': 2},
+    'Quartz': {'marker': 'x', 'ms': 8, 'lw': 2},
+}
+
+
+###########################################################
+#
+#           Scope over integrated reflectivity
+#
+###########################################################
+
+
+def scope_reflected_intensities(
+    miller_max=None,
+    target_lamb=None,
+    materials=None,  
+    # plotting
+    dmarker=None,
+    tit=None,
+):
+    
+    """
+    
+    Provide target_lamb in AA
+    
+    """
+
+    # -------------------
+    # check input
+    # -------------------
+    
+    # miller_max
+    miller_max = int(ds._generic_check._check_var(
+        miller_max, 'miller_max',
+        types=(int, float),
+        default=10,
+        sign='>0',
+    ))
+    
+    # materials
+    lok = ['Quartz', 'Germanium']
+    if isinstance(materials, str):
+        materials = [materials]
+    materials = list(ds._generic_check._check_var_iter(
+        materials, 'materials',
+        types=(list, tuple),
+        types_iter=str,
+        default=lok,
+        allowed=lok,
+    ))
+    
+    # target_bragg
+    target_lamb = ds._generic_check._check_flat1darray(
+        target_lamb, 'target_lamb',
+        sign='>0',
+    )
+    
+    # dmarker
+    if dmarker is None:
+        dmarker = _DMARKER
+        
+    # tit
+    tit = ds._generic_check._check_var(
+        tit, 'tit',
+        types=str,
+        default="Scoping integrated reflectivity",
+    )
+    
+    # -------------------
+    # Prepare
+    # -------------------
+    
+    ddd = miller_max + 1
+    
+    dout = {
+        'materials': materials,
+        'target_lamb': target_lamb,
+        'miller_max': miller_max,
+        'reflectivity': {
+            k0: {
+                k1: {
+                    'Bragg': np.full((ddd, ddd, ddd), np.nan),
+                    'Rint':  np.full((ddd, ddd, ddd), np.nan),
+                    'miller': np.full((ddd, ddd, ddd), 'hkl', dtype='S3')
+                }
+                for k1 in target_lamb
+            }
+            for k0 in materials
+        },
+    }    
+
+    # miller indices ranges
+    rangeh = np.arange(0, miller_max + 1)
+    rangek = np.arange(0, miller_max + 1)
+    rangel = np.arange(0, miller_max + 1)
+
+    # -------------------
+    # computing
+    # -------------------
+    
+    # Loop over materials
+    for lamb0, mat in itt.product(target_lamb, materials):
+        results = dout['reflectivity'][mat][lamb0]
+    
+        # Loop over Miller indices
+        for hh, kk, ll in itt.product(rangeh, rangek, rangel):
+        
+            # skip bulk reflection
+            if hh == 0 and kk == 0 and ll == 0:
+                continue
+ 
+            # Builds material matrix
+            dcry4 = {
+                'material': mat,
+                'name': 'SCOPING',
+                'symbol': f"{mat[:2]}{hh}{kk}{ll}",
+                'miller': np.r_[hh, kk, ll],
+                'target': {
+                    # 'ion': 'Kr34+',
+                    'lamb': lamb0 * 1e10,
+                    'units': 'A',
+                    },
+                'd_hkl': None,
+            }
+ 
+            results['miller'][hh, kk, ll] = f"{hh}{kk}{ll}"
+ 
+            # Calculates rocking curve
+            try:
+                
+                dout4 = rc.compute_rockingcurve(
+                    crystal=dcry4['name'],
+                    din=dcry4,
+                    lamb=dcry4['target']['lamb'], 
+                    plot_power_ratio=False,
+                )
+    
+                results['Bragg'][hh,kk,ll] = dout4['Bragg angle of reference (rad)']*180/np.pi
+    
+                results['Rint'][hh,kk,ll] = np.trapz(
+                    np.nanmean(
+                        [
+                            dout4['Power ratio'][0,0,0,:],
+                            interp1d(
+                                dout4['Glancing angles'][1,0,0,:],
+                                dout4['Power ratio'][1,0,0,:],
+                                bounds_error=False,
+                                fill_value = (
+                                    dout4['Power ratio'][1,0,0,0],
+                                    dout4['Power ratio'][1,0,0,-1],
+                                )
+                            )(dout4['Glancing angles'][0,0,0,:]),
+                        ],
+                        axis=0,
+                    ),
+                    dout4['Glancing angles'][0,0,0,:],
+                )
+
+            except:
+                pass
+ 
+    # -------------------
+    # plotting
+    # -------------------
+        
+    # figure
+    fig = plt.figure(figsize=(12, 8))
+    fig.suptitle(tit, size=14, fontweight='bold')
+    
+    # axes
+    ax = fig.add_axes([0.1, 0.1, 0.7, 0.8], yscale='log')
+    ax.set_xlabel(r'$\theta_B$ [deg]', size=12)
+    ax.set_ylabel('Integrated reflectivity [rad]', size=12)
+    ax.set_title(f"max miller index = {miller_max}", size=12, fontweight='bold')
+    ax.grid('on')
+    
+    # plotting
+    dcolor = {lamb0: None for lamb0 in target_lamb}
+    for lamb0 in target_lamb:
+        
+        for ii, mat in enumerate(materials):
+            
+            li, = ax.plot(
+                dout['reflectivity'][mat][lamb0]['Bragg'].flatten(),
+                dout['reflectivity'][mat][lamb0]['Rint'].flatten(),
+                ls='None',
+                label=mat,
+                color=dcolor[lamb0],
+                **dmarker[mat],
+            )
+            if ii == 0:
+                dcolor[lamb0] = li.get_color()
+    
+    # -----------------------
+    # legend proxys
+    
+    # legend proxys for lamb
+    lh = [
+        mlines.Line2D([], [], color=dcolor[lamb0], ls='-')
+        for lamb0 in target_lamb
+    ]
+    llab = [f"{lamb0*1e10: 5.3} AA" for lamb0 in target_lamb]
+    legend0 = ax.legend(
+        lh,
+        llab,
+        bbox_to_anchor=(1.05, 1),
+        loc='upper left', 
+        borderaxespad=0.,
+    )
+    ax.add_artist(legend0)
+    
+    # legend proxys for material
+    lh = [
+        mlines.Line2D([], [], color='k', ls='None', **dmarker[mat])
+        for mat in materials
+    ]
+    ax.legend(
+        lh,
+        materials,
+        bbox_to_anchor=(1.05, 0),
+        loc='lower left', 
+        borderaxespad=0.,
+    )
+    
+    # -------------------
+    # return
+    # -------------------
+
+    return dout, ax

--- a/tofu/tests/tests09_tutorials/tuto_real0.py
+++ b/tofu/tests/tests09_tutorials/tuto_real0.py
@@ -581,11 +581,11 @@ def _crystals(coll=None, crystals=None):
             },
             # 'dmat': 'Quartz_110',
             'dmat': {
-                'd_hkl': 0.944e-10 / (2*np.sin(24.2*np.pi/180.)),
-                'target': {
-                    'lamb': 0.944e-10,
-                },
-                'drock': drock,
+                'material': 'Germanium',
+                'name': 'Ge224',
+                'miller': np.r_[2,2,4],
+                # 'd_hkl': 0.944e-10 / (2*np.sin(24.2*np.pi/180.)),
+                'target': {'lamb': 0.944e-10},
             },
             'configuration': 'von hamos',
         }


### PR DESCRIPTION
Main changes:
-----------------
* `tf.spectro.scope_reflected_intensities()` implemented
    - basically based on the [MWE](https://github.com/ToFuProject/tofu/pull/796#issuecomment-1625663599) from PR #796 
    - also allows to plot simultaneously several desired wavelengths
    - `wavelength` are color-coded, `materials` are marker-coded 
* To be used as a practical one-liner to quickly get an overview of solutions for several wavelengths and materials

Issues:
-------
Fixes, in devel, issue #801 


Examples:
-----------

```
import tofu as tf

dout, ax = tf.spectro.scope_reflected_intensities(target_lamb=np.r_[0.944, 1.630, 2.72]*1e-10)
```

![image](https://github.com/ToFuProject/tofu/assets/5929562/0d22c601-5f5a-4681-b8fd-a848c9a1f57c)


