### PR TITLE
Issue808 sinograms

### DIFF
--- a/tofu/data/_class02_Rays.py
+++ b/tofu/data/_class02_Rays.py
@@ -359,12 +359,16 @@ class Rays(Previous):
             connect=connect,
         )
 
+    # --------------
+    # sinogram
+    # --------------
 
     def get_sinogram(
         self,
         key=None,
         # config
         config=None,
+        kVes=None,
         # sinogram ref
         R0=None,
         Z0=None,
@@ -374,10 +378,13 @@ class Rays(Previous):
         impact_pos=None,
         pmax=None,
         # plotting options
+        plot=None,
         sketch=None,
         color=None,
         marker=None,
         label=None,
+        # other options
+        verb=None,
         # figure
         dax=None,
         dmargin=None,
@@ -401,6 +408,7 @@ class Rays(Previous):
             key=key,
             # config
             config=config,
+            kVes=kVes,
             # sinogram ref
             R0=R0,
             Z0=Z0,
@@ -410,10 +418,13 @@ class Rays(Previous):
             impact_pos=impact_pos,
             pmax=pmax,
             # plotting options
+            plot=plot,
             sketch=sketch,
             color=color,
             marker=marker,
             label=label,
+            # other options
+            verb=verb,
             # figure
             dax=dax,
             dmargin=dmargin,

--- a/tofu/data/_class02_Rays.py
+++ b/tofu/data/_class02_Rays.py
@@ -15,15 +15,16 @@ from ._class01_Plasma2D import Plasma2D as Previous
 from . import _class2_check as _check
 from . import _class2_compute as _compute
 from . import _class2_plot as _plot
+from . import _class2_sinogram as _sinogram
 
 
 __all__ = ['Rays']
 
 
-# #############################################################################
-# #############################################################################
-#                           Diagnostic
-# #############################################################################
+# ##############################################################
+# ##############################################################
+#                       Rays
+# ##############################################################
 
 
 class Rays(Previous):
@@ -268,7 +269,7 @@ class Rays(Previous):
         return_pts=None,
         return_itot=None,
     ):
-        """ Return the tangancy radius to an axis of each ray segment
+        """ Return the tangency radius to an axis of each ray segment
 
         parameters
         ----------
@@ -356,4 +357,66 @@ class Rays(Previous):
             nlos=nlos,
             dinc=dinc,
             connect=connect,
+        )
+
+
+    def get_sinogram(
+        self,
+        key=None,
+        # config
+        config=None,
+        # sinogram ref
+        R0=None,
+        Z0=None,
+        # sinogram options
+        ang=None,
+        ang_units=None,
+        impact_pos=None,
+        pmax=None,
+        # plotting options
+        sketch=None,
+        color=None,
+        marker=None,
+        label=None,
+        # figure
+        dax=None,
+        dmargin=None,
+        fs=None,
+        wintit=None,
+    ):
+        """ plot the sinogram of a set of rays / diagnostic LOS
+
+        Optionally plot also the configuration
+
+        The sinogram can be plotted with:
+            * ang = 'ksi' or 'theta'
+            * ang_units = 'rad' or 'deg'
+            * impact_pos = True or False
+            * sketch = True or False
+
+        """
+
+        return _sinogram.sinogram(
+            coll=self,
+            key=key,
+            # config
+            config=config,
+            # sinogram ref
+            R0=R0,
+            Z0=Z0,
+            # sinogram options
+            ang=ang,
+            ang_units=ang_units,
+            impact_pos=impact_pos,
+            pmax=pmax,
+            # plotting options
+            sketch=sketch,
+            color=color,
+            marker=marker,
+            label=label,
+            # figure
+            dax=dax,
+            dmargin=dmargin,
+            fs=fs,
+            wintit=wintit,
         )

--- a/tofu/data/_class2_plot.py
+++ b/tofu/data/_class2_plot.py
@@ -16,112 +16,10 @@ from . import _generic_check
 from . import _generic_plot
 
 
