### PR TITLE
Get rid of `np.int`

### DIFF
--- a/tofu/imas2tofu/_comp.py
+++ b/tofu/imas2tofu/_comp.py
@@ -33,6 +33,14 @@ except Exception as err:
     raise Exception('imas not available')
 
 
+# Useful scalar types
+_NINT = (np.int32, np.int64)
+_INT = (int,) + _NINT
+_NFLOAT = (np.float32, np.float64)
+_FLOAT = (float,) + _NFLOAT
+_NUMB = _INT + _FLOAT
+
+
 _DSHORT = _defimas2tofu._dshort
 _DCOMP = _defimas2tofu._dcomp
 _DDUNITS = imas.dd_units.DataDictionaryUnits()
@@ -255,7 +263,7 @@ def get_fsig(sig):
             ),
             (
                 stack and nsig > 1
-                and type(sig[0]) in [int, float, np.int_, np.float64, str]
+                and isinstance(sig[0], _NUMB + (str,))
             ),
             (
                 stack and nsig == 1
@@ -494,7 +502,7 @@ def _checkformat_getdata_indch(indch, nch):
 
     lc0 = [
         indch is None,
-        isinstance(indch, int),
+        isinstance(indch, _INT),
         hasattr(indch, '__iter__') and not isinstance(indch, str),
     ]
 
@@ -588,7 +596,7 @@ def _check_data(data, pos=None, nan=None, isclose=None, empty=None):
         for ii in range(0, len(data)):
             c0 = (
                 isinstance(data[ii], np.ndarray)
-                and any([ss in data[ii].dtype.name for ss in ['int', 'float']])
+                and data.dtype in _NUMB
             )
             if c0 is True:
                 # Make sure to test only non-nan to avoid warning

--- a/tofu/imas2tofu/_core.py
+++ b/tofu/imas2tofu/_core.py
@@ -935,7 +935,9 @@ class MultiIDSLoader(object):
             defidd = cls._defidd
 
         if lc[0]:
-            assert type(shot) in [int,np.int_]
+            # check type is int or numpy int
+            assert type(shot) == int, type(shot)
+
             params = dict(
                 shot=int(shot), run=run, refshot=refshot, refrun=refrun,
                 user=user, database=database, version=version,
@@ -1201,8 +1203,8 @@ class MultiIDSLoader(object):
 
         if occ is None:
             occ = 0
-        lc = [type(occ) in [int, np.int], hasattr(occ, '__iter__')]
-        assert any(lc)
+        lc = [type(occ) == int, hasattr(occ, '__iter__')]
+        assert any(lc), occ
 
         if lc[0]:
             occ = [np.r_[occ].astype(int) for _ in range(nids)]
@@ -1487,7 +1489,7 @@ class MultiIDSLoader(object):
             raise Exception(msg)
         if lc[1] or lc[2]:
             indt = np.r_[indt].rave()
-            lc = [indt.dtype == np.int]
+            lc = [indt.dtype == int]
             if not any(lc):
                 raise Exception(msg)
             assert np.all(indt>=0)
@@ -1677,7 +1679,7 @@ class MultiIDSLoader(object):
         if t0 is None:
             t0 = _defimas2tofu._T0
         elif t0 != False:
-            if type(t0) in [int, float, np.int_, np.float64]:
+            if type(t0) in [int, float, np.float64]:
                 t0 = float(t0)
             elif type(t0) is str:
                 t0 = t0.strip()
@@ -2317,7 +2319,7 @@ class MultiIDSLoader(object):
         """
         names, times = None, None
         c0 = (isinstance(tlim, list)
-              and all([type(tt) in [float, int, np.float64, np.int_]
+              and all([type(tt) in [float, int, np.float64]
                        for tt in tlim]))
         if not c0 and 'pulse_schedule' in self._dids.keys():
             try:

--- a/tofu/imas2tofu/_mat2ids2calc.py
+++ b/tofu/imas2tofu/_mat2ids2calc.py
@@ -19,6 +19,9 @@ _MSG0 = ("The input file structure is not as expected !\n"
          + "  => Maybe corrupted data ?\n")
 
 
+_LTYPES = (int, float, np.integer, np.float64)
+
+
 # ####################################################
 #               Utility
 # ####################################################
@@ -34,8 +37,7 @@ def _get_indtlim(t, tlim=None, shot=None, out=bool):
         tlim = [-np.inf, np.inf]
     else:
         assert len(tlim) == 2
-        ls = [int, float, np.float64]     # , str
-        assert all([tt is None or type(tt) in ls for tt in tlim])
+        assert all([tt is None or isinstance(tt, _LTYPES) for tt in tlim])
         tlim = list(tlim)
         for (ii, sgn) in [(0, -1.), (1, 1.)]:
             if tlim[ii] is None:

--- a/tofu/imas2tofu/_mat2ids2calc.py
+++ b/tofu/imas2tofu/_mat2ids2calc.py
@@ -34,7 +34,7 @@ def _get_indtlim(t, tlim=None, shot=None, out=bool):
         tlim = [-np.inf, np.inf]
     else:
         assert len(tlim) == 2
-        ls = [int, float, np.int64, np.float64]     # , str
+        ls = [int, float, np.float64]     # , str
         assert all([tt is None or type(tt) in ls for tt in tlim])
         tlim = list(tlim)
         for (ii, sgn) in [(0, -1.), (1, 1.)]:

--- a/tofu/nist2tofu/_requests.py
+++ b/tofu/nist2tofu/_requests.py
@@ -48,7 +48,7 @@ _DOP = {
 }
 
 
-_LTYPES = [int, float, np.float64]
+_LTYPES = (int, float, np.integer, np.float64)
 
 
 _DCERTIFICATES_BUNDLE = {
@@ -221,7 +221,7 @@ def _get_totalurl(
         if v0 is None:
             dlamb[k0] = ''
         else:
-            c0 = type(v0) in _LTYPES
+            c0 = isinstance(v0, _LTYPES)
             if not c0:
                 msg = (
                     "Arg {} must be a float!\n".format(k0)

--- a/tofu/nist2tofu/_requests.py
+++ b/tofu/nist2tofu/_requests.py
@@ -48,7 +48,7 @@ _DOP = {
 }
 
 
-_LTYPES = [int, float, np.int_, np.float64]
+_LTYPES = [int, float, np.float64]
 
 
 _DCERTIFICATES_BUNDLE = {

--- a/tofu/spectro/_analysis_tools.py
+++ b/tofu/spectro/_analysis_tools.py
@@ -17,10 +17,16 @@ __all__ = [
 ]
 
 
-_LTYPES = (int, float, np.integer, np.float64)
-
 _GITHUB = 'https://github.com/ToFuProject/tofu/issues'
 _WINTIT = f'tofu-{__version__}\treport issues / requests at {_GITHUB}'
+
+
+# Useful scalar types
+_NINT = (np.int32, np.int64)
+_INT = (int,) + _NINT
+_NFLOAT = (np.float32, np.float64)
+_FLOAT = (float,) + _NFLOAT
+_NUMB = _INT + _FLOAT
 
 
 ###########################################################
@@ -127,7 +133,7 @@ def _get_localextrema_1d_check(
             width = 0.
         else:
             width = False
-    c0 = width is False or (isinstance(width, _LTYPES) and width >= 0.)
+    c0 = width is False or (isinstance(width, _NUMB) and width >= 0.)
     if not c0:
         msg = (
             "Arg width must be a float\n"
@@ -146,7 +152,7 @@ def _get_localextrema_1d_check(
 
     if rel_height is None:
         rel_height = 0.8
-    if not (isinstance(rel_height, _LTYPES) and 0 <= rel_height <= 1.):
+    if not (isinstance(rel_height, _NUMB) and 0 <= rel_height <= 1.):
         msg = (
             "Arg rel_height must be positive float in [0, 1]!\n"
             + "Provided: {}".format(rel_height)

--- a/tofu/spectro/_analysis_tools.py
+++ b/tofu/spectro/_analysis_tools.py
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-_LTYPES = [int, float, np.int_, np.float64]
+_LTYPES = (int, float, np.integer, np.float64)
 
 _GITHUB = 'https://github.com/ToFuProject/tofu/issues'
 _WINTIT = f'tofu-{__version__}\treport issues / requests at {_GITHUB}'
@@ -127,7 +127,7 @@ def _get_localextrema_1d_check(
             width = 0.
         else:
             width = False
-    c0 = width is False or (type(width) in _LTYPES and width >= 0.)
+    c0 = width is False or (isinstance(width, _LTYPES) and width >= 0.)
     if not c0:
         msg = (
             "Arg width must be a float\n"
@@ -146,7 +146,7 @@ def _get_localextrema_1d_check(
 
     if rel_height is None:
         rel_height = 0.8
-    if not (type(rel_height) in _LTYPES and 0 <= rel_height <= 1.):
+    if not (isinstance(rel_height, _LTYPES) and 0 <= rel_height <= 1.):
         msg = (
             "Arg rel_height must be positive float in [0, 1]!\n"
             + "Provided: {}".format(rel_height)

--- a/tofu/tests/tests01_geom/test_01_GG.py
+++ b/tofu/tests/tests01_geom/test_01_GG.py
@@ -13,6 +13,14 @@ from .testing_tools import compute_ves_norm
 VerbHead = 'tofu.geom.test_01_GG'
 
 
+# Useful scalar types
+_NINT = (np.int32, np.int64)
+_INT = (int,) + _NINT
+_NFLOAT = (np.float32, np.float64)
+_FLOAT = (float,) + _NFLOAT
+_NUMB = _INT + _FLOAT
+
+
 #######################################################
 #
 #     Setup and Teardown

--- a/tofu/utils.py
+++ b/tofu/utils.py
@@ -32,6 +32,14 @@ _NSAVETYP = len(_SAVETYP)
 _LIDS_CUSTOM = ['magfieldlines', 'events', 'shortcuts', 'config']
 
 
+# Useful scalar types
+_NINT = (np.int32, np.int64)
+_INT = (int,) + _NINT
+_NFLOAT = (np.float32, np.float64)
+_FLOAT = (float,) + _NFLOAT
+_NUMB = _INT + _FLOAT
+
+
 ###############################################
 #           File searching
 ###############################################
@@ -1596,8 +1604,8 @@ def _check_InputsGeneric(ld, tab=0):
     bstr1 = "\n"+"    "*(tab+1) + "Expected: "
     bstr2 = "\n"+"    "*(tab+1) + "Provided: "
 
-    ltypes_f2i = [int, float, np.integer, np.floating]
-    ltypes_i2f = [int, float, np.integer, np.floating]
+    ltypes_f2i = _NUMB
+    ltypes_i2f = _NUMB
 
     # Check
     err, msg = False, ''
@@ -2137,7 +2145,7 @@ class ToFuObjectBase(object):
                         if not eqk:
                             m0 = str(d0[k])
                             m1 = str(d1[k])
-                    elif type(d0[k]) in [int,float,np.int64,np.float64]:
+                    elif isinstance(d0[k], _NUMB):
                         eqk = np.allclose([d0[k]],[d1[k]], equal_nan=True)
                         if not eqk:
                             m0 = str(d0[k])
@@ -2356,7 +2364,7 @@ class ToFuObject(ToFuObjectBase):
     @staticmethod
     def _checkformat_scalar(ss, name='ss', extramsg=''):
         if ss is not None:
-            if type(ss) not in [int, float, np.int_, np.float64]:
+            if not isinstance(ss, _NUMB):
                 msg = ("Please provide {} as a float:\n".format(name)
                        + "\t- provided: {} ({})\n".format(ss, type(ss))
                        + extramsg)
@@ -3146,7 +3154,7 @@ class DChans(object):
             return ind
 
         lt0 = [list, tuple, np.ndarray]
-        lt1 = [str, int, float, np.int64, np.float64, bool]
+        lt1 = _NUMB + (bool,)
         C0 = log in ['any', 'all']
         C1 = type(log) in lt0 and all([ll in ['any', 'all'] for ll in log])
         assert C0 or C1, "Arg out is not valid ('any','all' or an iterable) !"
@@ -3510,7 +3518,7 @@ class KeyHandler_mpl(object):
             c2 = all([s in v.keys() for s in ls])
             if not (c0 and c1 and c2):
                 raise Exception(cls._msgdobj)
-            assert type(v['nMax']) in [int,np.int64]
+            assert type(v['nMax']) in _INT
             assert type(v['key']) is str
             assert v['defax'] in dax.keys()
         lg = sorted(list(dgroup.keys()))


### PR DESCRIPTION
Main changes:
----------------

New strategy for int/ float type checks

```
# Useful scalar types
_NINT = (np.int32, np.int64)
_INT = (int,) + _NINT
_NFLOAT = (np.float32, np.float64)
_FLOAT = (float,) + _NFLOAT
_NUMB = _INT + _FLOAT
```

And always run `isinstance()`

Because the behaviour of `np.int`, `np.int_` or `np.integer` is too dependent on the version of numpy and on the plateform 
Also shows different results depending is using `type()` or `dtype` or `isinstance()`
* `isintance()` allows multiple types and subclasses
* Better to use tuple of all explicit numpy types that resort to generic types

Issues:
-------

Fixes, in devel, issue #983