### PR TITLE
Issue1005 save2stp rays chain

### DIFF
--- a/tofu/data/_class00_poly2d_sample.py
+++ b/tofu/data/_class00_poly2d_sample.py
@@ -218,7 +218,7 @@ def _edges(
     npts = np.round(dist / res, decimals=0).astype(int)
 
     # interpolation for x0
-    out0 = np.ravel([
+    out0 = np.concatenate([
         np.r_[x0_closed[ii]]
         if npts[ii] <= 1 else
         x0_closed[ii] + dx0[ii] * np.linspace(0, 1, npts[ii], endpoint=False)
@@ -226,7 +226,7 @@ def _edges(
     ])
 
     # interpolation for x1
-    out1 = np.ravel([
+    out1 = np.concatenate([
         np.r_[x1_closed[ii]]
         if npts[ii] <= 1 else
         x1_closed[ii] + dx1[ii] * np.linspace(0, 1, npts[ii], endpoint=False)

--- a/tofu/data/_class02_Rays.py
+++ b/tofu/data/_class02_Rays.py
@@ -465,6 +465,7 @@ class Rays(Previous):
         include_centroid=None,
         factor=None,
         color=None,
+        chain=None,
         # ---------------
         # saving
         pfe_save=None,
@@ -503,6 +504,7 @@ class Rays(Previous):
             include_centroid=include_centroid,
             factor=factor,
             color=color,
+            chain=chain,
             # ---------------
             # saving
             pfe_save=pfe_save,

--- a/tofu/data/_class02_Rays.py
+++ b/tofu/data/_class02_Rays.py
@@ -465,6 +465,7 @@ class Rays(Previous):
         include_centroid=None,
         factor=None,
         color=None,
+        color_by_pixel=None,
         chain=None,
         # ---------------
         # saving
@@ -504,6 +505,7 @@ class Rays(Previous):
             include_centroid=include_centroid,
             factor=factor,
             color=color,
+            color_by_pixel=color_by_pixel,
             chain=chain,
             # ---------------
             # saving

--- a/tofu/data/_class02_save2stp.py
+++ b/tofu/data/_class02_save2stp.py
@@ -963,13 +963,13 @@ def _get_ind_global_to_local(dind_ok=None, din=None, ncum=None, lkcam=None):
     return func
 
 
-def _get_ind_local_to_global(ncum=None, dshape=None, lkcam=None):
+def _get_ind_local_to_global(ncum=None, dind_ok=None, lkcam=None):
 
     def func(
             kcam,
             ind,
             ncum=ncum,
-            dshape=dshape,
+            dind_ok=dind_ok,
             lkcam=lkcam,
         ):
 
@@ -1431,7 +1431,7 @@ def _get_data_polyline(
     dk0ind = {
         'pts': {
             'global_to_local': _get_ind_local_to_global(
-                dshape={k0: v0.shape for k0, v0 in dptsx.items()},
+                dind_ok={k0: v0.nonzero() for k0, v0 in dok.items()},
                 ncum=np.r_[0, np.cumsum([dnpts[kcam] for kcam in lkcam])],
                 lkcam=lkcam,
             ),

--- a/tofu/data/_class02_save2stp.py
+++ b/tofu/data/_class02_save2stp.py
@@ -24,7 +24,7 @@ import datastock as ds
 # #################################################################
 
 
-_COLOR = 'k'
+_COLOR = 'pixel'
 _NAME = 'rays'
 
 
@@ -786,13 +786,13 @@ def _get_dcolor(dptsx=None, color=None):
     # color
     # ---------------
 
+    if color is None:
+        color = _COLOR
+
     if isinstance(color, str) and color == 'pixel':
         color0 = color
     else:
         color0 = None
-
-    if color is None:
-        color = _COLOR
 
     # -----------------
     # str

--- a/tofu/data/_class02_save2stp.py
+++ b/tofu/data/_class02_save2stp.py
@@ -52,6 +52,7 @@ def main(
     factor=None,
     color=None,
     chain=None,
+    curve=None,
     # ---------------
     # saving
     pfe_save=None,
@@ -84,6 +85,8 @@ def main(
         DESCRIPTION. The default is None.
     chain : bool
         Flag to chain all pixels, for each camera
+    curve:  str
+        Flag to use either 'LINE' or 'POLYLINE'
     pfe_save : str, optional
         DESCRIPTION. The default is None.
     overwrite : bool, optional
@@ -107,6 +110,7 @@ def main(
         include_centroid,
         factor, color,
         chain,
+        curve,
         iso,
         pfe_save, overwrite,
     ) = _check(
@@ -123,6 +127,7 @@ def main(
         factor=factor,
         color=color,
         chain=chain,
+        curve=curve,
         # saving
         pfe_save=pfe_save,
         overwrite=overwrite,
@@ -172,16 +177,32 @@ def main(
     )
 
     # DATA
-    msg_data = _get_data(
-        dptsx=dptsx,
-        dptsy=dptsy,
-        dptsz=dptsz,
-        fname=fname,
-        # options
-        dcolor=dcolor,
-        # norm
-        iso=iso,
-    )
+    if curve == 'LINE':
+        msg_data = _get_data_line(
+            dptsx=dptsx,
+            dptsy=dptsy,
+            dptsz=dptsz,
+            fname=fname,
+            # options
+            dcolor=dcolor,
+            # norm
+            iso=iso,
+        )
+
+    elif curve == 'POLYLINE':
+        msg_data = _get_data_polyline(
+            dptsx=dptsx,
+            dptsy=dptsy,
+            dptsz=dptsz,
+            fname=fname,
+            # options
+            dcolor=dcolor,
+            # norm
+            iso=iso,
+        )
+
+    else:
+        raise NotImplementedError()
 
     # -------------
     # save to stp
@@ -216,6 +237,7 @@ def _check(
     factor=None,
     color=None,
     chain=None,
+    curve=None,
     # saving
     pfe_save=None,
     overwrite=None,
@@ -358,15 +380,29 @@ def _check(
 
     chain = ds._generic_check._check_var(
         chain, 'chain',
-        types=bool,
+        types=(bool, str),
         default=False,
+        allowed=[True, False, 'pixel'],
     )
 
-    if chain is True and not (key_cam is not None or key_rays is not None):
+    if chain is not False and not (key_cam is not None or key_rays is not None):
         msg = (
-            "Arg chain can only be True if key_cam or key_rays is known!"
+            "Arg chain can only used if key_cam or key_rays is known!\n"
+            f"\t- chain: {chain}\n"
         )
         raise Exception(msg)
+
+    # ---------------
+    # curve
+    # ---------------
+
+    lok = ['LINE', 'POLYLINE']
+    curve = ds._generic_check._check_var(
+        curve, 'curve',
+        types=str,
+        default=lok[0],
+        allowed=lok,
+    )
 
     # ---------------
     # factor
@@ -433,6 +469,7 @@ def _check(
         include_centroid,
         factor, color,
         chain,
+        curve,
         iso,
         pfe_save, overwrite,
     )
@@ -575,7 +612,7 @@ def _extract(
         # --------------
         # chain
 
-        if chain is True:
+        if chain is not False:
 
             for k0, v0 in dptsx.items():
 
@@ -611,9 +648,31 @@ def _extract(
                 )
 
                 # chain and store
-                dptsx[k0] = np.ravel(ptsx, order='F')
-                dptsy[k0] = np.ravel(ptsy, order='F')
-                dptsz[k0] = np.ravel(ptsz, order='F')
+                if chain is True:
+                    dptsx[k0] = np.ravel(ptsx, order='F')
+                    dptsy[k0] = np.ravel(ptsy, order='F')
+                    dptsz[k0] = np.ravel(ptsz, order='F')
+
+                elif chain == 'pixel':
+                    shape = shape_cam + (-1,)
+                    dptsx[k0] = np.moveaxis(
+                        np.moveaxis(ptsx, 0, -1).reshape(shape),
+                        -1,
+                        0,
+                    )
+                    dptsy[k0] = np.moveaxis(
+                        np.moveaxis(ptsy, 0, -1).reshape(shape),
+                        -1,
+                        0,
+                    )
+                    dptsz[k0] = np.moveaxis(
+                        np.moveaxis(ptsz, 0, -1).reshape(shape),
+                        -1,
+                        0,
+                    )
+
+                else:
+                    raise NotImplementedError(f"{chain}")
 
     return dptsx, dptsy, dptsz
 
@@ -901,11 +960,11 @@ def _get_k0ind(dind_ok=None, ncum=None, lkcam=None):
 
 # #################################################################
 # #################################################################
-#          DATA
+#          DATA - LINE
 # #################################################################
 
 
-def _get_data(
+def _get_data_line(
     dptsx=None,
     dptsy=None,
     dptsz=None,
@@ -1102,6 +1161,363 @@ def _get_data(
     # -----------------
 
     k0 = 'LINE'
+    lines = []
+    for ii, ni in enumerate(dind[k0]['ind']):
+        kcam, ind = k0ind(ii)
+        lines.append(f"#{ni}={k0}('{kcam}_{ind}',#{dind['CARTESIAN_POINT']['ind'][ii]},#{dind['VECTOR']['ind'][ii]});")
+    dind[k0]['msg'] = "\n".join(lines)
+
+    # -----------------
+    # TRIMMED_CURVE
+    # -----------------
+
+    k0 = 'TRIMMED_CURVE'
+    lines = []
+    for ii, ni in enumerate(dind[k0]['ind']):
+        kcam, ind = k0ind(ii)
+        lines.append(f"#{ni}={k0}('{kcam}_{ind}',#{dind['LINE']['ind'][ii]},(PARAMETER_VALUE(0.)),(PARAMETER_VALUE(1.)),.T.,.PARAMETER.);")
+    dind[k0]['msg'] = "\n".join(lines)
+
+    # ----------------
+    # DRAUGHTING_PRE_DEFINED_CURVE_FONT
+    # ----------------
+
+    k0 = 'DRAUGHTING_PRE_DEFINED_CURVE_FONT'
+    ni = dind[k0]['ind'][0]
+    dind[k0]['msg'] = f"#{ni}={k0}('continuous');"
+
+    # ------------------
+    # CURVE_STYLE
+    # ------------------
+
+    k0 = 'CURVE_STYLE'
+    lines = []
+    for ii, ni in enumerate(dind[k0]['ind']):
+        lines.append(f"#{ni}={k0}('style {ii}',#{dind['DRAUGHTING_PRE_DEFINED_CURVE_FONT']['ind'][0]},POSITIVE_LENGTH_MEASURE(0.7),#{dind['COLOUR_RGB']['ind'][ii]});")
+    dind[k0]['msg'] = "\n".join(lines)
+
+    # -----------------
+    # PRESENTATION_STYLE_ASSIGNMENT
+    # ------------------
+
+    k0 = 'PRESENTATION_STYLE_ASSIGNMENT'
+    lines = []
+    for ii, ni in enumerate(dind[k0]['ind']):
+        lines.append(f"#{ni}={k0}((#{dind['CURVE_STYLE']['ind'][ii]}));")
+    dind[k0]['msg'] = "\n".join(lines)
+
+    #1605=PRESENTATION_STYLE_ASSIGNMENT((#2488));
+
+    # -----------------
+    # STYLED_ITEM
+    # -----------------
+
+    k0 = 'STYLED_ITEM'
+    lines = []
+    for ii, ni in enumerate(dind[k0]['ind']):
+        kcam, ind = k0ind(ii)
+        jj = colors.index(dcolor[kcam])
+        lines.append(f"#{ni}={k0}('{kcam}_{ind}',(#{dind['PRESENTATION_STYLE_ASSIGNMENT']['ind'][jj]}),#{dind['TRIMMED_CURVE']['ind'][ii]});")
+    dind[k0]['msg'] = "\n".join(lines)
+
+    # -----------------
+    # GEOMETRIC_CURVE_SET
+    # -----------------
+
+    k0 = 'GEOMETRIC_CURVE_SET'
+    ni = dind[k0]['ind'][0]
+    lstr = ','.join([f"#{ii}" for ii in dind['TRIMMED_CURVE']['ind']])
+    dind[k0]['msg'] = f"#{ni}={k0}('None',({lstr}));"
+
+    # ----------------------
+    # PRESENTATION_LAYER_ASSIGNMENT
+    # ----------------------
+
+    k0 = 'PRESENTATION_LAYER_ASSIGNMENT'
+    ni = dind[k0]['ind'][0]
+    lstr = ','.join([f"#{ii}" for ii in dind['TRIMMED_CURVE']['ind']])
+    dind[k0]['msg'] = f"#{ni}={k0}('1','Layer 1',({lstr}));"
+
+    # ----------------------------------
+    # MECHANICAL_DESIGN_GEOMETRIC_PRESENTATION_REPRESENTATION
+    # ----------------------------------
+
+    k0 = 'MECHANICAL_DESIGN_GEOMETRIC_PRESENTATION_REPRESENTATION'
+    ni = dind[k0]['ind'][0]
+    lstr = ','.join([f"#{ii}" for ii in dind['STYLED_ITEM']['ind']])
+    dind[k0]['msg'] = f"#{ni}={k0}('',({lstr}),#{i0});"
+
+    # ------------
+    # LEFTOVERS
+    # ------------
+
+    for k0, v0 in dind.items():
+        if v0.get('msg') is None:
+            if v0.get('str') is None:
+                msg = f"Looks like '{k0}' is missing!"
+                raise Exception(msg)
+            else:
+                ni = dind[k0]['ind'][0]
+                dind[k0]['msg'] = f"#{ni}={v0['str']}"
+
+
+    # --------------------
+    # msg_pre
+    # --------------------
+
+    msg_pre = (
+f"""
+DATA;
+#10=PROPERTY_DEFINITION_REPRESENTATION(#14,#12);
+#11=PROPERTY_DEFINITION_REPRESENTATION(#15,#13);
+#12=REPRESENTATION('',(#16),#{i0});
+#13=REPRESENTATION('',(#17),#{i0});
+#14=PROPERTY_DEFINITION('pmi validation property','',#21);
+#15=PROPERTY_DEFINITION('pmi validation property','',#21);
+#16=VALUE_REPRESENTATION_ITEM('number of annotations',COUNT_MEASURE(0.));
+#17=VALUE_REPRESENTATION_ITEM('number of views',COUNT_MEASURE(0.));
+#18=SHAPE_REPRESENTATION_RELATIONSHIP('None', 'relationship between {fname}-None and {fname}-None',#30,#19);
+#19=GEOMETRICALLY_BOUNDED_WIREFRAME_SHAPE_REPRESENTATION('{fname}-None',(#31),#{i0});
+#20=SHAPE_DEFINITION_REPRESENTATION(#21,#30);
+#21=PRODUCT_DEFINITION_SHAPE('','',#22);
+#22=PRODUCT_DEFINITION(' ','',#24,#23);
+#23=PRODUCT_DEFINITION_CONTEXT('part definition',#29,'design');
+#24=PRODUCT_DEFINITION_FORMATION_WITH_SPECIFIED_SOURCE(' ',' ',#26,.NOT_KNOWN.);
+#25=PRODUCT_RELATED_PRODUCT_CATEGORY('part','',(#26));
+#26=PRODUCT('{fname}','{fname}',' ', (#27));
+#27=PRODUCT_CONTEXT(' ',#29,'mechanical');
+#28=APPLICATION_PROTOCOL_DEFINITION('international standard','automotive_design',2010,#29);
+#29=APPLICATION_CONTEXT('core data for automotive mechanical design processes');
+#30=SHAPE_REPRESENTATION('{fname}-None',(#6215),#{i0});
+"""
+    )
+
+    # --------------------
+    # msg_post
+    # --------------------
+
+    # 5->91
+    ind = i0 + np.arange(0, 8)
+    msg_post = (
+f"""
+#{ind[0]}=(
+GEOMETRIC_REPRESENTATION_CONTEXT(3)
+GLOBAL_UNCERTAINTY_ASSIGNED_CONTEXT((#{ind[1]}))
+GLOBAL_UNIT_ASSIGNED_CONTEXT((#{ind[7]},#{ind[3]},#{ind[2]}))
+REPRESENTATION_CONTEXT('{fname}','TOP_LEVEL_ASSEMBLY_PART')
+);
+#{ind[1]}=UNCERTAINTY_MEASURE_WITH_UNIT(LENGTH_MEASURE(2.E-5),#{ind[7]}, 'DISTANCE_ACCURACY_VALUE','Maximum Tolerance applied to model');
+#{ind[2]}=(
+NAMED_UNIT(*)
+SI_UNIT($,.STERADIAN.)
+SOLID_ANGLE_UNIT()
+);
+#{ind[3]}=(
+CONVERSION_BASED_UNIT('DEGREE',#{ind[5]})
+NAMED_UNIT(#{ind[4]})
+PLANE_ANGLE_UNIT()
+);
+#{ind[4]}=DIMENSIONAL_EXPONENTS(0.,0.,0.,0.,0.,0.,0.);
+#{ind[5]}=PLANE_ANGLE_MEASURE_WITH_UNIT(PLANE_ANGLE_MEASURE(0.0174532925), #{ind[6]});
+#{ind[6]}=(
+NAMED_UNIT(*)
+PLANE_ANGLE_UNIT()
+SI_UNIT($,.RADIAN.)
+);
+#{ind[7]}=(
+LENGTH_UNIT()
+NAMED_UNIT(*)
+SI_UNIT(.MILLI.,.METRE.)
+);
+ENDSEC;
+END-{iso};"""
+    )
+
+    # --------------------
+    # assemble
+    # --------------------
+
+    msg = msg_pre + "\n".join([dind[k0]['msg'] for k0 in lkey]) + msg_post
+
+    return msg
+
+
+# #################################################################
+# #################################################################
+#          DATA - POLYLINE
+# #################################################################
+
+
+def _get_data_polyline(
+    dptsx=None,
+    dptsy=None,
+    dptsz=None,
+    fname=None,
+    # options
+    dcolor=None,
+    # norm
+    iso=None,
+):
+
+
+    # ----------------
+    # prepare
+    # ----------------
+
+    dok = {k0: np.isfinite(v0) for k0, v0 in dptsx.items()}
+
+    dpts_ind = {}
+    for k0, v0 in dptsx.items():
+
+        dpts_ind[k0] = {}
+        for ind in np.ndindex(v0.shape[1:]):
+            sli = (slice(None),) + ind
+
+            iok = np.isfinite(v0[sli])
+            if np.any(iok):
+                dpts_ind[k0][ind] = {
+                    'ind': iok.nonzero()[0],
+                    'nn': iok.sum(),
+                    'color': None,
+                }
+
+    # nb of polylines
+    dnpoly = {k0: len(v0) for k0, v0 in dpts_ind.items()}
+    npoly = np.sum([v0 for v0 in dnpoly.values()])
+
+    dnpts = {k0: np.sum([v1['nn'] for v1 in v0.values()])}
+    npts = np.sum([v0 for v0 in dnpts.values()])
+
+    # -----------
+    # nrays
+    # -----------
+
+    # --------------
+    # order of kcam
+
+    # TO BE UPDATED FOR PTS and POLYLINE
+    lkcam = sorted(dptsx.keys())
+    k0ind = _get_k0ind(
+        dind_ok={k0: v0.nonzero() for k0, v0 in dok.items()},
+        ncum=np.cumsum([dnrays[kcam] for kcam in lkcam]),
+        lkcam=lkcam,
+    )
+
+    # -----------
+    # colors
+    # -----------
+
+    colors = sorted(set([v0 for v0 in dcolor.values()]))
+    ncol = len(colors)
+
+    # -----------------
+    # get index in file
+    # ------------------
+
+    i0 = 31
+    dind = {
+        'GEOMETRIC_CURVE_SET': {'order': 0},
+        'PRESENTATION_LAYER_ASSIGNMENT': {'order': 1},
+        'STYLED_ITEM': {
+            'order': 2,
+            'nn': npoly,
+        },
+        'PRESENTATION_STYLE_ASSIGNMENT': {
+            'order': 3,
+            'nn': ncol,
+        },
+        'CURVE_STYLE': {
+            'order': 4,
+            'nn': ncol,
+        },
+        'COLOUR_RGB': {
+            'order': 5,
+            'nn': ncol,
+        },
+        'DRAUGHTING_PRE_DEFINED_CURVE_FONT': {
+            'order': 6,
+            # 'nn': nrays,
+        },
+        'TRIMMED_CURVE': {
+            'order': 7,
+            'nn': npoly,
+        },
+        'POLYLINE': {
+            'order': 8,
+            'nn': npoly,
+        },
+        'AXIS2_PLACEMENT_3D': {'order': 10},
+        'DIRECTION0': {
+            'order': 9,
+            'str': "DIRECTION('',(0.,0.,1.));",
+        },
+        'DIRECTION1': {
+            'order': 10,
+            'str': "DIRECTION('',(1.,0.,0.));",
+        },
+        'CARTESIAN_POINT0': {
+            'order': 11,
+            'str': "CARTESIAN_POINT('',(0.,0.,0.));",
+        },
+        'CARTESIAN_POINT': {
+            'order': 12,
+            'nn': npts,
+        },
+        'MECHANICAL_DESIGN_GEOMETRIC_PRESENTATION_REPRESENTATION': {
+            'order': 13,
+        },
+    }
+
+    # complement
+    lkey = [k0 for k0 in dind.keys()]
+    lorder = [dind[k0]['order'] for k0 in lkey]
+
+    # safety check
+    assert np.unique(lorder).size == len(lorder)
+    inds = np.argsort(lorder)
+    lkey = [lkey[ii] for ii in inds]
+
+    # derive indices
+    for k0 in lkey:
+        nn = dind[k0].get('nn', 1)
+        dind[k0]['ind'] = i0 + np.arange(0, nn)
+        i0 += nn
+
+    # -----------------
+    # COLOUR_RGB
+    # -----------------
+
+    k0 = 'COLOUR_RGB'
+    lines = []
+    for ii, ni in enumerate(dind[k0]['ind']):
+        lines.append(f"#{ni}={k0}('color {ii}',{colors[ii][0]},{colors[ii][1]},{colors[ii][2]});")
+    dind[k0]['msg'] = "\n".join(lines)
+
+    # -----------------
+    # CARTESIAN_POINT
+    # -----------------
+
+    k0 = 'CARTESIAN_POINT'
+    lines = []
+    for ii, ni in enumerate(dind[k0]['ind']):
+        kcam, ind = k0ind(ii)
+        lines.append(f"#{ni}={k0}('{kcam}_{ind}',({dptsx[kcam][ind]},{dptsy[kcam][ind]},{dptsz[kcam][ind]}));")
+    dind[k0]['msg'] = "\n".join(lines)
+
+    # -----------------
+    # AXIS2_PLACEMENT_3D
+    # -----------------
+
+    k0 = 'AXIS2_PLACEMENT_3D'
+    ni = dind[k0]['ind'][0]
+    lstr = ', '.join([f"#{ii}" for ii in dind['TRIMMED_CURVE']['ind']])
+    dind[k0]['msg'] = f"#{ni}={k0}('',#{dind['CARTESIAN_POINT0']['ind'][0]},#{dind['DIRECTION0']['ind'][0]},#{dind['DIRECTION1']['ind'][0]});"
+
+    # -----------------
+    # LINE
+    # -----------------
+
+    k0 = 'POLYLINE'
     lines = []
     for ii, ni in enumerate(dind[k0]['ind']):
         kcam, ind = k0ind(ii)

--- a/tofu/data/_class02_save2stp.py
+++ b/tofu/data/_class02_save2stp.py
@@ -971,6 +971,7 @@ def _get_ind_global_to_local(dind_ok=None, din=None, ncum=None, lkcam=None):
 # #################################################################
 
 
+# DEPRECATED
 def _get_data_line(
     dptsx=None,
     dptsy=None,
@@ -1385,6 +1386,7 @@ def _get_data_polyline(
         # -------
         # points
 
+        #have to trasnpose because nonzero operates in C-order only
         iok_pts = np.all(
             [
                 np.isfinite(dptsx[k0]),
@@ -1392,10 +1394,10 @@ def _get_data_polyline(
                 np.isfinite(dptsz[k0]),
             ],
             axis=0,
-        )
+        ).T
 
         # make sure at least 2 points
-        iok_pts[:, np.sum(iok_pts, axis=0) < 2] = False
+        iok_pts[np.sum(iok_pts, axis=-1) < 2, :] = False
 
         nptsi = iok_pts.sum()
         if nptsi == 0:
@@ -1403,7 +1405,7 @@ def _get_data_polyline(
 
         pts += [
             {
-                'ind_local': tt,
+                'ind_local': tt[::-1],
                 'kcam': k0,
             }
             for tt in zip(*iok_pts.nonzero())
@@ -1413,14 +1415,14 @@ def _get_data_polyline(
         # poly
 
         i0_poly = 0
-        for tt in np.ndindex(iok_pts.shape[1:]):
+        for tt in np.ndindex(iok_pts.shape[:-1]):
 
-            sli = (slice(None),) + tt
+            sli = tt + (slice(None),)
             nptsi = iok_pts[sli].sum()
             ipts = i0_poly + np.arange(nptsi)
 
             dpoly = {
-                'ind_local': tt,
+                'ind_local': tt[::-1],
                 'kcam': k0,
                 'ipts_global': i0_pts + ipts,
                 'color': None,

--- a/tofu/data/_class08_generate_rays.py
+++ b/tofu/data/_class08_generate_rays.py
@@ -844,7 +844,7 @@ def _generic(
             oo = np.full(shape_cam + (nstart, nraysu.max()), np.nan)
 
             for ii, ind in enumerate(np.ndindex(shape_cam)):
-                sli = ind + (slice(None), np.arange(0, dnrays[ind]))
+                sli = ind + (slice(None), slice(0, dnrays[ind], 1))
                 oo[sli] = dout[kk][ind]
 
             dout[kk] = oo

--- a/tofu/data/_class08_generate_rays.py
+++ b/tofu/data/_class08_generate_rays.py
@@ -631,6 +631,7 @@ def _generic(
     dout_pixel = poly2d_sample(
         coll.ddata[kout0]['data'],
         coll.ddata[kout1]['data'],
+        key=kcam,
         dedge=dsampling_pixel.get('dedge'),
         dsurface=dsampling_pixel.get('dsurface'),
     )
@@ -868,6 +869,7 @@ def _get_end_optics(
     dout_optics = poly2d_sample(
         coll.ddata[kout0]['data'],
         coll.ddata[kout1]['data'],
+        key=kop,
         dedge=dsampling_optics.get('dedge'),
         dsurface=dsampling_optics.get('dsurface'),
     )

--- a/tofu/data/_class08_generate_rays.py
+++ b/tofu/data/_class08_generate_rays.py
@@ -233,6 +233,16 @@ def _check(
     )
 
     # ------------
+    # overwrite
+    # ------------
+
+    overwrite = ds._generic_check._check_var(
+        overwrite, 'overwrite',
+        types=bool,
+        default=False,
+    )
+
+    # ------------
     # key_rays
     # ------------
 
@@ -266,16 +276,6 @@ def _check(
 
     else:
         key_rays = None
-
-    # ------------
-    # overwrite
-    # ------------
-
-    overwrite = ds._generic_check._check_var(
-        overwrite, 'overwrite',
-        types=bool,
-        default=False,
-    )
 
     return (
         key,
@@ -949,6 +949,9 @@ def _store(
     for kcam, v0 in dout.items():
 
         key = key_rays[kcam]
+
+        if key in coll.dobj['rays'].keys() and overwrite is True:
+            coll.remove_rays(key)
 
         # -----------------
         # add ref


### PR DESCRIPTION
Main changes:
----------------

* `tofu/data/_class00_poly2d_sample.py`:
    -  debug `concatenate` vs `ravel`

* `add_rays_from_diagnostic()`:
    - `overwrite = bool` implemented
    - Better error msg

* `save_rays_to_stp()`
    - `chain = 'camera' and 'pixel'` implemented
    - `color_by_pixel = float in [0, 1]` implemented 
    - now uses `POLYLINE`


Issues:
-------

Fixes, in devel, issue #1005 

Possible improvements on chain by re-using existing `CARTESIAN POINTS` indices instead of duplicating points, cf issue #1012 

Examples:
-----------

Preliminiary (generate rays):

```
# After having created a diagnostic
coll.add_rays_from_diagnostic(
         dsampling_optics={'dedge': {'res': 'min'}, 'dsurface': {'nb': 3}}, 
        dsampling_pixel={'dedge': {'res': 'min'}, 'dsurface': {'nb': 3}}, 
        optics=-1, 
        config=conf, 
        store=True, 
        overwrite=True,
)
```

Saving diagnostic (LOS), chain=True (so by camera) and automatic coloring by camera:
```
pfe =  'C:/Users/dvezinet/Documents/SPARC_SYSTEMS/DIAG/XRAY/FDR_2024/mFDR_XRAY-A_SXRHXR-InVessel/Topical/Field_of_view_synthetic_signals/HXR_test_camera.stp'

coll.save_rays_to_stp(
        key='HXRVA_v0_200', 
        factor=1000, 
        chain=True, 
        pfe_save=pfe, 
        overwrite=True, 
        color='camera', 
)
```

![image](https://github.com/user-attachments/assets/ac42fe45-31a7-47d6-88ec-e51a1c09397b)

Saving diagnostic (LOS), chained by pixel and automatic coloring by pixel:

```
pfe =  'C:/Users/dvezinet/Documents/SPARC_SYSTEMS/DIAG/XRAY/FDR_2024/mFDR_XRAY-A_SXRHXR-InVessel/Topical/Field_of_view_synthetic_signals/HXR_test_pixel.stp'

coll.save_rays_to_stp(
        key='HXRVA_v0_200', 
        factor=1000, 
        chain='pixel', 
        pfe_save=pfe, 
        overwrite=True, 
        color='camera', 
       color_by_pixel=0.5,
)
```

![image](https://github.com/user-attachments/assets/808e3ca0-a410-49ec-aa2a-ef5026448bf8)

Saving 2 sets of rays, one after the other, chained by pixel, colored by pixel:

```
pfe =  'C:/Users/dvezinet/Documents/SPARC_SYSTEMS/DIAG/XRAY/FDR_2024/mFDR_XRAY-A_SXRHXR-InVessel/Topical/Field_of_view_synthetic_signals/HXR_test_right.stp'

coll.save_rays_to_stp(
        key='HXRVA_v0_200_right_rays', 
        factor=1000, 
        chain='pixel', 
        pfe_save=pfe, 
        overwrite=True, 
        color='r', 
       color_by_pixel=0.5,
)

pfe =  'C:/Users/dvezinet/Documents/SPARC_SYSTEMS/DIAG/XRAY/FDR_2024/mFDR_XRAY-A_SXRHXR-InVessel/Topical/Field_of_view_synthetic_signals/HXR_test_left.stp'

coll.save_rays_to_stp(
        key='HXRVA_v0_200_left_rays', 
        factor=1000, 
        chain='pixel', 
        pfe_save=pfe, 
        overwrite=True, 
        color='b', 
       color_by_pixel=0.5,
)
```

![image](https://github.com/user-attachments/assets/ad41d86e-a09d-4c73-ba4f-17f14a711848)



