### PR TITLE
Issue917 rocking curve new

### DIFF
--- a/tofu/data/_class5_compute.py
+++ b/tofu/data/_class5_compute.py
@@ -91,7 +91,7 @@ def _bragglamb(
         defrock = False
         lok = (False,)
     else:
-        defrock = True
+        defrock = False
         lok = (False, True)
 
     rocking_curve = ds._generic_check._check_var(

--- a/tofu/data/_class5_plot.py
+++ b/tofu/data/_class5_plot.py
@@ -50,21 +50,24 @@ def plot_rocking_curve(
     if color is None:
         color = 'k'
 
-    # T
-    if T is not None:
-        T = ds._generic_check._check_var(
-            T, 'T',
-            types=(int, float),
-            sign='>0',
-        )
-
     # -----------
     # plot
 
     # is2d
     if is2d:
 
-        if T is not None:
+        if T is False:
+            T = drock['Tref']
+            bragg = None
+            is2d = False
+
+        elif T is not None:
+            T = ds._generic_check._check_var(
+                T, 'T',
+                types=(int, float),
+                sign='>0',
+            )
+
             T0 = coll.ddata[drock['T']]['data']
             braggT = coll.ddata[drock['braggT']]['data']
             indT = np.argmin(np.abs(T0 - T))
@@ -87,10 +90,11 @@ def plot_rocking_curve(
     # not is2d
     if is2d is False:
 
-        bragg = coll.get_crystal_bragglamb(
-            key=key,
-            rocking_curve=False,
-        )[0][0]
+        if bragg is None:
+            bragg = coll.get_crystal_bragglamb(
+                key=key,
+                rocking_curve=False,
+            )[0][0]
 
         return _plot_rc_1d(
             key=key,
@@ -128,6 +132,9 @@ def _plot_rc_1d(
 
     if plot_FW is None:
         plot_FW = True
+
+    if issubclass(dax.__class__, plt.Axes):
+        dax = {'rc': {'handle': dax, 'type': 'matrix'}}
 
     # ----------
     # prepare

--- a/tofu/data/_class8_reverse_ray_tracing.py
+++ b/tofu/data/_class8_reverse_ray_tracing.py
@@ -620,22 +620,6 @@ def _prepare_lamb(
 
     dang = np.mean(np.diff(ang_rel))
 
-    # elif res_rock_curve is not None:
-    #     if isinstance(res_rock_curve, int):
-    #         nang = res_rock_curve
-    #     else:
-    #         nang = int(
-    #             (np.max(ang_rel) - np.min(ang_rel)) / res_rock_curve
-    #         )
-
-    #     ang_rel2 = np.linspace(np.min(ang_rel), np.max(ang_rel), nang)
-    #     pow_ratio = scpinterp.interp1d(
-    #         ang_rel,
-    #         pow_ratio,
-    #         kind='linear',
-    #     )(ang_rel2)
-    #     ang_rel = ang_rel2
-
     # --------------------------------------
     # overall bragg angle with rocking curve
     # --------------------------------------

--- a/tofu/data/_class8_reverse_ray_tracing.py
+++ b/tofu/data/_class8_reverse_ray_tracing.py
@@ -563,7 +563,11 @@ def _prepare_lamb(
         lamb = np.linspace(lambmin - 0.2*Dlamb, lambmax + 0.2*Dlamb, nlamb)
         dlamb = lamb[1] - lamb[0]
 
-        bragg = coll.get_crystal_bragglamb(key=kspectro, lamb=lamb)[0]
+        bragg = coll.get_crystal_bragglamb(
+            key=kspectro,
+            lamb=lamb,
+            rocking_curve=False,
+        )[0]
 
     elif lamb is not None:
 
@@ -575,7 +579,11 @@ def _prepare_lamb(
         )
         nlamb = lamb.size
         dlamb = None
-        bragg = coll.get_crystal_bragglamb(key=kspectro, lamb=lamb)[0]
+        bragg = coll.get_crystal_bragglamb(
+            key=kspectro,
+            lamb=lamb,
+            rocking_curve=False,
+        )[0]
 
     # ---------------
     # get bragg angle

--- a/tofu/data/_class8_reverse_ray_tracing.py
+++ b/tofu/data/_class8_reverse_ray_tracing.py
@@ -724,10 +724,12 @@ def _loop0(
     if append is True:
         lp0, lp1 = [], []
         lpx, lpy, lpz = [], [], []
+        dpow = {ll: [] for ll in lamb}
         lsang = []
     else:
         lp0, lp1 = None, None
         lpx, lpy, lpz = None, None, None
+        lpow = None
         lsang = None
 
     # power ratio
@@ -841,6 +843,14 @@ def _loop0(
             lp0.append(x0c[iok])
             lp1.append(x1c[iok])
 
+            # pow
+            for kk, ll in enumerate(lamb):
+                inds = np.searchsorted(
+                    angbragg[:, kk],
+                    angles[iok],
+                )
+                dpow[ll].append(pow_ratio[inds])
+
         # safety check
         iok2 = (
             (x0c[iok] >= cbin0[0])
@@ -948,6 +958,7 @@ def _loop0(
         'lpx': {'data': lpx, 'units': 'm'},
         'lpy': {'data': lpy, 'units': 'm'},
         'lpz': {'data': lpz, 'units': 'm'},
+        'dpow': {'data': dpow, 'units': ''},
         'lsang': {'data': lsang, 'units': 'sr'},
     }
 


### PR DESCRIPTION
Main changes:
----------------
* `get_crystal_bragglamb()` now return the non-corrected bragg angle by default 
    - fixes a double-correction of the bragg angle when doing ray-tracing with a rocking curve
* Changed rocking curve interpolation from nearest neighbor to linear 


Issues:
--------
Fixes, in devel, issue #917 

Examples:
-----------

Before fix:
![image](https://github.com/ToFuProject/tofu/assets/112180133/e90726e1-9fd0-4e49-976c-bc09631c06f7)

After:
![image](https://github.com/ToFuProject/tofu/assets/112180133/e6591715-bd59-4a27-b45d-30657946d16b)