-# ##################################################################
-# ##################################################################
-#                           plot check
-# ##################################################################
-
-
-def _plot_rays_check(
-    coll=None,
-    key=None,
-    mode=None,
-    concatenate=None,
-    # figure
-    proj=None,
-    # interactivity
-    color_dict=None,
-    nlos=None,
-    connect=None,
-):
-
-    # -------
-    # key
-
-    lok = list(coll.dobj.get('rays', {}).keys())
-    key = ds._generic_check._check_var(
-        key, 'key',
-        types=str,
-        allowed=lok,
-    )
-
-    ref = coll.dobj['rays'][key]['ref']
-    nrays = np.prod(coll.dobj['rays'][key]['shape'])
-    
-    # ------------
-    # concatenate
-
-    concatenate = ds._generic_check._check_var(
-        concatenate, 'concatenate',
-        types=bool,
-        default=True,
-    )
-
-    # -----
-    # mode
-    
-    lok = ['rel']
-    if concatenate is True:
-        lok += ['abs']
-    mode = ds._generic_check._check_var(
-        mode, 'mode',
-        types=str,
-        default='rel',
-        allowed=lok,
-    )
-
-    # -----
-    # proj
-
-    proj = _generic_plot._proj(
-        proj=proj,
-        pall=['cross', 'hor', '3d', 'camera'],
-    )
-
-    # -------
-    # color_dict
-
-    if color_dict is None:
-        lc = ['r', 'g', 'b', 'm', 'c', 'y']
-        color_dict = {
-            'x': lc,
-            'y': lc,
-        }
-
-    # -------
-    # nlos
-
-    nlos = ds._generic_check._check_var(
-        nlos, 'nlos',
-        types=int,
-        default=5,
-    )
-
-    # -------
-    # connect
-
-    connect = ds._generic_check._check_var(
-        connect, 'connect',
-        types=bool,
-        default=True,
-    )
-
-    return (
-        key,
-        ref,
-        mode,
-        concatenate,
-        proj,
-        color_dict,
-        nlos,
-        connect,
-    )
-
-
-# ##################################################################
-# ##################################################################
+# ###############################################################
+# ###############################################################
 #                           plot main
