### PR TITLE
Cross-diag inversions

### DIFF
--- a/tofu/data/_class08_Diagnostic.py
+++ b/tofu/data/_class08_Diagnostic.py
@@ -163,8 +163,8 @@ class Diagnostic(Previous):
         default=None,
         print_full_doc=None,
         **kwdargs,
-        ):
-        """ Return dict of data for chosen cameras
+    ):
+        """ Return dict of built-in data for chosen cameras
 
         data can be:
             'etendue'
@@ -177,7 +177,7 @@ class Diagnostic(Previous):
             'res'
 
         """
-        return _get_data._get_data(
+        return _get_data.main(
             coll=self,
             key=key,
             key_cam=key_cam,
@@ -200,7 +200,7 @@ class Diagnostic(Previous):
 
 
         """
-        return _concatenate._concatenate_data(
+        return _concatenate.main(
             coll=self,
             key=key,
             key_data=key_data,

--- a/tofu/data/_class08_concatenate_data.py
+++ b/tofu/data/_class08_concatenate_data.py
@@ -171,6 +171,9 @@ def _check(
 
             if lok is None:
                 lok = []
+            if lok_equi is None:
+                lok_equi = []
+
             key_data = ds._generic_check._check_var(
                 key_data, 'key_data',
                 types=str,
@@ -203,13 +206,13 @@ def _check(
 
     lcam = [coll.ddata[k0]['camera'] for k0 in key_data]
 
-    lc = [
+    lc = (
         [all([kcam in key_cam for kcam in lcam])]
         + [
             all([kcam in dcam_equi[kdiag] for kcam in lcam])
             for kdiag in ldiag_equi
         ]
-    ]
+    )
 
     if not any(lc):
         lstr = (
@@ -253,7 +256,7 @@ def _check(
         kdiag = ldiag_equi[lc.index(True) - 1]
         key_cam_equi = [k0 for k0 in dcam_equi[kdiag] if k0 in lcam]
         key_cam = [
-            k0 for k0, ii in enumerate(key_cam)
+            k0 for ii, k0 in enumerate(key_cam)
             if dcam_equi[kdiag][ii] in lcam
         ]
 

--- a/tofu/data/_class08_concatenate_data.py
+++ b/tofu/data/_class08_concatenate_data.py
@@ -6,6 +6,9 @@ Created on Thu May 30 13:39:45 2024
 """
 
 
+import itertools as itt
+
+
 import numpy as np
 import datastock as ds
 
@@ -16,7 +19,7 @@ import datastock as ds
 # ##################################################################
 
 
-def _concatenate_data(
+def main(
     coll=None,
     key=None,
     key_data=None,
@@ -27,7 +30,7 @@ def _concatenate_data(
     # ------------
     # check inputs
 
-    key, key_data, key_cam, is2d, stack, ref, flat = _concatenate_data_check(
+    key, key_data, key_cam, key_cam_equi, is2d, stack, ref, flat = _check(
         coll=coll,
         key=key,
         key_data=key_data,
@@ -84,6 +87,7 @@ def _concatenate_data(
         'data': data,
         'keys': key_data,
         'keys_cam': key_cam,
+        'keys_cam_equi': key_cam_equi,
         'units': units,
         'ref': ref,
         'axis': axis,
@@ -98,7 +102,7 @@ def _concatenate_data(
 # ##################################################################
 
 
-def _concatenate_data_check(
+def _check(
     coll=None,
     key=None,
     key_data=None,
@@ -115,6 +119,37 @@ def _concatenate_data_check(
     is2d = coll.dobj['diagnostic'][key]['is2d']
     stack = coll.dobj['diagnostic'][key]['stack']
 
+    # ---------------------------
+    # get list of equivalent camera series
+    # ---------------------------
+
+    wdiag = 'diagnostic'
+    wcam = 'camera'
+    ldiag_equi = [
+        kdiag
+        for kdiag, vdiag in coll.dobj.get(wdiag, {}).items()
+        if kdiag != key
+        and len(vdiag['camera']) == len(coll.dobj[wdiag][key]['camera'])
+        and all([
+            coll.dobj[wcam][vdiag['camera'][ii]]['dgeom']['shape']
+            == coll.dobj[wcam][kcam]['dgeom']['shape']
+            for ii, kcam in enumerate(coll.dobj[wdiag][key]['camera'])
+        ])
+    ]
+
+    # ---------------------------
+    # get list of equivalent camera series
+    # ---------------------------
+
+    dcam_equi = {
+        kdiag: [
+            coll.dobj[wdiag][kdiag]['camera'][ii]
+            for ii, kcam in enumerate(coll.dobj[wdiag][key]['camera'])
+            if kcam in key_cam
+        ]
+        for kdiag in ldiag_equi
+    }
+
     # ------------
     # key_data
     # ------------
@@ -129,12 +164,17 @@ def _concatenate_data_check(
 
         else:
             lok = coll.dobj['diagnostic'][key]['signal']
+            lok_equi = list(itt.chain.from_iterable([
+                coll.dobj['diagnostic'][kdiag]['signal']
+                for kdiag in ldiag_equi
+            ]))
+
             if lok is None:
                 lok = []
             key_data = ds._generic_check._check_var(
                 key_data, 'key_data',
                 types=str,
-                allowed=lok,
+                allowed=lok + lok_equi,
             )
 
             key_data = coll.dobj['synth sig'][key_data]['data']
@@ -157,26 +197,40 @@ def _concatenate_data_check(
         )
         raise Exception(msg)
 
-    # ---------------
-    # check cameras
-    # ---------------
+    # -----------------------
+    # check cameras validity
+    # -----------------------
 
-    # get excluded cameras, if any
-    dout = {
-        k0: coll.ddata[k0].get('camera')
-        for k0 in key_data
-        if coll.ddata[k0].get('camera') not in key_cam
-    }
-    if len(dout) > 0:
-        lstr = [f"\t- {k0}: {v0}" for k0, v0 in dout.items()]
+    lcam = [coll.ddata[k0]['camera'] for k0 in key_data]
+
+    lc = [
+        [all([kcam in key_cam for kcam in lcam])]
+        + [
+            all([kcam in dcam_equi[kdiag] for kcam in lcam])
+            for kdiag in ldiag_equi
+        ]
+    ]
+
+    if not any(lc):
+        lstr = (
+            [f"\t- {key_cam}"]
+            + [f"\t- {dcam_equi[kdiag]}" for kdiag in ldiag_equi]
+        )
+        lstr2 = [f"\t- '{k0}': '{lcam[ii]}'" for ii, k0 in enumerate(key_data)]
         msg = (
-            f"The following data refers to no known camera in diag '{key}':\n"
+            "All data provided must be associated to one "
+            "of the following cameras series:\n"
             + "\n".join(lstr)
+            + "But the provided data has:\n"
+            + "\n".join(lstr2)
         )
         raise Exception(msg)
 
+    # ---------------------
+    # check cameras unicity
+    # ---------------------
+
     # check unicity of cameras
-    lcam = [coll.ddata[k0]['camera'] for k0 in key_data]
     if len(set(lcam)) > len(lcam):
         msg = (
             f"Non-unique camera references for diag '{key}'\n:"
@@ -185,19 +239,40 @@ def _concatenate_data_check(
         )
         raise Exception(msg)
 
-    key_cam = [k0 for k0 in key_cam if k0 in lcam]
+    # ---------------------
+    # is_equi
+    # ---------------------
+
+    if lc[0]:
+
+        key_cam = [k0 for k0 in key_cam if k0 in lcam]
+        key_cam_equi = None
+        key_cam_ref = [coll.dobj[wcam][kk]['dgeom']['ref'] for kk in key_cam]
+
+    else:
+        kdiag = ldiag_equi[lc.index(True) - 1]
+        key_cam_equi = [k0 for k0 in dcam_equi[kdiag] if k0 in lcam]
+        key_cam = [
+            k0 for k0, ii in enumerate(key_cam)
+            if dcam_equi[kdiag][ii] in lcam
+        ]
+
+        key_cam_ref = [coll.dobj[wcam][kk]['dgeom']['ref'] for kk in key_cam_equi]
 
     # ------------
-    # re-order
+    # re-order data
     # -------------
 
-    key_data = [key_data[lcam.index(k0)] for k0 in key_cam]
+    if key_cam_equi is None:
+        key_data = [key_data[lcam.index(k0)] for k0 in key_cam]
+    else:
+        key_data = [key_data[lcam.index(k0)] for k0 in key_cam_equi]
 
-    # ref uniformity
+    # check uniformity of ref dimensions
     lref = [coll.ddata[k0]['ref'] for k0 in key_data]
     if any([len(ref) != len(lref[0]) for ref in lref[1:]]):
         msg = (
-            f"Non uniform refs for data in diag '{key}':\n"
+            f"Non uniform refs length for data in diag '{key}':\n"
             f"\t- key_data = {key_data}\n"
             f"\t- lref = {lref}\n"
         )
@@ -208,21 +283,20 @@ def _concatenate_data_check(
     # -------------
 
     laxcam = [
-        [
-            ref.index(rr)
-            for rr in coll.dobj['camera'][key_cam[ii]]['dgeom']['ref']
-        ]
+        [ref.index(rr) for rr in key_cam_ref[ii]]
         for ii, ref in enumerate(lref)
     ]
+
+    # check all 2d or all 1d (future: flatten if needed)
     if any([len(ax) != len(laxcam[0]) for ax in laxcam[1:]]):
         msg = (
             f"Non-uniform camera concatenation axis for diag '{key}':\n"
             f"\t- key_data: {key_data}\n"
             f"\t- laxcam:   {laxcam}"
         )
-        import pdb; pdb.set_trace()     # DB
         raise Exception(msg)
 
+    # concatenation axis uniformity
     laxcam = np.array(laxcam)
     if not np.allclose(laxcam, laxcam[0:1, :]):
         msg = (
@@ -232,6 +306,7 @@ def _concatenate_data_check(
         raise Exception(msg)
     axcam = laxcam[0]
 
+    # consistency vs is2d
     if len(axcam) != 1 + is2d:
         msg = (
             f"ref not consistent with is2d for diag '{key}':\n"
@@ -240,6 +315,7 @@ def _concatenate_data_check(
         )
         raise Exception(msg)
 
+    # get unique ref and set concatenation axis to None
     ref = list(lref[0])
     for ii in axcam:
         ref[ii] = None
@@ -254,320 +330,4 @@ def _concatenate_data_check(
         default=is2d,
     )
 
-    return key, key_data, key_cam, is2d, stack, ref, flat
-
-
-# ##################################################################
-# ##################################################################
-#                   back-up
-# ##################################################################
-
-
-# def _concatenate_check(
-    # coll=None,
-    # key=None,
-    # key_cam=None,
-    # data=None,
-    # rocking_curve=None,
-    # returnas=None,
-    # # naming
-    # key_data=None,
-    # key_ref=None,
-    # **kwdargs,
-    # ):
-
-    # # -------------
-    # # key, key_cam
-    # # -------------
-
-    # key, key_cam = coll.get_diagnostic_cam(key=key, key_cam=key_cam)
-    # spectro = coll.dobj['diagnostic'][key]['spectro']
-    # is2d = coll.dobj['diagnostic'][key]['is2d']
-    # # stack = coll.dobj['diagnostic'][key]['stack']
-
-    # if is2d and len(key_cam) > 1:
-        # msg = (
-            # "Cannot yet concatenate several 2d cameras\n"
-            # "\t- key: '{key}'\n"
-            # "\t- is2d: {is2d}\n"
-            # "\t- key_cam: {key_cam}\n"
-        # )
-        # raise NotImplementedError(msg)
-
-    # # ---------------
-    # # build ddata
-    # # -------------
-
-    # # basic check on data
-    # if data is not None:
-        # lquant = ['los', 'etendue', 'amin', 'amax']
-        # lcomp = ['tangency radius']
-        # if spectro:
-            # lcomp += ['lamb', 'lambmin', 'lambmax', 'res']
-
-        # data = ds._generic_check._check_var(
-            # data, 'data',
-            # types=str,
-            # allowed=lquant + lcomp,
-        # )
-
-    # # build ddata
-    # ddata = {}
-    # comp = False
-    # if data is None or data in lquant:
-
-        # # --------------------------
-        # # data is None => kwdargs
-
-        # if data is None:
-            # # check kwdargs
-            # dparam = coll.get_param(which='data', returnas=dict)
-            # lkout = [k0 for k0 in kwdargs.keys() if k0 not in dparam.keys()]
-
-            # if len(lkout) > 0:
-                # msg= (
-                    # "The following args correspond to no data parameter:\n"
-                    # + "\n".join([f"\t- {k0}" for k0 in lkout])
-                # )
-                # raise Exception(msg)
-
-            # # list all available data
-            # lok = [
-                # k0 for k0, v0 in coll.ddata.items()
-                # if v0.get('camera') in key_cam
-            # ]
-
-            # # Adjust with kwdargs
-            # if len(kwdargs) > 0:
-                # lok2 = coll.select(
-                    # which='data', log='all', returnas=str, **kwdargs,
-                # )
-                # lok = [k0 for k0 in lok2 if k0 in lok]
-
-            # # check there is 1 data per cam
-            # lcam = [
-                # coll.ddata[k0]['camera'] for k0 in lok
-                # if coll.ddata[k0]['camera'] in key_cam
-            # ]
-
-            # if len(set(lcam)) > len(key_cam):
-                # msg = (
-                    # "There are more / less data identified than cameras:\n"
-                    # f"\t- key_cam:  {key_cam}\n"
-                    # f"\t- data cam: {lcam}\n"
-                    # f"\t- data: {data}"
-                # )
-                # raise Exception(msg)
-            # elif len(set(lcam)) < len(key_cam):
-                # pass
-
-            # # reorder
-            # ddata = {
-                # cc: [lok[lcam.index(cc)]]
-                # for cc in key_cam if cc in lcam
-            # }
-
-        # # -----------------
-        # # data in lquant
-
-        # elif data in lquant:
-            # for cc in key_cam:
-                # if data == 'los':
-                    # kr = coll.dobj['diagnostic'][key]['doptics'][cc][data]
-                    # dd = coll.dobj['rays'][kr]['pts']
-                # else:
-                    # dd = coll.dobj['diagnostic'][key]['doptics'][cc][data]
-                # lc = [
-                    # isinstance(dd, str) and dd in coll.ddata.keys(),
-                    # isinstance(dd, tuple)
-                    # and all([isinstance(di, str) for di in dd])
-                    # and all([di in coll.ddata.keys() for di in dd])
-                # ]
-                # if lc[0]:
-                    # ddata[cc] = [dd]
-                # elif lc[1]:
-                    # ddata[cc] = list(dd)
-                # elif dd is None:
-                    # pass
-                # else:
-                    # msg = f"Unknown data: '{data}'"
-                    # raise Exception(msg)
-
-        # # dref
-        # dref = {
-            # k0: [coll.ddata[k1]['ref'] for k1 in v0]
-            # for k0, v0 in ddata.items()
-        # }
-
-    # # --------------------
-    # # data to be computed
-
-    # # TBF
-    # elif data in lcomp:
-
-        # comp = True
-        # ddata = {[None] for cc in key_cam}
-        # dref = {[None] for cc in key_cam}
-
-        # if data in ['lamb', 'lambmin', 'lambmax', 'res']:
-            # for cc in key_cam:
-               # ddata[cc][0], dref[cc][0] = coll.get_diagnostic_lamb(
-                   # key=key,
-                   # key_cam=cc,
-                   # rocking_curve=rocking_curve,
-                   # lamb=data,
-               # )
-
-        # elif data == 'tangency radius':
-            # ddata[cc][0], _, dref[cc][0] = coll.get_rays_tangency_radius(
-                # key=key,
-                # key_cam=key_cam,
-                # segment=-1,
-                # lim_to_segments=False,
-            # )
-
-    # # -----------------------------------
-    # # Final safety checks and adjustments
-    # # -----------------------------------
-
-    # # adjust key_cam
-    # key_cam = [cc for cc in key_cam if cc in ddata.keys()]
-
-    # # ddata vs dref vs key_cam
-    # lcd = sorted(list(ddata.keys()))
-    # lcr = sorted(list(dref.keys()))
-    # if not (sorted(key_cam) == lcd == lcr):
-        # msg = (
-            # "Wrong keys!\n"
-            # f"\t- key_cam: {key_cam}\n"
-            # f"\t- ddata.keys(): {lcd}\n"
-            # f"\t- dref.keys(): {lcr}\n"
-        # )
-        # raise Exception(msg)
-
-    # # nb of data per cam
-    # ln = [len(v0) for v0 in ddata.values()]
-    # if len(set(ln)) != 1:
-        # msg = (
-            # "Not the same number of data per cameras!\n"
-            # + str(ddata)
-        # )
-        # raise Exception(msg)
-
-    # # check shapes and ndim
-    # dshapes = {
-        # k0: [tuple([coll.dref[k2]['size'] for k2 in k1]) for k1 in v0]
-        # for k0, v0 in dref.items()
-    # }
-
-    # # all same ndim
-    # ndimref = None
-    # for k0, v0 in dshapes.items():
-        # lndim = [len(v1) for v1 in v0]
-        # if len(set(lndim)) > 1:
-            # msg = "All data must have same number of dimensions!\n{dshapes}"
-            # raise Exception(msg)
-        # if ndimref is None:
-            # ndimref = lndim[0]
-        # elif lndim[0] != ndimref:
-            # msg = "All data must have same number of dimensions!\n{dshapes}"
-            # raise Exception(msg)
-
-    # # check indices of camera ref in data ref
-    # indref = None
-    # for k0, v0 in dref.items():
-        # for v1 in v0:
-            # ind = [v1.index(rr) for rr in coll.dobj['camera'][k0]['dgeom']['ref']]
-            # if indref is None:
-                # indref = ind
-            # elif ind != indref:
-                # msg = "All data must have same index of cam ref!\n{drf}"
-                # raise Exception(msg)
-
-    # if len(indref) > 1:
-        # msg = "Cannot conatenate 2d cameras so far"
-        # raise Exception(msg)
-
-    # # check all shapes other than camera shapes are identical
-    # if ndimref > len(indref):
-        # ind = np.delete(np.arange(0, ndimref), indref)
-        # shape0 = tuple(np.r_[dshapes[key_cam[0]][0]][ind])
-        # lcout = [
-            # cc for cc in key_cam
-            # if any([tuple(np.r_[vv][ind]) != shape0 for vv in dshapes[cc]])
-        # ]
-        # if len(lcout) > 0:
-            # msg = (
-                # "The cameras data shall all have same shape (except pixels)\n"
-                # + str(dshapes)
-            # )
-            # raise Exception(msg)
-
-    # # check indices of camera ref in data ref
-    # ref = None
-    # for k0, v0 in dref.items():
-        # for v1 in v0:
-            # if ref is None:
-                # ref = [
-                    # None if ii == indref[0] else rr
-                    # for ii, rr in enumerate(v1)
-                # ]
-            # else:
-                # lc = [
-                    # v1[ii] == ref[ii] for ii in range(ndimref)
-                    # if ii not in indref
-                # ]
-                # if not all(lc):
-                    # msg = (
-                        # "All ref axcept the camera ref must be the same!\n"
-                        # f"\t- ref: {ref}\n"
-                        # f"\t- indref: {indref}\n"
-                        # f"\t- ndimref: {ndimref}\n"
-                        # f"\t- v1: {v1}\n"
-                        # f"\t- lc: {lc}\n"
-                        # + str(dref)
-                    # )
-                    # raise Exception(msg)
-
-    # # -----------------------------------
-    # # keys for new data and ref
-    # # -----------------------------------
-
-    # if key_data is None:
-        # if data in lquant + lcomp:
-            # if data == 'los':
-                # key_data = [
-                    # f'{key}_los_ptsx',
-                    # f'{key}_los_ptsy',
-                    # f'{key}_los_ptsz',
-                # ]
-            # else:
-                # key_data = [f'{key}_{data}']
-        # else:
-            # key_data = [f'{key}_data']
-    # elif isinstance(key_data, str):
-        # key_data = [key_data]
-
-    # if key_ref is None:
-        # key_ref = f'{key}_npix'
-
-    # ref = tuple([key_ref if rr is None else rr for rr in ref])
-
-    # # -----------------------------------
-    # # Other variables
-    # # -----------------------------------
-
-    # # returnas
-    # returnas = ds._generic_check._check_var(
-        # returnas, 'returnas',
-        # default='Datastock',
-        # allowed=[dict, 'Datastock'],
-    # )
-
-    # return (
-        # key, key_cam, is2d,
-        # ddata, ref, comp,
-        # dshapes, ndimref, indref,
-        # key_data, key_ref,
-        # returnas,
-    # )
+    return key, key_data, key_cam, key_cam_equi, is2d, stack, ref, flat

--- a/tofu/data/_class08_get_data.py
+++ b/tofu/data/_class08_get_data.py
@@ -23,7 +23,7 @@ from . import _class08_get_data_vos_spectro
 # ##################################################################
 
 
-def _get_data(
+def main(
     coll=None,
     key=None,
     key_cam=None,
@@ -40,12 +40,12 @@ def _get_data(
     # ----------------
 
     (
-     key, key_cam,
-     spectro, is_vos, is_3d,
-     data,
-     lok, lcam, lquant,
-     davail,
-    ) = _get_data_check(
+        key, key_cam,
+        spectro, is_vos, is_3d,
+        data,
+        lok, lcam, lquant,
+        davail,
+    ) = _check(
         coll=coll,
         key=key,
         key_cam=key_cam,
@@ -270,7 +270,7 @@ def _get_data(
 # ##################################################################
 
 
-def _get_data_check(
+def _check(
     coll=None,
     key=None,
     key_cam=None,
@@ -300,11 +300,11 @@ def _get_data_check(
     # execute
     if print_full_doc is True:
         davail = _class08_get_data_def.get_davail()
-        _get_data_print(davail)
+        _print(davail)
 
     # stop here if relevant
     if pdef is True:
-        return [None]*14
+        return [None]*10
 
     # --------------
     # key, key_cam
@@ -373,7 +373,7 @@ def _get_data_check(
 
     if all(lc) and print_full_doc is False:
 
-        _get_data_print(
+        _print(
             davail,
             key=key,
             spectro=spectro,
@@ -457,7 +457,7 @@ def _get_data_check(
         except Exception as err:
             msg = (
                 f"{err}\n"
-                + _get_data_print(
+                + _print(
                     davail,
                     key=key,
                     spectro=spectro,
@@ -469,11 +469,11 @@ def _get_data_check(
             raise Exception(msg)
 
     return (
-     key, key_cam,
-     spectro, is_vos, is_3d,
-     data,
-     lok, lcam, lquant,
-     davail,
+        key, key_cam,
+        spectro, is_vos, is_3d,
+        data,
+        lok, lcam, lquant,
+        davail,
     )
 
 
@@ -483,7 +483,7 @@ def _get_data_check(
 # ##################################################################
 
 
-def _get_data_print(
+def _print(
     davail,
     key=None,
     spectro=None,
@@ -508,7 +508,7 @@ def _get_data_print(
 
     msg = "\n\n##############################################\n"
     if key is None:
-        msg += "The following data is available in general:\n\n"
+        msg += "The following built-in data is available in general:\n\n"
     else:
         msg += (
             f"The following data is available for '{key}':\n"

--- a/tofu/data/_class10_checks.py
+++ b/tofu/data/_class10_checks.py
@@ -148,7 +148,7 @@ def _compute_check(
     )
 
     if reft is None:
-        reft = f'{key}-nt'
+        reft = f'{key}_nt'
 
     # update all accordingly
     if hastime and dindt is not None:

--- a/tofu/data/_class10_refs.py
+++ b/tofu/data/_class10_refs.py
@@ -26,6 +26,10 @@ def _get_ref_vector_common(
     dconstraints=None,
     strategy=None,
     strategy_bounds=None,
+    # exclude from search
+    key_exclude=None,
+    ref_exclude=None,
+    # others
     dref_vector=None,
 ):
 
@@ -88,7 +92,12 @@ def _get_ref_vector_common(
 
     refc1 = None
     if ddata is not None:
-        key_cam = ddata['keys_cam']
+
+        # handle equivalent diag / cameras
+        kcameq = 'keys_cam' if ddata['keys_cam_equi'] is None else 'keys_cam_equi'
+        key_cam = ddata[kcameq]
+
+        # loop
         for ii, k0 in enumerate(ddata['keys']):
             refi = [
                 rr for rr in coll.ddata[k0]['ref']
@@ -100,6 +109,7 @@ def _get_ref_vector_common(
                     "Multiple possible non-camera refs for ddata[k0]:\n"
                     f"\t- k0: {k0}\n"
                     f"\t- ii: {ii}\n"
+                    f"\t- key_cam_equi: {ddata['keys_cam'] is not None}\n"
                     f"\t- key_cam[ii]: {key_cam[ii]}\n"
                     f"\t- coll.dobj['camera']['{key_cam[ii]}']['dgeom']['ref']: {coll.dobj['camera'][key_cam[ii]]['dgeom']['ref']}\n"
                     f"\t- coll.ddata['{k0}']['ref']: {coll.ddata[k0]['ref']}\n"
@@ -194,5 +204,9 @@ def _get_ref_vector_common(
             ref=refc,
             strategy=strategy,
             strategy_bounds=strategy_bounds,
+            # exclude from search
+            key_exclude=key_exclude,
+            ref_exclude=ref_exclude,
+            # others
             **dref_vector,
         )


### PR DESCRIPTION
Caveat:
--------

Requires `datastock >= 0.0.40` (or `devel` branch post [PR163](https://github.com/ToFuProject/datastock/pull/163))

Main changes:
----------------

* Introducing the concept of equivalent diagnostic. Two diagnostics are eqivalent if:
      - they have the same number of cameras
      - each camera of the first diagnostic can be associated to a camera of the other with eaxctly the same shape (nb. of pixels)
      - This is a way of ensuring compatibility of array shapes for matrix operations

* add_inversion(data=...) now accepts data from other diagnostics if they are equivalent
       - The reference diagnostic is the one associated to the geometry matrix
       - e.g: accepts synthetic data computed by a different diagnostic as long as it is equivalent

Details:
--------

* Most changes occur in `datastock` (main dependency of `tofu`, and in the following tofu routines:
     - 

Issues:
-------

Fixes, in devel, issue #958 