### PR TITLE
Issue1000 vos broad band

### DIFF
--- a/tofu/data/_class8_los_angles.py
+++ b/tofu/data/_class8_los_angles.py
@@ -332,8 +332,13 @@ def _vos_from_los(
 
         phi = np.arctan2(ptsy, ptsx)
         phimin, phimax = np.nanmin(phi), np.nanmax(phi)
+
+        # across pi?
         if phimax - phimin > np.pi:
-            phimin, phimax = phimax, phimin + 2.*np.pi
+            phimin = np.min(phi[phi > 0])
+            phimax = np.max(phi[phi < 0])
+            phimax = phimax + 2*np.pi
+
         dphi[(0,) + ind] = phimin
         dphi[(1,) + ind] = phimax
 

--- a/tofu/data/_class8_vos_utilities.py
+++ b/tofu/data/_class8_vos_utilities.py
@@ -374,7 +374,7 @@ def _get_dphi_from_R_phor(
     dphi = np.full((2, R.size), np.nan)
     for ir, rr in enumerate(R):
 
-        nphi = np.ceil(rr*(phimax - phimin) / (0.05*res)).astype(int)
+        nphi = np.ceil(rr*np.abs(phimax - phimin) / (0.05*res)).astype(int) + 1
         phi = np.linspace(phimin, phimax, nphi)
 
         ind = path.contains_points(


### PR DESCRIPTION
Main changes:
----------------

* Primary issue was actually the computation of `dvos['dphi']` from LOS
    - was not handling correctly case with LOS crossing `phi = pi`
    - fixed by proper handling of that case (distinguishing between cases)
* In addition, also made `_get_dphi_from_R_phor()` more robust by:
    - ensuring `nphi >= 2` by design 
    - taking the absolute value of `dphi`

Issues:
--------

Fixes, in devel issue #1000 