### PR TITLE
Better `interpolate_along_los()`: plotting + `'l_from_impact'`

### DIFF
--- a/tofu/data/_class2_compute.py
+++ b/tofu/data/_class2_compute.py
@@ -313,6 +313,8 @@ def _sample(
             kk[itot == np.nanmax(itot)] = 1.
         else:
             kk = [ii - np.floor(ii) for ii in itot]
+            for ij in range(len(kk)):
+                kk[ij][itot[ij] == np.nanmax(itot[ij])] = 1.
 
     lout = []
     for cc in return_coords:

--- a/tofu/data/_class8_los_data.py
+++ b/tofu/data/_class8_los_data.py
@@ -387,33 +387,32 @@ def _interpolate_along_los(
                         inplace=False,
                     )[c2d]
 
-                    llmin = pts_ll[jj][np.nanargmin(q2d['data'], axis=q2d['ref'].index(None))]
-
                     # check shapes
-                    pts_ll[jj], q2d, axis_los = _interpolate_along_los_reshape(
+                    pts_ll2, q2d, axis_los = _interpolate_along_los_reshape(
                         xdata=pts_ll[jj],
                         ydata=q2d['data'],
                         yref=q2d['ref'],
                     )
 
+                    llmin = pts_ll[jj][np.nanargmin(q2d, axis=axis_los)]
+
                     sli = tuple([
                         None if ij == axis_los else slice(None)
                         for ij in range(q2d.ndim)
                     ])
-                    pts_ll[jj] = pts_ll[jj] - llmin[sli]
+                    pts_ll2 = pts_ll2 - llmin[sli]
 
 
                     # concatenate
-                    iok = np.isfinite(q2d) & np.isfinite(pts_ll[jj])
                     if j0 == 0:
-                        dx[kk] = pts_ll[jj]
+                        dx[kk] = pts_ll2
                         dy[kk] = q2d
                         sh = list(q2d.shape)
                         sh[axis_los] = 1
                         nan = np.full(sh, np.nan)
                     else:
                         dx[kk] = np.concatenate(
-                            (dx[kk], nan, pts_ll[jj]),
+                            (dx[kk], nan, pts_ll2),
                             axis=axis_los,
                         )
                         dy[kk] = np.concatenate(
@@ -860,8 +859,8 @@ def _integrate_along_los_check(
             "\t\t'marker': ...,\n"
             "\t\t'ms': ...,\n"
             "\t}\n"
-            "\nProvided:\n{dcolor}\n"
-        )
+            "\nProvided:\n{dcolor}\n\n\n"
+        ) + str(err)
         raise Exception(msg)
 
     return (


### PR DESCRIPTION
Main changes:
----------------

* `interpolate_along_los(`) now:
    - accepts `key_coords='l_from_impact'`
    - is more robust vs non-concatenated data
    - allows to define all plotting features in `dcolor` (color, linestyle, linewidth, marker...)
    - `domain=dict` is operational for `'l_from_impact'` too


Issues:
--------

fixes, in devel, issue #936 