### PR TITLE
Pinned `setuptools` version to `>=40.8.0, <64`

### DIFF
--- a/.github/workflows/test-complete-matrix.yml
+++ b/.github/workflows/test-complete-matrix.yml
@@ -42,6 +42,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: install tofu
       run: |
+        python -c "import setuptools; print(f'\nsetuptools version = {setuptools.__version__}\n')"
         pip install -e ".[dev]" --no-build-isolation
     - name: Test with pytest and coverage
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-        "setuptools>=40.8.0, <65",
+        "setuptools>=40.8.0, <64",
 	"wheel",
 	"Cython>=0.26",
 	"numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-        "setuptools>=40.8.0, <65.*",
+        "setuptools>=40.8.0, <65",
 	"wheel",
 	"Cython>=0.26",
 	"numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-        "setuptools>=40.8.0",
+        "setuptools>=40.8.0, <65.*",
 	"wheel",
 	"Cython>=0.26",
 	"numpy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy
 numpy
 # scikit-sparse    # does not work on windows, and requires "apt/brew install libsuitesparse-dev/suite-sparse" on linux / MacOs
 # scikit-umfpack   # similar issue
-setuptools!=65.*,!=74.*
+setuptools>=40.8.0, <65.*
 matplotlib
 contourpy
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy
 numpy
 # scikit-sparse    # does not work on windows, and requires "apt/brew install libsuitesparse-dev/suite-sparse" on linux / MacOs
 # scikit-umfpack   # similar issue
-setuptools>=40.8.0, <65.*
+setuptools>=40.8.0, <65
 matplotlib
 contourpy
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy
 numpy
 # scikit-sparse    # does not work on windows, and requires "apt/brew install libsuitesparse-dev/suite-sparse" on linux / MacOs
 # scikit-umfpack   # similar issue
-setuptools>=40.8.0, <65
+setuptools>=40.8.0, <64
 matplotlib
 contourpy
 requests

--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        "setuptools>=40.8.0, <65.*",
+        "setuptools>=40.8.0, <65",
         "numpy",
         "scipy",
         # "scikit-sparse",

--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        "setuptools!=65.*,!=74.*",
+        "setuptools>=40.8.0, <65.*",
         "numpy",
         "scipy",
         # "scikit-sparse",

--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        "setuptools>=40.8.0, <65",
+        "setuptools>=40.8.0, <64",
         "numpy",
         "scipy",
         # "scikit-sparse",

--- a/tofu/geom/_core.py
+++ b/tofu/geom/_core.py
@@ -32,12 +32,15 @@ try:
     import tofu.geom._comp as _comp
     import tofu.geom._comp_solidangles as _comp_solidangles
     import tofu.geom._plot as _plot
-except Exception:
-    from . import _def as _def
-    from . import _GG as _GG
-    from . import _comp as _comp
-    from . import _comp_solidangles
-    from . import _plot as _plot
+except Exception as err0:
+    try:
+        from . import _def as _def
+        from . import _GG as _GG
+        from . import _comp as _comp
+        from . import _comp_solidangles
+        from . import _plot as _plot
+    except Exception as err1:
+        raise err1 from err0
 
 
 __all__ = [

--- a/tofu/tests/tests00_root/test_03_plot.py
+++ b/tofu/tests/tests00_root/test_03_plot.py
@@ -8,12 +8,6 @@ This module contains tests for tofu.geom in its structured version
 import os
 import numpy as np
 import matplotlib.pyplot as plt
-import warnings as warn
-
-
-# Importing package tofu.geom
-import tofu as tf
-from tofu import __version__
 
 
 _here = os.path.abspath(os.path.dirname(__file__))
@@ -29,6 +23,7 @@ _Exp = 'WEST'
 #######################################################
 
 def setup_module(module):
+    from tofu import __version__
     print("") # this is to get a newline after the dots
     lf = os.listdir(_here)
     lf = [f for f in lf
@@ -53,6 +48,7 @@ def setup_module(module):
         #print("setup_module before anything in this file")
 
 def teardown_module(module):
+    from tofu import __version__
     #os.remove(VesTor.Id.SavePath + VesTor.Id.SaveName + '.npz')
     #os.remove(VesLin.Id.SavePath + VesLin.Id.SaveName + '.npz')
     #print("teardown_module after everything in this file")
@@ -95,6 +91,7 @@ class Test01_plot_shotovervew(object):
         #print("---- "+cls.__name__)
 
         # conf
+        import tofu as tf
         cls.conf = tf.geom.utils.create_config('B3')
 
         # time vectors
@@ -139,17 +136,18 @@ class Test01_plot_shotovervew(object):
 
     def test01_plot_shotoverview(self):
         # One by one, without conf
+        import tofu as tf
         for shot, dextra in self.dobj.items():
-            kh = tf._plot.plot_shotoverview({shot:dextra})
+            _ = tf._plot.plot_shotoverview({shot:dextra})
 
         # All together, without conf
-        kh = tf._plot.plot_shotoverview(self.dobj)
+        _ = tf._plot.plot_shotoverview(self.dobj)
         plt.close('all')
 
         # One by one, with conf
         for shot, dextra in self.dobj.items():
-            kh = tf._plot.plot_shotoverview({shot:dextra}, config=self.conf)
+            _ = tf._plot.plot_shotoverview({shot:dextra}, config=self.conf)
 
         # All together, with conf
-        kh = tf._plot.plot_shotoverview(self.dobj, config=self.conf)
+        _ = tf._plot.plot_shotoverview(self.dobj, config=self.conf)
         plt.close('all')


### PR DESCRIPTION
Main changes:
----------------

* Pinned `setuptools` version to `>=40.8.0, <64` in:
    - `seutp.py`
    - `requirements.txt`
    - `pyproject.toml`

* `<65` is needed to avoid issues with `distutils.msvcompiler`
* `<64` is needed to avoid issues with [loop import in unit tests](https://github.com/ToFuProject/tofu/actions/runs/12141565325/job/33854680422)

Issues:
-------

Hopefully fixes, in devel, issue #951 