### PR TITLE
Issue993 dphi pilatus

### DIFF
--- a/tofu/data/_class08_Diagnostic.py
+++ b/tofu/data/_class08_Diagnostic.py
@@ -238,6 +238,7 @@ class Diagnostic(Previous):
         key_nseg=None,
         # bool
         compute_vos_from_los=None,
+        return_dcompute=None,
         verb=None,
         plot=None,
         store=None,
@@ -297,6 +298,9 @@ class Diagnostic(Previous):
                 compute_vos_from_los=compute_vos_from_los,
                 overwrite=overwrite,
             )
+
+        if return_dcompute is True:
+            return dcompute
 
     def compute_diagnostic_solidangle_from_plane(
         self,

--- a/tofu/data/_class8_check.py
+++ b/tofu/data/_class8_check.py
@@ -370,7 +370,6 @@ def _check_doptics_basics(
             'pinhole': bool(pinhole),
             'paths': doptics[k0]['paths'],
             'los': None,
-            'vos': None,
             'etendue': None,
             'etend_type': None,
             'amin': None,

--- a/tofu/data/_class8_etendue_los.py
+++ b/tofu/data/_class8_etendue_los.py
@@ -322,7 +322,7 @@ def compute_etendue_los(
                     coll.remove_data(ketendue, propagate=False)
                 else:
                     msg = (
-                        "data '{ketendue}' already exists!\n"
+                        f"data '{ketendue}' already exists!\n"
                         "Use overwrite=True to force overwriting\n"
                     )
                     raise Exception(msg)

--- a/tofu/data/_class8_los_angles.py
+++ b/tofu/data/_class8_los_angles.py
@@ -247,7 +247,7 @@ def _vos_from_los(
     lpoly_hor = []
 
     shape0 = v0['cx'].shape
-    dphi = np.full(tuple([2] + list(shape0)), np.nan)
+    dphi = np.full(((2,) + shape0), np.nan)
     linds = [range(ss) for ss in shape0]
 
     for ii, ind in enumerate(itt.product(*linds)):
@@ -261,12 +261,12 @@ def _vos_from_los(
         if pinhole is False:
             iref = v0['iref'][ind]
 
-        # if not par:
-        #     e0 = [coll.ddata[kk]['data'][ind] for kk in ke0]
-        #     e1 = [coll.ddata[kk]['data'][ind] for kk in ke1]
-        #     dx = out0 * e0[0] + out1 * e1[0]
-        #     dy = out0 * e0[1] + out1 * e1[1]
-        #     dz = out0 * e0[2] + out1 * e1[2]
+        if not par:
+            e0 = [coll.ddata[kk]['data'][ind] for kk in ke0]
+            e1 = [coll.ddata[kk]['data'][ind] for kk in ke1]
+            dx = out0 * e0[0] + out1 * e1[0]
+            dy = out0 * e0[1] + out1 * e1[1]
+            dz = out0 * e0[2] + out1 * e1[2]
 
         # -----------------------
         # get start / end points
@@ -277,9 +277,9 @@ def _vos_from_los(
             cx=v0['cx'][ind],
             cy=v0['cy'][ind],
             cz=v0['cz'][ind],
-            dx=np.r_[0],
-            dy=np.r_[0],
-            dz=np.r_[0],
+            dx=dx,  # np.r_[0],
+            dy=dy,  # np.r_[0],
+            dz=dz,  # np.r_[0],
             # end points
             x0=np.r_[v0['x0'][sli], v0['cents0'][ind]],
             x1=np.r_[v0['x1'][sli], v0['cents1'][ind]],

--- a/tofu/data/_class8_vos.py
+++ b/tofu/data/_class8_vos.py
@@ -172,6 +172,7 @@ def compute_vos(
     # user-defined
 
     user_limits = _get_user_limits(
+        coll=coll,
         user_limits=user_limits,
         doptics=doptics,
         key_cam=list(dcompute.keys()),
@@ -547,7 +548,24 @@ def _check(
     )
 
 
+def _user_limits_err(user_limits, lc=None):
+    msg = (
+        "user_limits must be either:\n"
+        "\t- None: not used\n"
+        "\t- True: remove all limits\n"
+        "\t- dict: specify limits with at least one of the keys:\n"
+        "\t\t- 'DR': list of 2 scalars or None\n"
+        "\t\t- 'DZ': list of 2 scalars or None\n"
+        "\t\t- 'Dphi': list of 2 scalars or None\n"
+        + ("" if lc is None else f"lc = {lc}\n")
+        + f"Provided:\n{user_limits}\n"
+    )
+    raise Exception(msg)
+
+
+
 def _get_user_limits(
+    coll=None,
     user_limits=None,
     doptics=None,
     key_cam=None,
@@ -567,26 +585,17 @@ def _get_user_limits(
     # dict
     if user_limits not in [None, True]:
 
-        c0 = (
-            isinstance(user_limits, dict)
-            and any([
-                user_limits.get(ss) is not None
-                and user_limits[ss]
-                for ss in ['DR', 'DZ', 'Dphi']
-            ])
-        )
+        if not isinstance(user_limits, dict):
+            _user_limits_err(user_limits)
 
-        if not c0:
-            msg = (
-                "user_limits must be either:\n"
-                "\t- None: not used\n"
-                "\t- True: remove all limits\n"
-                "\t- dict: specify limits with at least one of the keys:\n"
-                "\t\t- 'DR': list of 2 scalars or None\n"
-                "\t\t- 'DZ': list of 2 scalars or None\n"
-                "\t\t- 'Dphi': list of 2 scalars or None\n"
-            )
-            raise Exception(msg)
+        lc = [
+            user_limits.get(ss) is not None
+            and len(user_limits[ss]) == 2
+            for ss in ['DR', 'DZ', 'Dphi']
+        ]
+
+        if not any(lc):
+            _user_limits_err(user_limits, lc)
 
     # --------------
     # trivial
@@ -597,57 +606,92 @@ def _get_user_limits(
     elif user_limits is True:
         user_limits = {}
 
-    # ---------------
-    # user-defined limits
+    # --------------------
+    # Preliminary check on Dphi
+    # --------------------
 
-    # DR
-    if user_limits.get('DR') is None:
-        user_limits['DR'] = [x0u[0]-1e-9, x0u[-1]+1e-9]
-    user_limits['DR'] = ds._generic_check._check_flat1darray(
-        user_limits['DR'], "user_limits.get('DR')",
-        dtype=float,
-        size=2,
-        unique=True,
-        sign='>=0',
-    )
+    if user_limits.get('Dphi') is not None:
+        user_limits['Dphi'] = ds._generic_check._check_flat1darray(
+            user_limits['Dphi'], "user_limits.get('Dphi')",
+            dtype=float,
+            size=2,
+            unique=True,
+        )
+        phi = np.linspace(user_limits['Dphi'][0], user_limits['Dphi'][1], 50)
 
-    # DZ
-    if user_limits.get('DZ') is None:
-        user_limits['DZ'] = [x1u[0]-1e-9, x1u[-1]+1e-9]
-    user_limits['DZ'] = ds._generic_check._check_flat1darray(
-        user_limits['DZ'], "user_limits['DZ']",
-        dtype=float,
-        size=2,
-        unique=True,
-    )
+    # --------------------
+    # user-defined pcross
+    # --------------------
 
-    # pcross_user
-    DR = user_limits['DR']
-    DZ = user_limits['DZ']
-    user_limits['pcross_user'] = np.array([
-        np.r_[DR[0], DR[1], DR[1], DR[0]],
-        np.r_[DZ[0], DZ[0], DZ[1], DZ[1]],
-    ])
+    if user_limits.get('DR') is not None or user_limits.get('DZ') is not None:
 
-    # Dphi
-    # phor_user
-    if user_limits.get('Dphi') is None:
-        user_limits['phor_user'] = np.array([
-            DR[1] * np.r_[-1, 1, 1, -1],
-            DR[1] * np.r_[-1, -1, 1, 1],
+        # DR
+        if user_limits.get('DR') is None:
+            user_limits['DR'] = [x0u[0]-1e-9, x0u[-1]+1e-9]
+        user_limits['DR'] = ds._generic_check._check_flat1darray(
+            user_limits['DR'], "user_limits.get('DR')",
+            dtype=float,
+            size=2,
+            unique=True,
+            sign='>=0',
+        )
+
+        # DZ
+        if user_limits.get('DZ') is None:
+            user_limits['DZ'] = [x1u[0]-1e-9, x1u[-1]+1e-9]
+        user_limits['DZ'] = ds._generic_check._check_flat1darray(
+            user_limits['DZ'], "user_limits['DZ']",
+            dtype=float,
+            size=2,
+            unique=True,
+        )
+
+        # pcross_user
+        DR = user_limits['DR']
+        DZ = user_limits['DZ']
+        user_limits['pcross_user'] = np.array([
+            np.r_[DR[0], DR[1], DR[1], DR[0]],
+            np.r_[DZ[0], DZ[0], DZ[1], DZ[1]],
         ])
 
-    else:
-        phi = np.linspace(user_limits['Dphi'][0], user_limits['Dphi'][1], 50)
-        user_limits['phor_user'] = np.array([
-            np.r_[
-                DR[0]*np.cos(phi),
-                DR[1]*np.cos(phi[::-1]),
-            ],
-            np.r_[
-                DR[0]*np.sin(phi),
-                DR[1]*np.sin(phi[::-1]),
-            ],
+        # --------------------
+        # user-defined phor
+        # --------------------
+
+        # Dphi
+        # phor_user
+        if user_limits.get('Dphi') is not None:
+            user_limits['phor_user'] = np.array([
+                DR[1] * np.r_[-1, 1, 1, -1],
+                DR[1] * np.r_[-1, -1, 1, 1],
+            ])
+        else:
+
+            user_limits['phor_user'] = np.array([
+                np.r_[
+                    DR[0]*np.cos(phi),
+                    DR[1]*np.cos(phi[::-1]),
+                ],
+                np.r_[
+                    DR[0]*np.sin(phi),
+                    DR[1]*np.sin(phi[::-1]),
+                ],
+            ])
+
+    # -------------------
+    # case with only Dphi => use each pixel's pcross
+    # -------------------
+
+    elif user_limits.get('Dphi') is not None:
+
+        # Give phor_user the proper shape like phor TBF
+        kpc0, kpc1 = doptics[key_cam]['dvos']['pcross']
+        shape = coll.ddata[kpc0]['data'].shape
+        pcross0 = coll.ddata[kpc0]['data']
+        pcross1 = coll.ddata[kpc1]['data']
+        dphi = np.array([
+            np.full(shape, user_limits['Dphi'][0]),
+            np.full(shape, user_limits['Dphi'][1]),
         ])
 
     return user_limits

--- a/tofu/data/_class8_vos_broadband.py
+++ b/tofu/data/_class8_vos_broadband.py
@@ -80,29 +80,43 @@ def _vos(
     # ----------------
 
     if user_limits is not None:
-        xx, yy, zz, dind, ir, iz, iphi, dV = _vos_points(
-            # polygons
-            pcross0=user_limits['pcross_user'][0, :],
-            pcross1=user_limits['pcross_user'][1, :],
-            phor0=user_limits['phor_user'][0, :],
-            phor1=user_limits['phor_user'][1, :],
-            margin_poly=margin_poly,
-            dphi=np.r_[-np.pi, np.pi],
-            # sampling
-            dsamp=dsamp,
-            x0f=x0f,
-            x1f=x1f,
-            x0u=x0u,
-            x1u=x1u,
-            res=res_phi,
-            dx0=dx0,
-            dx1=dx1,
-            # shape
-            sh=sh,
-        )
 
-        shape = coll.dobj['camera'][key_cam]['dgeom']['shape']
-        shape = np.r_[0, shape]
+        if user_limits.get('pcross_user') is not None:
+            xx, yy, zz, dind, ir, iz, iphi, dV = _vos_points(
+                # polygons
+                pcross0=user_limits['pcross_user'][0, :],
+                pcross1=user_limits['pcross_user'][1, :],
+                phor0=user_limits['phor_user'][0, :],
+                phor1=user_limits['phor_user'][1, :],
+                margin_poly=margin_poly,
+                dphi=np.r_[-np.pi, np.pi],
+                # sampling
+                dsamp=dsamp,
+                x0f=x0f,
+                x1f=x1f,
+                x0u=x0u,
+                x1u=x1u,
+                res=res_phi,
+                dx0=dx0,
+                dx1=dx1,
+                # shape
+                sh=sh,
+            )
+
+            shape = coll.dobj['camera'][key_cam]['dgeom']['shape']
+            shape = np.r_[0, shape]
+
+        elif user_limits.get('Dphi') is not None:
+            # get temporary vos
+            kpc0, kpc1 = doptics[key_cam]['dvos']['pcross']
+            shape = coll.ddata[kpc0]['data'].shape
+            pcross0 = coll.ddata[kpc0]['data']
+            pcross1 = coll.ddata[kpc1]['data']
+
+            # phor
+            phor0 = user_limits['phor0']
+            phor1 = user_limits['phor1']
+            dphi = user_limits['dphi']
 
     else:
 
@@ -111,6 +125,8 @@ def _vos(
         shape = coll.ddata[kpc0]['data'].shape
         pcross0 = coll.ddata[kpc0]['data']
         pcross1 = coll.ddata[kpc1]['data']
+
+        # phor
         kph0, kph1 = doptics[key_cam]['dvos']['phor']
         phor0 = coll.ddata[kph0]['data']
         phor1 = coll.ddata[kph1]['data']
@@ -185,7 +201,7 @@ def _vos(
             t000 = dtm.datetime.now()     # DB
 
         # get points
-        if user_limits is None:
+        if user_limits is None or user_limits.get('pcross_user') is None:
 
             if np.isnan(pcross0[sli_poly0]):
                 pts_cross = np.zeros((0,), dtype=float)


### PR DESCRIPTION
Main changes:
----------------

* `compute_diagnostic_etendue_los()`:
    - `return_dcompute=bool` implemented
    - for computing `vos_from_los` now uses sampled pixel AND sampled apertures

* `compute_diagnostic_vos()`:
    - `debug=callable` implemented to debug with plots for a single pixel index
    - `user_limits={'Dphi': list}` implemented, will use pixel-wise `pcross`


Issues:
-------

Fixes, in devel, issue #993 