### PR TITLE
More robust algo4 + constraints for regularized algos

### DIFF
--- a/tofu/data/_class10_algos.py
+++ b/tofu/data/_class10_algos.py
@@ -674,18 +674,6 @@ def inv_linear_augTikho_pos_dense(
             end='\n',
         )
 
-        # ---- DEBUG ---
-        # msg = (
-        #     f"\t- R = {R}\n"
-        #     f"\t- sol0 = {sol0}\n"
-        #     f"\t- np.sum(R, axis=1) = {np.sum(R, axis=1)}\n"
-        #     f"\t- R.dot(sol0) = {R.dot(sol0)}\n"
-        #     f"\t- reg = {reg}\n"
-        #     f"\t- R\n"
-        # )
-        # raise Exception(msg)
-        # -------------
-
     while niter < 2 or (conv > conv_crit and niter < maxiter_outer):
         # quadratic method for positivity constraint
         sol = scpop.minimize(
@@ -767,7 +755,7 @@ def _augTikho_update(
 
     # ---- DEBUG --------
     # print()
-    # print(conv_reg, d)
+    # print('\t', conv_reg, d)
     # print('\t a0bis, b0:', a0bis, b0)
     # print('\t a1bis, b1', a1bis, b1)
     # print('\t res2, reg:', res2, reg)

--- a/tofu/data/_class10_algos.py
+++ b/tofu/data/_class10_algos.py
@@ -743,7 +743,7 @@ def _augTikho_update(
         Regularization", Research report, University of Hong Kong, 2008
     """
 
-    res2 = np.sum((Tn.dot(sol)-yn)**2)    # residu**2
+    res2 = np.sum(np.power(Tn.dot(sol)-yn, 2))    # residu**2
     reg = sol.dot(R.dot(sol))             # regularity term
 
     lamb = a0bis/(0.5*reg + b0)           # Update reg. param. estimate

--- a/tofu/data/_class10_algos.py
+++ b/tofu/data/_class10_algos.py
@@ -678,7 +678,7 @@ def inv_linear_augTikho_pos_dense(
         # quadratic method for positivity constraint
         sol = scpop.minimize(
             func_val, sol0,
-            args=(mu0, Tn, yn, TTn, Tyn),
+            args=(mu0, Tn, yn, TTn, Tyn, R),
             jac=func_jac,
             hess=func_hess,
             method=method,

--- a/tofu/data/_class10_algos.py
+++ b/tofu/data/_class10_algos.py
@@ -674,6 +674,18 @@ def inv_linear_augTikho_pos_dense(
             end='\n',
         )
 
+        # ---- DEBUG ---
+        # msg = (
+        #     f"\t- R = {R}\n"
+        #     f"\t- sol0 = {sol0}\n"
+        #     f"\t- np.sum(R, axis=1) = {np.sum(R, axis=1)}\n"
+        #     f"\t- R.dot(sol0) = {R.dot(sol0)}\n"
+        #     f"\t- reg = {reg}\n"
+        #     f"\t- R\n"
+        # )
+        # raise Exception(msg)
+        # -------------
+
     while niter < 2 or (conv > conv_crit and niter < maxiter_outer):
         # quadratic method for positivity constraint
         sol = scpop.minimize(
@@ -753,6 +765,7 @@ def _augTikho_update(
     mu1 = (lamb/tau) * (2*a1bis/res2)**d  # rescale mu with noise estimate
     # mu1 = (lamb/tau) * (2*a1bis/max(res2, 1e-3))**d  # rescale mu with noise estimate
 
+    # ---- DEBUG --------
     # print()
     # print(conv_reg, d)
     # print('\t a0bis, b0:', a0bis, b0)
@@ -761,6 +774,7 @@ def _augTikho_update(
     # print('\t lamb, tau:', lamb, tau)
     # print('\t mu comp.:', lamb/tau, (2*a1bis/res2)**d, mu1)
     # print()
+    # ---- DEBUG END -----
 
     # Compute convergence variable
     if conv_reg:

--- a/tofu/data/_class10_checks.py
+++ b/tofu/data/_class10_checks.py
@@ -1287,12 +1287,21 @@ def _algo_check(
                 method = 'trf'
             else:
                 method = 'L-BFGS-B'
+                method = 'TNC'     # more robust ?
 
-        if method == 'L-BFGS-B':
+        # solver-specific options
+        elif method == 'TNC':
             if options.get('ftol') is None:
                 options['ftol'] = conv_crit/100.
             if options.get('disp') is None:
                 options['disp'] = False
+
+        elif method == 'L-BFGS-B':
+            if options.get('ftol') is None:
+                options['ftol'] = conv_crit/100.
+            if options.get('disp') is None:
+                options['disp'] = False
+
         elif dalgo['name'] != 'algo7':
             raise NotImplementedError
 

--- a/tofu/data/_class10_checks.py
+++ b/tofu/data/_class10_checks.py
@@ -305,17 +305,6 @@ def _compute_check(
     if np.all(indok):
         indok = None
 
-    # --------------------
-    # algo vs dconstraints
-
-    if regul and dconstraints is not None:
-        msg = (
-            "Constraints for regularized algorithms not implemented yet!\n"
-            f"\t- algo:         {dalgo['name']}\n"
-            f"\t- dconstraints: {dconstraints}\n"
-        )
-        raise NotImplementedError(msg)
-
     # -------------------
     # regularity operator
 

--- a/tofu/data/_class10_checks.py
+++ b/tofu/data/_class10_checks.py
@@ -171,7 +171,14 @@ def _compute_check(
                 dsigma['data'] = dsigma['data'][ind0, :]
 
     if m3d:
-        assert matrix.shape[0] == ddata['data'].shape[0]
+        if matrix.ndim != 3 or matrix.shape[0] != ddata['data'].shape[0]:
+            msg = (
+                "Inconsistent interpretation of matrix and data shapes:\n"
+                f"\t- m3d: {m3d}\n"
+                f"\t- matrix.shape: {matrix.shape}\n"
+                f"\t- ddata['data'].shape: {ddata['data'].shape}\n"
+            )
+            raise Exception(msg)
 
     # ------------------
     # constraints update

--- a/tofu/data/_class10_checks.py
+++ b/tofu/data/_class10_checks.py
@@ -322,7 +322,7 @@ def _compute_check(
     # get operator
     if regul:
 
-        if 'N2' not in operator:
+        if operator is None or 'N2' not in operator:
             msg = (
                 "Quadratic operator needed for inversions!"
                 f"Provided: {operator}"

--- a/tofu/data/_class10_compute.py
+++ b/tofu/data/_class10_compute.py
@@ -118,7 +118,11 @@ def compute_inversions(
     )
 
     # normalize geometry matrix to avoid having 1e-15 * 1e16
-    matnorm = np.mean(np.mean(matrix, axis=-1), axis=-1)
+    if hasattr(matrix, 'toarray'):
+        matnorm = np.mean(np.mean(matrix.toarray(), axis=-1), axis=-1)
+    else:
+        matnorm = np.mean(np.mean(matrix, axis=-1), axis=-1)
+
     matrix_norm = matrix / matnorm[:, None, None] if m3d else matrix / matnorm
 
     # prepare computation intermediates

--- a/tofu/data/_class10_compute.py
+++ b/tofu/data/_class10_compute.py
@@ -118,7 +118,7 @@ def compute_inversions(
     )
 
     # normalize geometry matrix to avoid having 1e-15 * 1e16
-    matnorm = np.mean(matrix, axis=(-2, -1))
+    matnorm = np.mean(np.mean(matrix, axis=-1), axis=-1)
     matrix_norm = matrix / matnorm[:, None, None] if m3d else matrix / matnorm
 
     # prepare computation intermediates

--- a/tofu/data/_class8_compute_signal.py
+++ b/tofu/data/_class8_compute_signal.py
@@ -561,7 +561,7 @@ def _compute_los(
 
         # --------------------------
         # optional spectral binning
-        
+
         # spectral_binning
         spectral_binning = ds._generic_check._check_var(
             spectral_binning, 'spectral_binning',
@@ -571,7 +571,7 @@ def _compute_los(
 
         # if spectral binning => add bins of len 2 for temporary storing
         if spectral_binning is True:
-            ktemp_bin = f'{key_bs_spectro}_temp_bin'
+            ktemp_bin = f'{key_ref_spectro}_temp_bin'
             coll.add_bins(
                 key=ktemp_bin,
                 edges=[0, 1],
@@ -616,7 +616,7 @@ def _compute_los(
 
         # ----------------
         # spectro
-        
+
         if spectro:
             E, _ = coll.get_diagnostic_lamb(
                 key_diag,
@@ -706,7 +706,7 @@ def _compute_los(
                 #try:
                 coll.binning(
                     data=key_integrand,
-                    bin_data0=key_bs_spectro,
+                    bin_data0=key_ref_spectro if key_bs_spectro is None else key_bs_spectro,
                     bins0=ktemp_bin,
                     integrate=True,
                     verb=verb,
@@ -861,7 +861,6 @@ def _compute_los(
             else:
                 sh_dE = [-1 if aa == axis else 1 for aa in range(len(refi))]
                 data *= dE_flat.reshape(sh_dE)
-
 
         # reshape if 2d
         if is2d:

--- a/tofu/tests/tests07_inversions/test_01_isotropic.py
+++ b/tofu/tests/tests07_inversions/test_01_isotropic.py
@@ -241,6 +241,9 @@ class Test01_Inversions():
                 if kmat == 'gmat05' and comb == ('algo1', 'D2N2'):
                     continue
 
+                if comb == ('algo1', 'D1N2'):
+                    continue
+
                 kdat = 's0' if kd == 'd0' else 's1'
                 try:
 


### PR DESCRIPTION
Main changes:
----------------
* what was failing for Ti inversions was the method '' used by `scipy.optimize.minimize` (called by `algo4`), it was not iterating
* `method = 'TNC'`, more robust, is used by default now
* Regularized algorithms now work with dconstraints (for radial meshes only)

Also:
* geometry matrix normalization implemented for inversions to reduce risk of numerical errors
* Better handling of errors and better error msg
* Better handling of non-bspline spectral dimensions

Issues:
-------
Fixes, in devel:
* issue #815 
* issue #817 