### PR TITLE
[#1111] Safety check + error msg in single_pt_cam when 1 ray only + better `interpolate_along_los()`

### DIFF
--- a/tofu/data/_class02_single_point_camera.py
+++ b/tofu/data/_class02_single_point_camera.py
@@ -456,6 +456,15 @@ def _rays_intersection(
         py = ptsy[0, ...]
         pz = ptsz[0, ...]
 
+        # safety check
+        if px.size <= 1:
+            msg = (
+                f"Intersection fof rays '{kray}' for single_pt_cam:\n"
+                "\t- Cannot compute intersection without at least 2 rays!\n"
+                f"\t- rays.shape = {px.shape}\n"
+            )
+            raise Exception(msg)
+
         # unit vectors
         vx, vy, vz = coll.get_rays_vect(
             kray,

--- a/tofu/data/_class08_interpolate_along_los.py
+++ b/tofu/data/_class08_interpolate_along_los.py
@@ -223,7 +223,7 @@ def main(
             )[key_coords]['data']
 
             # interpolate
-            q2dy = coll.interpolate_profile2d(
+            q2dy = coll.interpolate(
                 keys=key_integrand,
                 x0=Ri,
                 x1=pts_z,
@@ -239,13 +239,23 @@ def main(
             )[key_integrand]['data']
 
             # check shape
-            if q2dx['data'].shape != q2dy['data'].shape:
-                msg = "The two interpolated quantities must have same shape!"
+            if q2dx.shape != q2dy.shape:
+                msg = (
+                    "The two interpolated quantities must have same shape!\n"
+                    f"\t- '{key_coords}': {q2dx.shape}\n"
+                    f"\t- '{key_integrand}': {q2dy.shape}\n"
+                )
                 raise Exception(msg)
 
+            # axis_los
+            wbs = coll._which_bsplines
+            kbs = coll.ddata[key_integrand][wbs][0]
+            rbs = coll.dobj[wbs][kbs]['ref']
+            axis_los = coll.ddata[key_integrand]['ref'].index(rbs[0])
+
             # prepare
-            dx[kk] = np.full(q2d.shape, np.nan)
-            dy[kk] = np.full(q2d.shape, np.nan)
+            dx[kk] = np.full(q2dx.shape, np.nan)
+            dy[kk] = np.full(q2dx.shape, np.nan)
 
             # isok
             isok = np.isfinite(q2dx) & np.isfinite(q2dy) & np.isfinite(Ri)

--- a/tofu/data/_class08_interpolate_along_los.py
+++ b/tofu/data/_class08_interpolate_along_los.py
@@ -307,6 +307,7 @@ def main(
 
     dind = _get_dind(
         coll=coll,
+        key_cam=key_cam,
         doptics=doptics,
         dx=dx,
         dy=dy,
@@ -574,7 +575,7 @@ def _interpolate_along_los_reshape(
                 else:
                     ref[ii] = 1
 
-        # None not macthing xdata (e.g.: domain)
+        # None not matching xdata (e.g.: domain)
         xdata = xdata.reshape(ref) * np.ones(ydata.shape)
 
     return xdata, ydata, axis_los
@@ -587,6 +588,7 @@ def _interpolate_along_los_reshape(
 
 def _get_dind(
     coll=None,
+    key_cam=None,
     doptics=None,
     dx=None,
     dy=None,
@@ -596,7 +598,7 @@ def _get_dind(
     #  loop on cameras
 
     dind = {}
-    for kcam in doptics.keys():
+    for kcam in key_cam:
 
         klos = doptics[kcam]['los']
 
@@ -636,8 +638,8 @@ def _get_dind(
         # -----------
         # safety check
 
-        lc = [np.any(inan[ind>=0]), (ind == -1).sum() < nnan]
-        if  any(lc):
+        lc = [np.any(inan[ind >= 0]), (ind == -1).sum() < nnan]
+        if any(lc):
             msg = (
                 "Inconsistent nans!\n"
                 f"\t- lc: {lc}\n"
@@ -668,7 +670,6 @@ def interpolate_along_los_plot(
     dcolor=None,
     dax=None,
 ):
-
 
     # -------------
     # check inputs


### PR DESCRIPTION
Main changes:
----------------

* Better error msg + safety check in `single_pt_camera()`
* `interpolate_along_los()` more robust

Issues:
--------

Fixes, in devel issue #1111 