### PR TITLE
Optics order checking when creating a `diagnostic`: better warning msg + minor bugfix for `collimator` cameras

### DIFF
--- a/tofu/data/_class8_check.py
+++ b/tofu/data/_class8_check.py
@@ -483,6 +483,8 @@ def _check_optic(
                 f"{iout.nonzero()[0]}\n\n"
                 f"'{oo}':\n{dgeom}\n\n"
                 f"'{last_ref}':\n{dgeom_lastref}\n\n"
+                "Tip:\n"
+                "\tMake sure to provide optics ordered from camera to plasma"
             )
             raise Exception(msg)
 
@@ -497,13 +499,14 @@ def _check_optic(
 
         cx, cy, cz = dgeom_cam['cents']
         if ind_pix is None:
-            cx = coll.ddata[cx]['data'][ind_pix]
-            cy = coll.ddata[cy]['data'][ind_pix]
-            cz = coll.ddata[cz]['data'][ind_pix]
-        else:
             cx = coll.ddata[cx]['data'][None, ...]
             cy = coll.ddata[cy]['data'][None, ...]
             cz = coll.ddata[cz]['data'][None, ...]
+
+        else:
+            cx = coll.ddata[cx]['data'][ind_pix]
+            cy = coll.ddata[cy]['data'][ind_pix]
+            cz = coll.ddata[cz]['data'][ind_pix]
 
         # ------------------------
         # get pixel unit vector(s)
@@ -535,9 +538,14 @@ def _check_optic(
 
         if np.any(iout):
             msg = (
+                f"diag '{key}':\n"
                 f"The following points of {ocls} '{oo}' are on the wrong"
-                f"side of camera '{cam}':\n"
-                f"{np.unique(iout.nonzero()[0])}"
+                f"side of lastref {last_ref_cls} '{last_ref}':\n"
+                f"{iout.nonzero()[0]}\n\n"
+                f"'{oo}':\n{dgeom}\n\n"
+                f"'{last_ref}':\n{dgeom_lastref}\n\n"
+                "Tip:\n"
+                "\tMake sure to provide optics ordered from camera to plasma\n"
             )
             warnings.warn(msg)
 

--- a/tofu/data/_class8_check.py
+++ b/tofu/data/_class8_check.py
@@ -481,8 +481,8 @@ def _check_optic(
                 f"The following points of {ocls} '{oo}' are on the wrong"
                 f"side of lastref {last_ref_cls} '{last_ref}':\n"
                 f"{iout.nonzero()[0]}\n\n"
-                f"'{oo}':\n{dgeom}\n\n"
-                f"'{last_ref}':\n{dgeom_lastref}\n\n"
+                f"last ref {last_ref_cls} '{last_ref}':\n{dgeom_lastref}\n\n"
+                f"optics {ocls} '{oo}':\n{dgeom}\n\n"
                 "Tip:\n"
                 "\tMake sure to provide optics ordered from camera to plasma"
             )
@@ -542,8 +542,8 @@ def _check_optic(
                 f"The following points of {ocls} '{oo}' are on the wrong"
                 f"side of lastref {last_ref_cls} '{last_ref}':\n"
                 f"{iout.nonzero()[0]}\n\n"
-                f"'{oo}':\n{dgeom}\n\n"
-                f"'{last_ref}':\n{dgeom_lastref}\n\n"
+                f"last ref {last_ref_cls} '{last_ref}':\n{dgeom_lastref}\n\n"
+                f"optics {ocls} '{oo}':\n{dgeom}\n\n"
                 "Tip:\n"
                 "\tMake sure to provide optics ordered from camera to plasma\n"
             )


### PR DESCRIPTION
Main changes:
-----------------

* `add_diagnostic()`:
     - was testing all centers of all pixels for `optics` order, even when called for a single pixel in the case of collimator cameras
     - now print a more informative warning msg

* no numerical error found

![image](https://github.com/user-attachments/assets/6d4f7171-296d-4dcf-b414-7b7ff48648a3)

Issues:
--------

Fixes, in devel, issue #956 

Examples:
-----------

It should be noted that the etendue * length overestimates the VOS by a factor 10 because the sensors is 3 times larger than the collimator and analytical etendue formula assumes that the whole pixel is illuminated, which is clearly not the case here, by a factor 9 approximately

![image](https://github.com/user-attachments/assets/04c8265b-ccbd-4e50-b191-5ebe4396a6c1)
