### PR TITLE
Issue984 sub cam

### DIFF
--- a/tofu/data/_class08_Diagnostic.py
+++ b/tofu/data/_class08_Diagnostic.py
@@ -241,6 +241,7 @@ class Diagnostic(Previous):
         verb=None,
         plot=None,
         store=None,
+        overwrite=None,
         debug=None,
     ):
         """ Compute the etendue of the diagnostic (per pixel)
@@ -252,7 +253,7 @@ class Diagnostic(Previous):
         """
 
         # prepare computation
-        dcompute, store = _etendue_los.compute_etendue_los(
+        dcompute, store, overwrite = _etendue_los.compute_etendue_los(
             coll=self,
             key=key,
             # etendue
@@ -273,6 +274,7 @@ class Diagnostic(Previous):
             verb=verb,
             plot=plot,
             store=store,
+            overwrite=overwrite,
             debug=debug,
         )
 
@@ -293,6 +295,7 @@ class Diagnostic(Previous):
                 key_nseg=key_nseg,
                 dcompute=dcompute,
                 compute_vos_from_los=compute_vos_from_los,
+                overwrite=overwrite,
             )
 
     def compute_diagnostic_solidangle_from_plane(

--- a/tofu/data/_class8_etendue_los.py
+++ b/tofu/data/_class8_etendue_los.py
@@ -47,6 +47,7 @@ def compute_etendue_los(
     verb=None,
     plot=None,
     store=None,
+    overwrite=None,
     debug=None,
 ):
 
@@ -69,6 +70,7 @@ def compute_etendue_los(
         verb,
         plot,
         store,
+        overwrite,
     ) = _check(
         coll=coll,
         key=key,
@@ -81,6 +83,7 @@ def compute_etendue_los(
         verb=verb,
         plot=plot,
         store=store,
+        overwrite=overwrite,
     )
 
     # -----------
@@ -313,8 +316,18 @@ def compute_etendue_los(
                 },
             }
 
-            coll.update(ddata=ddata)
+            # check vs overwrite
+            if ketendue in coll.ddata.keys():
+                if overwrite is True:
+                    coll.remove_data(ketendue, propagate=False)
+                else:
+                    msg = (
+                        "data '{ketendue}' already exists!\n"
+                        "Use overwrite=True to force overwriting\n"
+                    )
+                    raise Exception(msg)
 
+            coll.update(ddata=ddata)
             coll._dobj['diagnostic'][key]['doptics'][key_cam]['etendue'] = ketendue
             coll._dobj['diagnostic'][key]['doptics'][key_cam]['etend_type'] = etend_type
 
@@ -336,10 +349,21 @@ def compute_etendue_los(
                     },
                 }
 
+                # check vs overwrite
+                if ketendue in coll.ddata.keys():
+                    if overwrite is True:
+                        coll.remove_data(ketendue, propagate=False)
+                    else:
+                        msg = (
+                            f"data '{ketendue}' already exists!\n"
+                            "Use overwrite=True to force overwriting\n"
+                        )
+                        raise Exception(msg)
+
                 coll.update(ddata=ddata)
                 coll._dobj['diagnostic'][key]['doptics'][key_cam]['etendue0'] = ketendue
 
-    return dcompute, store
+    return dcompute, store, overwrite
 
 
 # ################################################################
@@ -360,6 +384,7 @@ def _check(
     verb=None,
     plot=None,
     store=None,
+    overwrite=None,
 ):
 
     # --------
@@ -528,6 +553,16 @@ def _check(
         allowed=lok,
     )
 
+    # -----------
+    # overwrite
+    # -----------
+
+    overwrite = ds._generic_check._check_var(
+        overwrite, 'overwrite',
+        types=bool,
+        default=False,
+    )
+
     return (
         key,
         spectro,
@@ -543,6 +578,7 @@ def _check(
         verb,
         plot,
         store,
+        overwrite,
     )
 
 

--- a/tofu/data/_class8_los_angles.py
+++ b/tofu/data/_class8_los_angles.py
@@ -76,7 +76,7 @@ def compute_los_angles(
         cx2, cy2, cz2 = coll.get_camera_cents_xyz(key=key_cam)
 
         # check overwrite
-        if klos in coll.dobj['rays'].keys():
+        if klos in coll.dobj.get('rays', {}).keys():
             if overwrite is True:
                 coll.remove_rays(klos)
             else:


### PR DESCRIPTION
Main changes:
----------------

* There was an indexing issue in `tofu/data/_class8_los_angles.py`
![image](https://github.com/user-attachments/assets/55e024f6-ce8a-4cd6-85b6-45642502cb37)

Fixed by using a tuple of indices:
![image](https://github.com/user-attachments/assets/69346a00-1d56-4c09-a92f-d0de5e046af7)


* `compute_diagnostic_etendue_los(overwrite=bool)` implemented
    - Allows to rerun multiple times and overwrite previous results
    - mostly useful for debugging


Issues:
-------
Fixes, in devel, issue #984 


Example:
----------

Using the `Collection` instance sent by @cjperks7 , one can now finish the computation of the vos from the los, calling directly the method that does the computation, with overwrite=True (because the original computation could not be carried out).

```
import tofu as tf

# load SPARC reduced geometry
conf = tf.load_config('SPARC-V0')

# load the Collection from path/file.ext
pfe = '/data/home/dvezinet/storage-root/sparc_htpd24_v2_subcamKr.npz'
coll = tf.data.load(pfe)

# re-compute and overwrite previous partial results
coll.compute_diagnostic_etendue_los(
    store='analytical', 
    numerical=False, 
    analytical=True, 
    compute_vos_from_los=True,
    overwrite=True, 
    config=conf,
)

# plot etendue
dax = coll.plot_diagnostic(plot_config=conf, data='etendue')

```

![image](https://github.com/user-attachments/assets/1b9e9b20-3eaf-4ce6-ae70-fa495d9b5537)