### PR TITLE
Tools for ray-tracing validation

### DIFF
--- a/tofu/data/_class08_Diagnostic.py
+++ b/tofu/data/_class08_Diagnostic.py
@@ -562,12 +562,32 @@ class Diagnostic(Previous):
         pix1=None,
         tit=None,
     ):
-        """ Compute the vos of the diagnostic (per pixel)
+        """ Compute the image of a mono-wavelength plasma volume
 
-        - poly_margin (0.3) fraction by which the los-estimated vos is widened
-        -store:
-            - if replace_poly, will replace the vos polygon approximation
-            - will store the toroidally-integrated solid angles
+        Does ray-tracing from the whole plasma volume
+        For a set of discrete user-defined wavelengths
+        Optionally (dobin=True) also provides the binned (per-pixel) image
+
+        - lamb: float or sequence of floats, wavelength to be traced
+
+        Parameters for plasma volume sampling:
+            - res_RZ: float (m)
+            - res_phi: float (m)
+            - res_rock_curve: float (rad)
+
+        Parameters for sampling the solid angle for each point source
+            - n0: int, nb of rays in horizontal direction
+            - n1: int, nb of rays in vertical direction
+
+        Parameters for binning (by default uses the camera pixels)
+            - dobin: bool, do the binning or not
+            - bin0: int, nb of pixels in the horizontal direction
+            - bin1: int, nb of pixels in the vertical direction
+
+        Parameters for plotting
+            - plot: bool
+            - pix0: index 0 of pixels outlines to be plotted
+            - pix1: index 1 of pixels outlines to be plotted
 
         """
 

--- a/tofu/data/_class8_reverse_ray_tracing.py
+++ b/tofu/data/_class8_reverse_ray_tracing.py
@@ -131,6 +131,7 @@ def _from_pts(
         key_diag=key,
         key_cam=key_cam,
         kspectro=kspectro,
+        lamb=lamb0,
         res_lamb=res_lamb,
         res_rock_curve=res_rock_curve,
         verb=False,
@@ -527,9 +528,9 @@ def _prepare_lamb(
         dlamb = lamb[1] - lamb[0]
 
         bragg = coll.get_crystal_bragglamb(key=kspectro, lamb=lamb)[0]
-    
+
     elif lamb is not None:
-        
+
         lamb = ds._generic_check._check_flat1darray(
             lamb, 'lamb',
             dtype=float,
@@ -877,17 +878,17 @@ def _loop0(
                     )
 
     return {
-        'ncounts': ncounts,
-        'sang0': sang0,
-        'sang': sang,
-        'sang_lamb': sang_lamb * dlamb,
-        'lamb': lamb,
-        'dlamb': dlamb,
-        'lp0': lp0,
-        'lp1': lp1,
-        'lpx': lpx,
-        'lpy': lpy,
-        'lpz': lpz,
+        'ncounts': {'data': ncounts, 'units': ''},
+        'sang0': {'data': sang0, 'units': 'sr'},
+        'sang': {'data': sang, 'units': 'sr'},
+        'sang_lamb': {'data': sang_lamb, 'units': 'sr'},
+        'lamb': {'data': lamb, 'units': 'm'},
+        'dlamb': {'data': dlamb, 'units': 'm'},
+        'lp0': {'data': lp0, 'units': 'm'},
+        'lp1': {'data': lp1, 'units': 'm'},
+        'lpx': {'data': lpx, 'units': 'm'},
+        'lpy': {'data': lpy, 'units': 'm'},
+        'lpz': {'data': lpz, 'units': 'm'},
     }
 
 
@@ -1172,13 +1173,13 @@ def _loop1(
     )
 
     return {
-        'ncounts': ncounts / length,
-        'lp0': lp0,
-        'lp1': lp1,
-        'ptsx': np.array(xx),
-        'ptsy': np.array(yy),
-        'ptsr': x0u[ir],
-        'ptsz': x1u[iz],
+        'ncounts': {'data': ncounts / length, 'units': 'm3/m'},
+        'lp0': {'data': lp0, 'units': 'm'},
+        'lp1': {'data': lp1, 'units': 'm'},
+        'ptsx': {'data': np.array(xx), 'units': 'm'},
+        'ptsy': {'data': np.array(yy), 'units': 'm'},
+        'ptsr': {'data': x0u[ir], 'units': 'm'},
+        'ptsz': {'data': x1u[iz], 'units': 'm'},
     }
 
 
@@ -1415,15 +1416,15 @@ def _plot(
 
     coll.add_data(
         key=ktemp,
-        data=dout['ncounts'],
         ref=coll.dobj['camera'][key_cam]['dgeom']['ref'],
-        units='counts',
+        **dout['ncounts'],
     )
 
+    kd = 'sang'
     if vmin is None:
         vmin = 0
     if vmax is None:
-        vmax = np.nanmax(dout['ncounts'])
+        vmax = np.nanmax(dout[kd]['data'])
 
     # --------------
     # prepare
@@ -1505,8 +1506,8 @@ def _plot(
             ax = dax[kax]['handle']
 
             ax.plot(
-                dout['ptsr'],
-                dout['ptsz'],
+                dout['ptsr']['data'],
+                dout['ptsz']['data'],
                 ls='None',
                 lw=1.,
                 marker='.',
@@ -1517,8 +1518,8 @@ def _plot(
             ax = dax[kax]['handle']
 
             ax.plot(
-                dout['ptsx'],
-                dout['ptsy'],
+                dout['ptsx']['data'],
+                dout['ptsy']['data'],
                 ls='None',
                 lw=1.,
                 marker='.',
@@ -1528,8 +1529,8 @@ def _plot(
         if dax.get(kax) is not None:
             ax = dax[kax]['handle']
 
-            p0 = np.concatenate([pp.ravel() for pp in dout['lp0']])
-            p1 = np.concatenate([pp.ravel() for pp in dout['lp1']])
+            p0 = np.concatenate([pp.ravel() for pp in dout['lp0']['data']])
+            p1 = np.concatenate([pp.ravel() for pp in dout['lp1']['data']])
             ax.plot(
                 p0,
                 p1,
@@ -1542,10 +1543,10 @@ def _plot(
         # --------------
         # ray-tracing
 
-        for ii in range(len(dout['lp0'])):
+        for ii in range(len(dout['lp0']['data'])):
 
-            p0 = dout['lp0'][ii]
-            p1 = dout['lp1'][ii]
+            p0 = dout['lp0']['data'][ii]
+            p1 = dout['lp1']['data'][ii]
 
             # --------------
             # camera image
@@ -1564,10 +1565,10 @@ def _plot(
             # --------------
             # rays
 
-            ind = np.arange(3, dout['lpx'][ii].size, 3)
-            px = np.insert(dout['lpx'][ii].T.ravel(), ind, np.nan)
-            py = np.insert(dout['lpy'][ii].T.ravel(), ind, np.nan)
-            pz = np.insert(dout['lpz'][ii].T.ravel(), ind, np.nan)
+            ind = np.arange(3, dout['lpx']['data'][ii].size, 3)
+            px = np.insert(dout['lpx']['data'][ii].T.ravel(), ind, np.nan)
+            py = np.insert(dout['lpy']['data'][ii].T.ravel(), ind, np.nan)
+            pz = np.insert(dout['lpz']['data'][ii].T.ravel(), ind, np.nan)
 
             kax = 'cross'
             if dax.get(kax) is not None:
@@ -1612,7 +1613,7 @@ def _plot(
 
         extent = (cbin0[0], cbin0[-1], cbin1[0], cbin1[-1])
         im = ax.imshow(
-            dout['ncounts'].T,
+            np.nansum(dout[kd]['data'], axis=-1).T,
             extent=extent,
             interpolation='nearest',
             origin='lower',
@@ -1620,7 +1621,9 @@ def _plot(
             vmax=vmax,
         )
 
-        plt.colorbar(im, ax=ax, cax=cax)
+        cb = plt.colorbar(im, ax=ax, cax=cax)
+        ax.set_title(kd, size=12, fontweight='bold')
+        cb.set_label(dout[kd]['units'], size=12, weight='bold')
 
     # ----------
     # diag geom
@@ -1667,8 +1670,8 @@ def _get_dax(
         types=dict,
         default={
             'bottom': 0.05, 'top': 0.95,
-            'left': 0.05, 'right': 0.95,
-            'wspace': 0.25, 'hspace': 0.2,
+            'left': 0.05, 'right': 0.94,
+            'wspace': 0.20, 'hspace': 0.25,
         },
     )
 

--- a/tofu/data/_class8_vos.py
+++ b/tofu/data/_class8_vos.py
@@ -452,10 +452,19 @@ def _check(
     # -----------
     # return_vector
 
+    if spectro is True:
+        lok = [True, False]
+    else:
+        if keep3d is False:
+            lok = [False]
+        else:
+            lok = [True, False]
+
     return_vector = ds._generic_check._check_var(
         return_vector, 'return_vector',
         types=bool,
         default=False,
+        allowed=lok,
     )
 
     # -----------
@@ -686,12 +695,12 @@ def _store(
     if spectro is True:
         lk = [
             'lamb',
-            'ph', 'cos', 'ncounts',
-            'phi_min', 'phi_max',
+            'ph_pix_cross_lamb', 'cos_pix_cross', 'ncounts_pix_cross',
+            'phi_pix_cross_min', 'phi_pix_cross_max',
             # optional
             'lamb0', 'dlamb',
-            'phi_mean',
-            'dV', 'etendlen',
+            'phi_pix_cross_mean',
+            'dV_cross', 'etendlen_pix',
         ]
     else:
         lk = ['sang_cross', 'sang_3d']

--- a/tofu/data/_class8_vos_broadband.py
+++ b/tofu/data/_class8_vos_broadband.py
@@ -159,6 +159,14 @@ def _vos(
         lvectx = []
         lvecty = []
         lvectz = []
+    else:
+        lindr_3d = None
+        lindz_3d = None
+        lphi_3d = None
+        lsang_3d = None
+        lvectx = None
+        lvecty = None
+        lvectz = None
 
     npix = coll.dobj['camera'][key_cam]['dgeom']['pix_nb']
     for ii in range(npix):
@@ -687,7 +695,7 @@ def _vos_points(
     # safety check
 
     if iru.size == 0:
-        return None, None, None, None, None
+        return None, None, None, None, None, None, None, None
 
     # ------------
     # go on
@@ -1102,6 +1110,10 @@ def _harmonize_reshape_others(
             + "\n".join(lstr)
         )
         raise Exception(msg)
+
+    # safety ceck
+    if len(lkey) == 0:
+        return {}
 
     lnpts = dnpts[lkey[0]]
     nmax = np.max(lnpts)

--- a/tofu/data/_class8_vos_spectro_nobin_at_lamb.py
+++ b/tofu/data/_class8_vos_spectro_nobin_at_lamb.py
@@ -284,11 +284,16 @@ def _check(
         dcompute,
         res_RZ,
         res_phi,
-        _,
+        _,       # res_lamb,
+        _,       # keep3d,
+        _,       # return_vector,
         convexHull,
         visibility,
         verb,
         debug,
+        _,       # store,
+        _,       # overwrite,
+        _,       # timing,
     ) = _vos._check(
         coll=coll,
         key_diag=key_diag,
@@ -300,7 +305,7 @@ def _check(
         visibility=visibility,
         verb=verb,
         debug=debug,
-    )[:-2]
+    )
 
     if spectro is False:
         msg = "Routine can only be used for spectro diag, not '{key_diag}'"

--- a/tofu/data/_class8_vos_spectro_nobin_at_lamb.py
+++ b/tofu/data/_class8_vos_spectro_nobin_at_lamb.py
@@ -90,6 +90,8 @@ def compute_vos_nobin_at_lamb(
         lamb,
         nmax_rays,
         plot,
+        pix0,
+        pix1,
     ) = _check(**locals())
 
     # ------------
@@ -394,6 +396,20 @@ def _check(
         default=True,
     )
 
+    # pix0, pix1
+    if pix0 is not None or pix1 is not None:
+        pix0 = ds._generic_check._check_flat1darray(
+            pix0, 'pix0',
+            dtype=int,
+            unique=False,
+        )
+        pix1 = ds._generic_check._check_flat1darray(
+            pix1, 'pix1',
+            dtype=int,
+            unique=False,
+            size=pix0.size,
+        )
+
     # ----------
     # verb
 
@@ -423,6 +439,8 @@ def _check(
         lamb,
         nmax_rays,
         plot,
+        pix0,
+        pix1,
     )
 
 
@@ -1011,9 +1029,14 @@ def _plot(
             # get pixel outline
             out0, out1 = coll.get_optics_outline(k0, total=False, closed=True)
 
+            # centers
+            c0, c1 = coll.dobj['camera'][k0]['dgeom']['cents']
+            c0 = coll.ddata[c0]['data'][pix0]
+            c1 = coll.ddata[c1]['data'][pix1]
+
             # multiple pixels
-            out0 = (pix0[:, None] + np.r_[out0, np.nan][None, :]).ravel()
-            out1 = (pix1[:, None] + np.r_[out1, np.nan][None, :]).ravel()
+            out0 = (c0[:, None] + np.r_[out0, np.nan][None, :]).ravel()
+            out1 = (c1[:, None] + np.r_[out1, np.nan][None, :]).ravel()
 
             ax0.plot(out0, out1, '-k')
             ax1.plot(out0, out1, '-k')

--- a/tofu/data/_class8_vos_spectro_nobin_at_lamb.py
+++ b/tofu/data/_class8_vos_spectro_nobin_at_lamb.py
@@ -887,12 +887,14 @@ def _dobin(
             bin0 = np.linspace(c0min, c0max, bin0)
             bin1 = np.linspace(c1min, c1max, bin1)
 
+        else:
+            raise Exception("Impossible")
+
     # --------------------------
     # derive bin centers in 2d
 
-    if isinstance(c0, str):
-        c0 = 0.5 * (bin0[1:] + bin0[:-1])
-        c1 = 0.5 * (bin1[1:] + bin1[:-1])
+    c0 = 0.5 * (bin0[1:] + bin0[:-1])
+    c1 = 0.5 * (bin1[1:] + bin1[:-1])
 
     n0, n1 = c0.size, c1.size
 

--- a/tofu/data/_class8_vos_utilities.py
+++ b/tofu/data/_class8_vos_utilities.py
@@ -75,28 +75,28 @@ def _get_overall_polygons(
 
     # -----------------------
     # envelop pcross and phor
-    
+
     if convexHull is True:
         # replace by convex hull
         pts = np.array([p0[iok], p1[iok]]).T
-        return pts[ConvexHull(pts).vertices, :].T 
-    
+        return pts[ConvexHull(pts).vertices, :].T
+
     else:
-        
+
         ipn = (np.all(iok, axis=0)).nonzero()[0]
         pp = plg.Polygon(np.array([p0[:, ipn[0]], p1[:, ipn[0]]]).T)
         for ii in ipn[1:]:
             pp |= plg.Polygon(np.array([p0[:, ii], p1[:, ii]]).T)
-    
+
         if len(pp) > 1:
-            
+
             # replace by convex hull
             pts = np.concatenate(
                 tuple([np.array(pp.contour(ii)) for ii in range(len(pp))]),
                 axis=0,
             )
-            poly = pts[ConvexHull(pts).vertices, :].T 
-        
+            poly = pts[ConvexHull(pts).vertices, :].T
+
             # plot for debugging
             fig = plt.figure()
             fig.suptitle("_get_overall_polygons()", size=12)
@@ -114,7 +114,7 @@ def _get_overall_polygons(
             msg = "multiple contours"
             warnings.warn(msg)
             return poly
-        
+
         else:
             return np.array(pp.contour(0)).T
 
@@ -250,9 +250,27 @@ def _simplify_concave(
     # ------------
     # safety check
 
-    sign = np.sign(cross)
-    sign0 = np.mean(sign)
-    assert np.all(cross * sign0 >= -1e-12)
+    imax = np.argmax(np.abs(cross))
+    sign0 = np.sign(cross[imax])
+    # sign0 = np.mean(sign)
+    iok0 = cross * sign0 >= -1e-12
+    if not np.all(iok0):
+        fig = plt.figure()
+        ax = fig.add_axes([0.1, 0.1, 0.8, 0.8])
+        ax.plot(
+            x0, x1, '.-k',
+        )
+        msg = (
+            "Non-conform cross * sign0 (>= -1e-12):\n"
+            f"\t- x0 = {x0}\n"
+            f"\t- x1 = {x1}\n"
+            f"\t- ind = {ind}\n"
+            f"\t- iok0 = {iok0}\n"
+            # f"\t- sign = {sign}\n"
+            f"\t- sign0 = {sign0}\n"
+            f"\t- cross * sign0 = {cross * sign0}\n"
+        )
+        raise Exception(msg)
 
     # ------------
     # loop


### PR DESCRIPTION
Main changes:
-----------------
* Minor changes to make `coll.compute_diagnostic_vos_nobin_at_lamb()` more robust


Issues:
--------
Fixes, in devel, issue #874 


Examples:
-----------

Double-checked output of 2 methods to make sure they are comparable

To plot ray tracing from a single point, single wavelength:

```
dout = coll.get_raytracing_from_pts(
    ptsx=1.80894181,
    ptsy=0.1967529,
    ptsz=0,
    lamb0=1.55e-10,
    n0=100,
    n1=100,
    plot=True,
    plot_config=conf,
)
```

![image](https://github.com/ToFuProject/tofu/assets/5929562/afd22d39-09e2-438e-bab3-59e9b5ebfa0f)

To compute the total contribution of a monochromatic and homogeneous plasma volume (single wavelength, emissivity=1 everywhere):

```
dout = coll.compute_diagnostic_vos_nobin_at_lamb(
    key_diag=None,
    key_cam=None,
    key_mesh='mRZ',
    # wavelength
    lamb=1.55e-10,
   # plasma volume sampling resolution
    res_RZ=0.02,
    res_phi=0.01,
    res_rock_curve=None,
    # sampling of the solid angle subtended by each point
    n0=100,
    n1=100,
    nmax_rays=None,
    # optional binning per pixel
    dobin=True,
    bin0=None,
    bin1=None,
    # plotting
    plot=True,
    pix0=np.r_[5, 5],
    pix1=np.r_[0, 5],
    tit=None,
)
```

![image](https://github.com/ToFuProject/tofu/assets/5929562/f515cb5f-a15e-49e4-99fb-2ca6e87f94c5)