-# ##################################################################
+# ###############################################################
 
 
 def _plot_rays(
@@ -184,7 +82,7 @@ def _plot_rays(
         rays_x = rays_x.reshape(shape)
         rays_y = rays_y.reshape(shape)
         rays_z = rays_z.reshape(shape)
-    
+
     rays_r = np.hypot(rays_x, rays_y)
 
     # -----------------
@@ -287,3 +185,105 @@ def _plot_rays(
             plot_config.plot(lax=ax, proj=kax)
 
     return dax
+
+
+# ###############################################################
+# ###############################################################
+#                           plot check
+# ###############################################################
+
+
+def _plot_rays_check(
+    coll=None,
+    key=None,
+    mode=None,
+    concatenate=None,
+    # figure
+    proj=None,
+    # interactivity
+    color_dict=None,
+    nlos=None,
+    connect=None,
+):
+
+    # -------
+    # key
+
+    lok = list(coll.dobj.get('rays', {}).keys())
+    key = ds._generic_check._check_var(
+        key, 'key',
+        types=str,
+        allowed=lok,
+    )
+
+    ref = coll.dobj['rays'][key]['ref']
+    nrays = np.prod(coll.dobj['rays'][key]['shape'])
+
+    # ------------
+    # concatenate
+
+    concatenate = ds._generic_check._check_var(
+        concatenate, 'concatenate',
+        types=bool,
+        default=True,
+    )
+
+    # -----
+    # mode
+
+    lok = ['rel']
+    if concatenate is True:
+        lok += ['abs']
+    mode = ds._generic_check._check_var(
+        mode, 'mode',
+        types=str,
+        default='rel',
+        allowed=lok,
+    )
+
+    # -----
+    # proj
+
+    proj = _generic_plot._proj(
+        proj=proj,
+        pall=['cross', 'hor', '3d'],
+    )
+
+    # -------
+    # color_dict
+
+    if color_dict is None:
+        lc = ['r', 'g', 'b', 'm', 'c', 'y']
+        color_dict = {
+            'x': lc,
+            'y': lc,
+        }
+
+    # -------
+    # nlos
+
+    nlos = ds._generic_check._check_var(
+        nlos, 'nlos',
+        types=int,
+        default=5,
+    )
+
+    # -------
+    # connect
+
+    connect = ds._generic_check._check_var(
+        connect, 'connect',
+        types=bool,
+        default=True,
+    )
+
+    return (
+        key,
+        ref,
+        mode,
+        concatenate,
+        proj,
+        color_dict,
+        nlos,
+        connect,
+    )

--- a/tofu/data/_class2_sinogram.py
+++ b/tofu/data/_class2_sinogram.py
@@ -784,7 +784,7 @@ def _check_plot(
 
     pmax = float(ds._generic_check._check_var(
         pmax, 'pmax',
-        types=(float, int, np.float, np.int),
+        types=(float, int),
         sign='>=0',
     ))
 

--- a/tofu/data/_class2_sinogram.py
+++ b/tofu/data/_class2_sinogram.py
@@ -114,12 +114,14 @@ def sinogram(
     # compute for config
     # -----------------
 
-    dout_config = _compute_config(
-        config=config,
-        kVes=kVes,
-        R0=R0,
-        Z0=Z0,
-    )
+    dout_config = None
+    if config is not None:
+        dout_config = _compute_config(
+            config=config,
+            kVes=kVes,
+            R0=R0,
+            Z0=Z0,
+        )
 
     # ------------
     # adjust

--- a/tofu/data/_class2_sinogram.py
+++ b/tofu/data/_class2_sinogram.py
@@ -1,0 +1,734 @@
+# -*- coding: utf-8 -*-
+
+
+# Built-in
+import warnings
+import itertools as itt
+
+
+# Common
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+from matplotlib.gridspec import GridSpec
+import datastock as ds
+
+
+# specific
+from . import _generic_check
+from . import _generic_plot
+
+
+# ###############################################################
+# ###############################################################
+#                       Compute
+# ###############################################################
+
+
+def sinogram(
+    coll=None,
+    key=None,
+    # config
+    config=None,
+    # sinogram ref point
+    R0=None,
+    Z0=None,
+    # sinogram options
+    ang=None,
+    ang_units=None,
+    impact_pos=None,
+    pmax=None,
+    # plotting options
+    plot=None,
+    color=None,
+    marker=None,
+    label=None,
+    sketch=None,
+    # figure
+    dax=None,
+    dmargin=None,
+    fs=None,
+    wintit=None,
+):
+
+    # -----------------
+    # check
+    # -----------------
+
+    (
+        key,
+        # config
+        config,
+        # sinogram options
+        ang,
+        ang_units,
+        impact_pos,
+        # plotting options
+        plot,
+    ) = _check(**locals())
+
+    # -----------------
+    # get R0, Z0
+    # -----------------
+
+    R0, Z0 = _get_RZ0(R0=R0, Z0=Z0, config=config)
+
+    # -----------------
+    # compute for rays
+    # -----------------
+
+    dout = {}
+    for k0 in key:
+        dout[k0] = _compute_rays(
+            coll=coll,
+            kray=k0,
+            R0=R0,
+            Z0=Z0,
+        )
+
+    # -----------------
+    # compute for config
+    # -----------------
+
+    # dout_config = _compute_config()
+    dout_config = None
+
+    # ------------
+    # adjust
+    # ------------
+
+    # convert impact parameter
+    if impact_pos is False:
+        for k0, v0 in dout.items():
+            ineg = v0['ang'] < 0.
+            dout[k0]['impact'][ineg] = -v0['impact'][ineg]
+            dout[k0]['ang'][ineg] = np.arctan2(
+                np.sin(v0['ang'][ineg] + np.pi),
+                np.cos(v0['ang'][ineg] + np.pi),
+            )
+
+    # convert angle
+    if ang == 'ksi':
+        for k0, v0 in dout.items():
+            dout[k0]['ang'] = np.arctan2(
+                np.sin(v0['ang'] - np.pi/2.),
+                np.cos(v0['ang'] - np.pi/2.),
+            )
+
+    # convert angle units
+    if ang_units == 'deg':
+        for k0, v0 in dout.items():
+            dout[k0]['ang'] = v0['ang'] * 180 / np.pi
+
+    # store in dict
+    for k0, v0 in dout.items():
+        dout[k0]['ang_var'] = ang
+        dout[k0]['ang_units'] = ang_units
+        dout[k0]['impact_pos'] = impact_pos
+
+
+    # ------------
+    # plot
+    # ------------
+
+    if plot is True:
+
+        dax = _plot(
+            dout=dout,
+            # sinogram ref point
+            R0=R0,
+            Z0=Z0,
+            # sinogram options
+            ang=ang,
+            ang_units=ang_units,
+            impact_pos=impact_pos,
+            pmax=pmax,
+            # plotting options
+            color=color,
+            marker=marker,
+            label=label,
+            sketch=sketch,
+            # figure
+            dax=dax,
+            dmargin=dmargin,
+            fs=fs,
+            wintit=wintit,
+        )
+
+        return dout, dax
+
+    return dout
+
+
+# ###############################################################
+# ###############################################################
+#                       Check
+# ###############################################################
+
+
+def _check(
+    coll=None,
+    key=None,
+    # config
+    config=None,
+    # sinogram ref point
+    R0=None,
+    Z0=None,
+    # sinogram options
+    ang=None,
+    ang_units=None,
+    impact_pos=None,
+    # plotting options
+    plot=None,
+    # unused
+    **kwdargs,
+):
+
+    # -------------
+    # key
+    # -------------
+
+    # allowed
+    lrays = list(coll.dobj.get('rays', {}).keys())
+    ldiag = list(coll.dobj.get('diagnostic', {}).keys())
+
+    if isinstance(key, str):
+        key = [key]
+
+    # check
+    key = ds._generic_check._check_var_iter(
+        key, 'key',
+        types=list,
+        types_iter=str,
+        allowed=ldiag + lrays,
+    )
+
+    # if diag => single
+    if any([ss in ldiag for ss in key]) and len(key) != 1:
+        msg = (
+            "Arg key must be either a list of ray keys or a single diag key!\n"
+            f"Provided: {key}"
+        )
+        raise Exception(msg)
+
+    # convrt to list of rays
+    if key[0] in ldiag:
+        key = []
+
+    # -------------------
+    # config
+
+    if config is not None:
+        pass
+
+    # ------------
+    # ang
+
+    ang = ds._generic_check._check_var(
+        ang, 'ang',
+        types=str,
+        default='xi',
+        allowed=['xi', 'theta'],
+    )
+
+    # ------------
+    # ang_units
+
+    ang_units = ds._generic_check._check_var(
+        ang_units, 'ang_units',
+        types=str,
+        default='deg',
+        allowed=['deg', 'radian'],
+    )
+
+    # ------------
+    # impact_pos
+
+    impact_pos = ds._generic_check._check_var(
+        impact_pos, 'impact_pos',
+        types=bool,
+        default=True,
+    )
+
+    # ------------
+    # plot
+
+    plot = ds._generic_check._check_var(
+        plot, 'plot',
+        types=bool,
+        default=True,
+    )
+
+    return (
+        key,
+        # config
+        config,
+        # sinogram options
+        ang,
+        ang_units,
+        impact_pos,
+        # plotting options
+        plot,
+    )
+
+
+def _get_RZ0(
+    R0=None,
+    Z0=None,
+    config=None,
+):
+
+    # ------------
+    # R0
+
+    if R0 is None:
+        if config is None:
+            msg = "Please provide a value for R0!"
+            raise Exception(msg)
+
+    # ------------
+    # Z0
+
+    if Z0 is None:
+        if config is None:
+            Z0 = 0.
+
+        else:
+            pass
+
+    return R0, Z0
+
+# ###############################################################
+# ###############################################################
+#               Compute - rays
+# ###############################################################
+
+
+def _compute_rays(
+    coll=None,
+    kray=None,
+    R0=None,
+    Z0=None,
+):
+
+    # --------------------------------
+    # compute (for first segment only)
+
+    # starting points
+    ptsx, ptsy, ptsz = coll.get_rays_pts(kray)
+    ptsx, ptsy, ptsz = ptsx[0, ...], ptsy[0, ...], ptsz[0, ...]
+
+    # unit vectors
+    vectx, vecty, vectz = coll.get_rays_vect(kray, norm=True)
+    vectx, vecty, vectz = vectx[0, ...], vecty[0, ...], vectz[0, ...]
+    vnorm2d = np.sqrt(vectx**2 + vecty**2)
+
+    # dphi
+    phi = np.arctan2(ptsy, ptsx)
+    cosdphi = np.cos(phi) * vectx / vnorm2d + np.sin(phi) * vecty / vnorm2d
+    dphi = np.arccos(np.abs(cosdphi))
+
+    # ----------------------
+    # solve k / AM = k v and AC = ZA ez + RA eRA
+
+    # Z = ZA + k (v.ez)
+    # R^2 = RA^2 + k^2 vpar^2 + 2 k RA (v.erA)
+    # R eR.v = RA eRA.v + (ZA - Z) vz + k
+    # AM.v = k = AC.v + R0 eR.v + p er.v (=0)
+    # ( R0 (R eR.v) )^2 = ( R [k - AC.v]  )^2
+    #
+    # Thus:
+    # R0^2 [ (ZA - Z) vz + RA eRA.v + k]^2 = R^2 [ k - AC.v ]^2
+    # R0^2 [ -k vz^2 + RA eRA.v + k]^2 = R^2 [ k - AC.v ]^2
+    # R0^2 [ k vpar^2 + RA eRA.v]^2 = R^2 [ k + CA.v ]^2
+    #
+    # R0^2 [ k^2 vpar^4 + 2 k vpar^2 RA (eRA.v) + RA^2 (eRA.v)^2 ]
+    # = [RA^2 + k^2 vpar^2 + 2 k RA (erA.v)] [ k^2 + 2k (CA.v) + (CA.v)^2 ]
+    #
+    # Polynom deg 4 = 0
+    # k^4:
+    #   vpar^2
+    # k^3:
+    #   2(CA.v) vpar^2 + 2RA (eRA.v)
+    # k^2:
+    #   vpar^2 (CA.v)^2 + 4RA(erA.v)(CA.v) + RA^2 - R0^2 vpar^4
+    # k:
+    #   2RA (eRA.v)(CA.v)^2 + 2(CA.v)RA^2 - 2 R0^2 vpar^2 RA (eRA.v)
+    # 0:
+    #   RA^2 (CA.v)^2 - R0^2 RA^2 (eRA.v)^2
+
+    CAv = ptsx * vectx + ptsy * vecty + (ptsz - Z0) * vectz
+    vpar2 = vnorm2d**2
+    RA = np.hypot(ptsx, ptsy)
+    eRAv = np.cos(phi) * vectx + np.sin(phi) * vecty
+
+    c4 = vpar2
+    c3 = 2*CAv * vpar2 + 2*RA * eRAv
+    c2 = vpar2 * CAv**2 + 4*RA*eRAv*CAv + RA**2 - R0**2 * vpar2**2
+    c1 = 2*RA * eRAv * CAv**2 + 2*CAv*RA**2 - 2*R0**2 * vpar2 * RA * eRAv
+    c0 = RA**2 * CAv**2 - R0**2 * RA**2 * eRAv**2
+
+    # --------------------------------
+    # loop on rays
+
+    linds = [range(ss) for ss in ptsx.shape]
+
+    dwarn = {}
+    roots0 = np.full(ptsx.shape, np.nan)
+    for ind in itt.product(*linds):
+
+        # define polynomial
+        poly = np.polynomial.polynomial.Polynomial(
+            [c0[ind], c1[ind], c2[ind], c3[ind], c4[ind]]
+        )
+
+        # roots
+        roots = poly.roots()
+        iok = np.isreal(roots)
+        iok[iok] = roots[iok] >= 0
+
+        nsol = np.sum(iok)
+        if nsol > 2:
+            dwarn[ind] = nsol
+
+        elif nsol == 2:
+            roots0[ind] = np.min(roots[iok])
+
+        else:
+            roots0[ind] = roots[iok]
+
+    # -----------------------
+    # warnings
+
+    if len(dwarn) > 0:
+        lstr = [f"\t- {k0}: {v0}" for k0, v0 in dwarn.items()]
+        msg = (
+            "\nSinogram computation\n"
+            f"The following rays of '{kray}' have non-unique solutions:\n"
+            + "\n".join(lstr)
+        )
+        warnings.warn(msg)
+
+    # -----------------------
+    # derive impact and angle
+
+    impact = np.full(ptsx.shape, np.nan)
+    ang = np.full(ptsx.shape, np.nan)
+
+    iok = np.isfinite(roots0)
+
+    rootsx = ptsx[iok] + roots0[iok] * vectx[iok]
+    rootsy = ptsy[iok] + roots0[iok] * vecty[iok]
+    rootsz = ptsx[iok] + roots0[iok] * vectz[iok]
+
+    rootphi = np.arctan2(rootsy, rootsx)
+    dMx = rootsx - R0*np.cos(rootphi)
+    dMy = rootsy - R0*np.sin(rootphi)
+    dMz = rootsz - Z0
+
+    impact[iok] = np.sqrt(dMx**2 + dMy**2 + dMz**2)
+    ang[iok] = np.arctan2(dMz, dMx*np.cos(rootphi) + dMy*np.sin(rootphi))
+
+    # ------------
+    # format ouput
+
+    dout = {
+        'R0': R0,
+        'Z0': Z0,
+        'root_kk': roots0,
+        'root_ptx': rootsx,
+        'root_pty': rootsy,
+        'root_ptz': rootsz,
+        'impact': impact,
+        'ang': ang,
+        'dphi': dphi,
+    }
+
+    return dout
+
+
+# ###############################################################
+# ###############################################################
+#               Plot
+# ###############################################################
+
+
+def _plot(
+    dout=None,
+    dout_config=None,
+    # sinogram ref point
+    R0=None,
+    Z0=None,
+    # sinogram options
+    ang=None,
+    ang_units=None,
+    impact_pos=None,
+    pmax=None,
+    # plotting options
+    color=None,
+    marker=None,
+    label=None,
+    sketch=None,
+    # figure
+    dax=None,
+    dmargin=None,
+    fs=None,
+    wintit=None,
+):
+
+    # --------------
+    # check
+
+    (
+        dprops,
+        sketch,
+        dax,
+    ) = _check_plot(**locals())
+
+    # -----------
+    # prepare
+
+
+    # -----------
+    # plot
+
+    # sinogram
+    kax = 'sinogram'
+    if dax.get(kax) is not None:
+        ax = dax[kax]['handle']
+
+        # plot rays
+        for k0, v0 in dout.items():
+            ax.plot(
+                v0['ang'].ravel(),
+                v0['impact'].ravel(),
+                **dprops[k0],
+            )
+
+        # legend
+        ax.legend(
+            loc='upper left',
+            bbox_to_anchor=(1, 1),
+        )
+
+    # sketch
+    kax = 'sketch'
+    if dax.get(kax) is not None:
+        ax = dax[kax]['handle']
+
+        _plot_sketch(ax)
+
+    return dax
+
+
+# ###############################################################
+# ###############################################################
+#               Check plot
+# ###############################################################
+
+
+def _check_plot(
+    dout=None,
+    R0=None,
+    Z0=None,
+    # angles
+    ang=None,
+    ang_units=None,
+    impact_pos=None,
+    pmax=None,
+    # options
+    color=None,
+    marker=None,
+    label=None,
+    sketch=None,
+    # figure
+    dax=None,
+    dmargin=None,
+    fs=None,
+    wintit=None,
+    tit=None,
+    # unused
+    **kwdargs,
+):
+
+    # --------------
+    # dprops
+
+    dprops = {}
+    for k0 in dout.keys():
+        dprops[k0] = {
+            'label': k0 if label is None else label,
+            'color': color,
+            'marker': '.' if marker is None else maker,
+        }
+
+    # -------------
+    # sketch
+
+    sketch = ds._generic_check._check_var(
+        sketch, 'sketch',
+        types=bool,
+        default=True,
+    )
+
+    # -------------
+    # pmax
+
+    if pmax is None:
+        pmax = np.nanmax([
+            np.nanmax(np.abs(v0['impact'])) for v0 in dout.values()
+        ])
+        if not np.isfinite(pmax):
+            msg = "Something seems wrong with impact parameters: all nans"
+            raise Exception(msg)
+
+    # -------------
+    # figure
+
+    if fs is None:
+        fs = (10, 8)
+
+    if wintit is None:
+        wintit = 'tofu - sinogram'
+
+    if tit is None:
+        tit = f"Sinogram with respect to (R, Z) = ({R0}, {Z0}) m"
+
+    if dmargin is None:
+        dmargin = {
+            'left': 0.10, 'right': 0.95,
+            'bottom': 0.10, 'top': 0.90,
+            'wspace': 0.25, 'hspace': 0.1,
+        }
+
+    # -------------
+    # sketch
+
+    if dax is None:
+        dax = _get_ax(
+            ang=ang,
+            ang_units=ang_units,
+            impact_pos=impact_pos,
+            pmax=pmax,
+            # figure
+            fs=fs,
+            wintit=wintit,
+            tit=tit,
+            dmargin=dmargin,
+        )
+
+    elif issubclass(dax, plt.Axes):
+        dax = {'sinogram': {'handle': dax}}
+
+    return (
+        dprops,
+        sketch,
+        dax,
+    )
+
+
+def _get_ax(
+    ang=None,
+    ang_units=None,
+    impact_pos=None,
+    pmax=None,
+    # figure
+    dmargin=None,
+    fs=None,
+    wintit=None,
+    tit=None,
+):
+
+    # create figure and axes
+    fig = plt.figure(figsize=fs)
+    fig.canvas.manager.set_window_title(wintit)
+    fig.suptitle(tit, size=14, fontweight='bold')
+
+    gs = GridSpec(ncols=6, nrows=6, **dmargin)
+
+    # sinogram
+    ax0 = fig.add_subplot(gs[:, :-1])
+    ax0.set_xlabel(r"$" + f"\{ang}" + r"$" + f" ({ang_units})", size=12, fontweight='bold')
+    ax0.set_ylabel(r"$p$ (m)", size=12, fontweight='bold')
+
+    angmax = np.pi
+    if ang_units == 'deg':
+        angmax = 180
+
+    if impact_pos is True:
+        ax0.set_xlim(-angmax, angmax)
+        ax0.set_ylim(0, pmax)
+    else:
+        ax0.set_xlim(0, angmax)
+        ax0.set_ylim(-pmax, pmax)
+
+    # sketch
+    ax1 = fig.add_subplot(
+        gs[-1, -1],
+        aspect='equal',
+        adjustable='datalim',
+        frameon=False,
+    )
+    ax1.set_xticks([])
+    ax1.set_yticks([])
+
+    # output dict
+    dax = {
+        'sinogram': {'handle': ax0},
+        'sketch': {'handle': ax1},
+    }
+
+    return dax
+
+
+# ##########################################################
+# ##########################################################
+#
+# ##########################################################
+
+
+def _plot_sketch(ax=None):
+
+    # get points
+    pt = np.array([[0, -0.8], [0, 0.8]])
+    line = np.array([[-1.6, 0.1], [0, 1.7]])
+    hor = np.array([[-0.4, 0.2], [1.2, 1.2]])
+    theta = np.linspace(0, 3.*np.pi/4., 30)
+    ksi = np.linspace(0, np.pi/4., 10)
+
+    theta = np.array([0.3*np.cos(theta),0.3*np.sin(theta)])
+    ksi = np.array([-0.4+0.4*np.cos(ksi), 1.2+0.4*np.sin(ksi)])
+
+    # plot
+    ax.plot(
+        pt[0,:], pt[1,:], '+k',
+        pt[0,:], pt[1,:], '--k',
+        line[0,:], line[1,:], '-k',
+        hor[0,:], hor[1,:], '-k',
+        theta[0,:], theta[1,:], '-k',
+        ksi[0,:], ksi[1,:], '-k',
+    )
+
+    # annotate
+    ax.annotate(
+        r"$\theta$",
+        xy=(0.3,0.4),
+        xycoords='data',
+        va="center",
+        ha="center",
+    )
+    ax.annotate(
+        r"$\xi$",
+        xy=(0.1,1.4),
+        xycoords='data',
+        va="center",
+        ha="center",
+    )
+    ax.annotate(
+        r"$p$",
+        xy=(-0.7,0.3),
+        xycoords='data',
+        va="center",
+        ha="center",
+    )
+    return

--- a/tofu/tests/tests08_diagnostics/test_01_diagnostics.py
+++ b/tofu/tests/tests08_diagnostics/test_01_diagnostics.py
@@ -600,3 +600,26 @@ class Test01_Diagnostic():
             )
             plt.close('all')
             del dax
+
+    def test04_sinogram(self):
+
+        lrays = list(self.obj.dobj['rays'].keys())
+        ldiag = [
+            k0 for k0, v0 in self.obj.dobj['diagnostic'].items()
+            if any([v1.get('los') is not None for v1 in v0['doptics'].values()])
+        ]
+        lk = [lrays] + ldiag
+        for ii, k0 in enumerate(lk):
+            dout, dax = self.obj.get_sinogram(
+                key=k0,
+                ang='theta' if ii % 2 == 0 else 'xi',
+                ang_units='deg' if ii % 3 == 0 else 'radian',
+                impact_pos=ii % 3 != 0,
+                R0=2.4 if ii % 3 != 1 else None,
+                config=None if ii % 3 != 1 else self.conf,
+                pmax=None if ii % 3 == 0 else 5,
+                plot=True,
+            )
+            plt.close('all')
+            del dax
+

--- a/tofu/tests/tests09_tutorials/tuto_real0.py
+++ b/tofu/tests/tests09_tutorials/tuto_real0.py
@@ -36,16 +36,16 @@ def main():
     # add several diagnostics
 
     # add broadband
-    # _add_broadband(coll, conf)
+    _add_broadband(coll, conf)
 
     # add 2d camera
-    # _add_2d(coll, conf)
+    _add_2d(coll, conf)
 
     # add PHA
     # _add_PHA(coll, conf)
 
     # add spectrometer
-    _add_spectrometer(coll, conf)   # , crystals=['c0'])
+    # _add_spectrometer(coll, conf)   # , crystals=['c0'])
 
     # add spectro-like without crystal
     # _add_spectrometer_like(coll, config=conf, key_diag='d02')
@@ -53,11 +53,11 @@ def main():
     # ------------------------
     # compute synthetic signal
 
-    _compute_synth_signal(
-        coll,
-        #ldiag=['diag00']),
-        spectral_binning=True,
-    )
+    # _compute_synth_signal(
+        # coll,
+        # #ldiag=['diag00']),
+        # spectral_binning=True,
+    # )
 
     # ------------------
     # geometry matrices


### PR DESCRIPTION
Main changes:
-----------------

* get_sinogram() implemented, with a plotting option
     - can handle a diag key, a list of rays keys and a config
     - can plot
    - can handle 4 different conventions (ang='theta' or  'xi', impact_pos=bool)
         - angle = `'theta'` in [-pi, pi] and impact parameter positive
         - angle = `'theta'` in [0, pi] and impact parameter signed
         - angle = `'xi'` in [-pi, pi] and impact parameter positive
         - angle = `'xi'` in [-pi/2, pi/2] and impact parameter signed
         
Issues:
--------
Fixes, in devel, issue #808 

Examples:
-----------

```
import tofu as tf

test = tf.tests.tests09_tutorials.tuto_real0

conf, coll = test.main()

dax = coll.plot_diagnostic('d0', elements='o', plot_config=conf)
```

![image](https://github.com/ToFuProject/tofu/assets/5929562/4f72e4d8-6a13-44f7-8475-677cb5bba496)

Plotting all four conventions for the same set of rays:

```
dout, dax = coll.get_sinogram('d0', config=conf, R0=2.4, verb=2, ang='theta', impact_pos=True)

dout, dax = coll.get_sinogram('d0', config=conf, R0=2.4, verb=2, ang='theta', impact_pos=False)

dout, dax = coll.get_sinogram('d0', config=conf, R0=2.4, verb=2, ang='xi', impact_pos=True)

dout, dax = coll.get_sinogram('d0', config=conf, R0=2.4, verb=2, ang='xi', impact_pos=False)
```


|  theta, p > 0                       |    theta, p signed         |   xi, p > 0     |    xi, p signed |
| -----------------------------| -----------------------| ----------------| ----------------|
|      ![image](https://github.com/ToFuProject/tofu/assets/5929562/d1c0fb58-9b2b-4d09-8c68-7895583e1a07)   | ![image](https://github.com/ToFuProject/tofu/assets/5929562/3e98eaa4-c946-4a03-be1c-5a0f4ec0f379)  |    ![image](https://github.com/ToFuProject/tofu/assets/5929562/a03e2c2c-bcaf-41af-96cd-79d61a111c56)      |     ![image](https://github.com/ToFuProject/tofu/assets/5929562/5fea36ab-6d7a-47fa-860c-dbaf1a26d798) |







