### PR TITLE
[#846] Debugging

### DIFF
--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -444,7 +444,7 @@ def _get_centroid(p0, p1, cent, debug=None):
     detABu = AB0 * vect[1] - AB1 * vect[0]
     detACu = (cent[0] - p0) * vect[1] - (cent[1] - p1) * vect[0]
     kk = detACu / detABu
-    ind = ((kk>=0) & (kk<1)).nonzero()[0]
+    ind = ((kk >= 0) & (kk < 1)).nonzero()[0]
 
     # pathological cases
     if ind.size != 2:

--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -182,9 +182,11 @@ def equivalent_apertures(
     for ii, ij in enumerate(pixel):
 
         # ----- DEBUG -------
-        # if ij not in [236, 239, 387]:
-        #     iok[ii] = False
-        #     continue
+        if ij not in [1148]:
+            iok[ii] = False
+            x0.append(None)
+            x1.append(None)
+            continue
         # -------------------
 
         if verb is True:
@@ -329,16 +331,16 @@ def equivalent_apertures(
             ).center()
 
             # --- DEBUG ---------
-            # if ii in [97]:
-                # _debug_plot2(
-                    # p0=p0, p1=p1,
-                    # cents0=cents0, cents1=cents1,
-                    # ii=ii,
-                    # ip=ip,
-                    # coord_x01toxyz=coord_x01toxyz,
-                    # cx=cx, cy=cy, cz=cz,
-                    # area=area,
-                # )
+            if ii in [1148]:
+                _debug_plot2(
+                    p0=p0, p1=p1,
+                    cents0=cents0, cents1=cents1,
+                    ii=ii,
+                    ip=ip,
+                    coord_x01toxyz=coord_x01toxyz,
+                    cx=cx, cy=cy, cz=cz,
+                    area=area,
+                )
             # --------------------
 
         centsx, centsy, centsz = coord_x01toxyz(
@@ -797,7 +799,7 @@ def _get_equivalent_aperture_spectro(
 
     # loop on optics after crystal
     for jj in range(nop_post):
-        # print(f'\t {jj} / {nop_post}')      # DB
+        print(f'\t {jj} / {nop_post}')      # DB
 
         # reflection
         p0, p1 = _class5_projections._get_reflection(
@@ -825,7 +827,7 @@ def _get_equivalent_aperture_spectro(
         )
 
         if p0 is None:
-            # print('\n\t \t None 0\n')       # DB
+            print('\n\t \t None 0\n')       # DB
             return p0, p1
 
         if convex:
@@ -836,25 +838,25 @@ def _get_equivalent_aperture_spectro(
             )
 
         # --- DEBUG ---------
-        # if ij in [236, 239, 387]:
-        #     _debug_plot(
-        #         p_a=p_a,
-        #         # p_b=p_a & plg.Polygon(np.array([p0, p1]).T),
-        #         pa0=p0,
-        #         pa1=p1,
-        #         ii=ii,
-        #         tit='not all',
-        #     )
+        if ij in [1148]:
+            _debug_plot(
+                p_a=p_a,
+                # p_b=p_a & plg.Polygon(np.array([p0, p1]).T),
+                pa0=p0,
+                pa1=p1,
+                ii=ii,
+                tit='not all',
+            )
         # ----------------------
 
         # intersection
         p_a = p_a & plg.Polygon(np.array([p0, p1]).T)
         if p_a.nPoints() < 3:
-            # print('\n\t \t None 1\n')       # DB
+            print('\n\t \t None 1\n')       # DB
             return None, None
 
-            # print(f'\t\t interp => {p0.size} pts')       # DB
-            # print('inter: ', p0)
+            print(f'\t\t interp => {p0.size} pts')       # DB
+            print('inter: ', p0)
 
     return p0, p1
 

--- a/tofu/data/_class8_equivalent_apertures.py
+++ b/tofu/data/_class8_equivalent_apertures.py
@@ -182,11 +182,11 @@ def equivalent_apertures(
     for ii, ij in enumerate(pixel):
 
         # ----- DEBUG -------
-        if ij not in [1148]:
-            iok[ii] = False
-            x0.append(None)
-            x1.append(None)
-            continue
+        # if ij not in [1148]:
+        #     iok[ii] = False
+        #     x0.append(None)
+        #     x1.append(None)
+        #     continue
         # -------------------
 
         if verb is True:
@@ -326,21 +326,29 @@ def equivalent_apertures(
             area[ii] = plg.Polygon(np.array([p0, p1]).T).area()
 
             # centroid in 3d
-            cents0[ii], cents1[ii] = plg.Polygon(
-                np.array([x0[ii, :], x1[ii, :]]).T
-            ).center()
+            polyi = plg.Polygon(np.array([x0[ii, :], x1[ii, :]]).T)
+            cent = polyi.center()
+            if not polyi.isInside(*cent):
+                cent = _get_centroid(
+                    x0[ii, :],
+                    x1[ii, :],
+                    cent,
+                    debug=False,
+                )
+
+            cents0[ii], cents1[ii] = cent
 
             # --- DEBUG ---------
-            if ii in [1148]:
-                _debug_plot2(
-                    p0=p0, p1=p1,
-                    cents0=cents0, cents1=cents1,
-                    ii=ii,
-                    ip=ip,
-                    coord_x01toxyz=coord_x01toxyz,
-                    cx=cx, cy=cy, cz=cz,
-                    area=area,
-                )
+            # if ii in [1148]:
+            #     _debug_plot2(
+            #         p0=p0, p1=p1,
+            #         cents0=cents0, cents1=cents1,
+            #         ii=ii,
+            #         ip=ip,
+            #         coord_x01toxyz=coord_x01toxyz,
+            #         cx=cx, cy=cy, cz=cz,
+            #         area=area,
+            #     )
             # --------------------
 
         centsx, centsy, centsz = coord_x01toxyz(
@@ -404,6 +412,84 @@ def equivalent_apertures(
         )
     else:
         return x0, x1, kref, iok
+
+
+def _get_centroid(p0, p1, cent, debug=None):
+
+    # ------------
+    # compute
+
+    # get unit vectors of lines going through centroid
+    mid0 = np.r_[0.5*(p0[1:] + p0[:-1]), 0.5*(p0[-1] + p0[0]), p0]
+    mid1 = np.r_[0.5*(p1[1:] + p1[:-1]), 0.5*(p1[-1] + p1[0]), p1]
+    u0 = mid0 - cent[0]
+    u1 = mid1 - cent[1]
+    un = np.sqrt(u0**2 + u1**2)
+    u0n = u0/un
+    u1n = u1/un
+
+    # get minimum of total algebraic distance from line
+    dist = np.sum(
+        u0n[:, None] * p1[None, :] - u1n[:, None] * p0[None, :],
+        axis=1,
+    )
+    imin = np.argmin(np.abs(dist))
+
+    # build unit vector
+    vect = np.r_[u0n[imin], u1n[imin]]
+
+    # get intersections
+    AB0 = np.r_[p0[1:] - p0[:-1], p0[0] - p0[-1]]
+    AB1 = np.r_[p1[1:] - p1[:-1], p1[0] - p1[-1]]
+    detABu = AB0 * vect[1] - AB1 * vect[0]
+    detACu = (cent[0] - p0) * vect[1] - (cent[1] - p1) * vect[0]
+    kk = detACu / detABu
+    ind = ((kk>=0) & (kk<1)).nonzero()[0]
+
+    # pathological cases
+    if ind.size != 2:
+        # return the point is question
+        cent2 = np.r_[mid0[imin], mid1[imin]]
+    else:
+        # normal case
+        cent2 = np.r_[
+            np.mean(p0[ind] + kk[ind] * AB0[ind]),
+            np.mean(p1[ind] + kk[ind] * AB1[ind]),
+        ]
+
+    # --------------
+    # debug
+
+    if debug:
+
+        indclose = np.r_[np.arange(p0.size), 0]
+        plt.figure()
+        plt.plot(dist, '.-')
+        plt.gca().axvline(imin, c='k', ls='--')
+
+        dim = 0.5 * max(np.max(p0) - np.min(p0), np.max(p1) - np.min(p1))
+        plt.figure()
+        plt.plot(
+            p0[indclose],
+            p1[indclose],
+            '.-',
+            cent[0] + np.r_[0, vect[0]*dim],
+            cent[1] + np.r_[0, vect[1]*dim],
+            'x-k',
+            cent2[0],
+            cent2[1],
+            'ok',
+            mid0[imin],
+            mid1[imin],
+            'sk',
+            p0[ind],
+            p1[ind],
+            '.-r',
+        )
+        plt.gca().set_aspect('equal', adjustable='datalim')
+        plt.gca().set_title(f"ind.size = {ind.size}")
+
+    return cent2
 
 
 # ##############################################################
@@ -799,7 +885,7 @@ def _get_equivalent_aperture_spectro(
 
     # loop on optics after crystal
     for jj in range(nop_post):
-        print(f'\t {jj} / {nop_post}')      # DB
+        # print(f'\t {jj} / {nop_post}')      # DB
 
         # reflection
         p0, p1 = _class5_projections._get_reflection(
@@ -827,7 +913,7 @@ def _get_equivalent_aperture_spectro(
         )
 
         if p0 is None:
-            print('\n\t \t None 0\n')       # DB
+            # print('\n\t \t None 0\n')       # DB
             return p0, p1
 
         if convex:
@@ -838,25 +924,25 @@ def _get_equivalent_aperture_spectro(
             )
 
         # --- DEBUG ---------
-        if ij in [1148]:
-            _debug_plot(
-                p_a=p_a,
-                # p_b=p_a & plg.Polygon(np.array([p0, p1]).T),
-                pa0=p0,
-                pa1=p1,
-                ii=ii,
-                tit='not all',
-            )
+        # if ij in [1148]:
+        #     _debug_plot(
+        #         p_a=p_a,
+        #         # p_b=p_a & plg.Polygon(np.array([p0, p1]).T),
+        #         pa0=p0,
+        #         pa1=p1,
+        #         ii=ii,
+        #         tit='not all',
+        #     )
         # ----------------------
 
         # intersection
         p_a = p_a & plg.Polygon(np.array([p0, p1]).T)
         if p_a.nPoints() < 3:
-            print('\n\t \t None 1\n')       # DB
+            # print('\n\t \t None 1\n')       # DB
             return None, None
 
-            print(f'\t\t interp => {p0.size} pts')       # DB
-            print('inter: ', p0)
+            # print(f'\t\t interp => {p0.size} pts')       # DB
+            # print('inter: ', p0)
 
     return p0, p1
 


### PR DESCRIPTION
Main changes:
-----------------
* Calculation of the centroid of the equivalent aperture did not guarantee that it was inside the polygon
* that is now checked and if not inside, a new sub-routine `_get_centroid()` is called to correct that.


Explanations:
---------------
The problem was coming rom the fact that for very curved non-convex equivalent apertures, the polygon centroid is actually not always inside the polygon itself:

![image](https://github.com/ToFuProject/tofu/assets/5929562/45eb8c50-a59d-4fd6-8efc-90c478806876)

After the fix:
![image](https://github.com/ToFuProject/tofu/assets/5929562/e0cda1a4-7981-40e1-af4a-cf0e9802a118)

![image](https://github.com/ToFuProject/tofu/assets/5929562/22942d5d-b8ec-43ec-ae63-8f9aa0af5968)

![image](https://github.com/ToFuProject/tofu/assets/5929562/e93b528a-ae2a-4904-9e3e-cf73ba3d953f)


Issues:
--------
Fixes, in devel, issue #846 

