### PR TITLE
Better error msg when defining collimator camera

### DIFF
--- a/tofu/data/_class8_check.py
+++ b/tofu/data/_class8_check.py
@@ -232,7 +232,11 @@ def _check_doptics_basics(
             and all([isinstance(k1, str) for k1 in doptics[k0]['optics']])
         )
         if not c0:
-            _err_doptics(key=key, doptics=doptics)
+            _err_doptics(
+                key=key,
+                doptics=doptics,
+                extra_msg="\n'optics' must be a list or tuple of known optics!\n",
+            )
 
     # --------------------
     # level 1: checking each optics class

--- a/tofu/data/_class8_check.py
+++ b/tofu/data/_class8_check.py
@@ -191,7 +191,11 @@ def _check_doptics_basics(
         doptics = {doptics[0]: type(doptics)(doptics[1:])}
 
     if not isinstance(doptics, dict):
-        _err_doptics(key=key, doptics=doptics)
+        _err_doptics(
+            key=key,
+            doptics=doptics,
+            extra_msg="\nShould be a dict!\n",
+        )
 
     # ----------
     # check keys
@@ -205,7 +209,11 @@ def _check_doptics_basics(
     ])
 
     if not c0:
-        _err_doptics(key=key, doptics=doptics)
+        _err_doptics(
+            key=key,
+            doptics=doptics,
+            extra_msg="\nSome keys (cam) are not valid!\n",
+        )
 
     # --------------------------
     # start re-arranging as dict


### PR DESCRIPTION
Main changes:
----------------

* `add_diagnostic()` now displays more detailed error messages when there is an issue with `doptics`, in particular for collimator cameras

Issues:
-------

Fixes, in devel, issue #952 

